### PR TITLE
chore: restore full issue templates (bug + feature) — no shortened versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,39 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a detailed report to help us improve MIND
+title: "[Bug]: "
 labels: bug
+assignees: ""
 ---
-**Describe the bug**
-**To Reproduce**
-**Expected behavior**
-**Environment (OS, Rust, commit)**
+
+## Describe the bug
+A clear and concise description of the issue.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. …
+2. …
+3. …
+
+## Expected behavior
+What you expected to happen.
+
+## Actual behavior
+What actually happened (include errors, logs).
+
+## Screenshots / Logs
+Paste relevant logs, stack traces, or screenshots.
+> Tip: use fenced code blocks for logs.
+
+## Environment
+- OS: (e.g., Ubuntu 22.04 / macOS 15)
+- Rust toolchain: (`rustc --version`)
+- LLVM version:
+- CUDA/ROCm (if applicable):
+- MIND commit SHA/branch:
+
+## Minimal Repro (code/config)
+Provide the smallest self-contained example that reproduces the issue.
+
+## Additional context
+Anything else we should know (workarounds, related issues, links).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,28 @@
 ---
 name: Feature request
-about: Suggest an idea for MIND
+about: Suggest an idea or enhancement for MIND
+title: "[Feature]: "
 labels: enhancement
+assignees: ""
 ---
-**Problem**
-**Proposal**
-**Alternatives**
-**Additional context**
+
+## Problem Statement
+What problem are you trying to solve? Who is affected?
+
+## Proposed Solution
+Describe the solution you'd like, including UX and API shape.
+
+## Alternatives Considered
+List other options you explored and why they aren’t sufficient.
+
+## Design Sketch / Pseudocode
+High-level design notes, pseudocode, or interface examples.
+
+## Impact / Risks
+Performance, compatibility, security, ergonomics—call out trade-offs.
+
+## Open Questions
+What needs input or an RFC?
+
+## Additional context
+Links, prior art, references, screenshots.


### PR DESCRIPTION
This PR restores **complete** issue templates for bug reports and feature requests, replacing previously shortened versions. No other files were modified. Text-only change; idempotent.

------
https://chatgpt.com/codex/tasks/task_b_690ca90ee74c832aa2e7bfd28f0104e1