### PR TITLE
ci: make MLIR/LLVM optional and remove system LLVM steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,6 @@ jobs:
         override: true
         components: rustfmt, clippy
 
-    - name: Install LLVM (Ubuntu)
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y llvm-15 llvm-15-dev
-
-    - name: Install LLVM (macOS)
-      if: runner.os == 'macOS'
-      run: brew install llvm@15
-
     - name: Cache cargo
       uses: actions/cache@v3
       with:
@@ -51,10 +41,10 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --no-default-features
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --no-default-features
 
     - name: Check formatting
       run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["compilers", "science"]
 [dependencies]
 logos = "0.13"
 chumsky = "0.9"
-melior = "0.15"
-inkwell = "0.2"
+melior = { version = "0.15", optional = true }
+inkwell = { version = "0.2", optional = true }
 clap = { version = "4.4", features = ["derive"] }
 colored = "2.0"
 anyhow = "1.0"
@@ -37,3 +37,8 @@ codegen-units = 1
 [profile.dev]
 opt-level = 0
 debug = true
+
+[features]
+default = []
+mlir = ["melior"]
+llvm = ["inkwell"]

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ More details: [/benchmarks/resnet.md](benchmarks/resnet.md)
 - LLVM 15+
 - CUDA Toolkit 11.8+ (for GPU support)
 
+> **Note:** MLIR/LLVM backends are currently feature-gated. By default, the crate builds without them (no system LLVM required).
+> Enable with `--features mlir` and/or `--features llvm` once you have a matching toolchain installed.
+
 ### Troubleshooting
 - **CUDA not found?** Check `CUDA_HOME` and `LD_LIBRARY_PATH` environment variables
 - **Build fails?** Ensure LLVM 15+ is in `PATH`


### PR DESCRIPTION
## Summary
- mark the melior and inkwell crates as optional behind explicit mlir/llvm features with empty defaults
- update CI to stop installing system LLVM and build/test without default features
- document in the README that the MLIR/LLVM backends are gated behind optional features

## Testing
- cargo build --no-default-features *(fails: existing syntax error in src/main.rs)*

------
https://chatgpt.com/codex/tasks/task_b_690caa194a34832aa61b1e6223eb41a3