### PR TITLE
Adjust CI coverage workflow for optional features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,41 @@ jobs:
       run: cargo install cargo-tarpaulin
 
     - name: Generate coverage
-      run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+      run: cargo tarpaulin --verbose --no-default-features --workspace --timeout 120 --out Xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
         files: ./cobertura.xml
+        fail_ci_if_error: false
+
+  coverage-optional-features:
+    name: Coverage (optional features)
+    runs-on: ubuntu-latest
+    if: ${{ vars.ENABLE_OPTIONAL_FEATURE_COVERAGE == 'true' }}
+    strategy:
+      matrix:
+        feature: [llvm, mlir]
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Install tarpaulin
+      run: cargo install cargo-tarpaulin
+
+    - name: Generate coverage (${{ matrix.feature }})
+      run: |
+        cargo tarpaulin --verbose --no-default-features --features ${{ matrix.feature }} --workspace --timeout 120 --out Xml
+        mv cobertura.xml cobertura-${{ matrix.feature }}.xml
+
+    - name: Upload coverage to Codecov (${{ matrix.feature }})
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./cobertura-${{ matrix.feature }}.xml
         fail_ci_if_error: false

--- a/GITHUB_SETUP_INSTRUCTIONS.md
+++ b/GITHUB_SETUP_INSTRUCTIONS.md
@@ -1,2 +1,4 @@
 # GitHub Setup (Quick)
 Enable Issues, Discussions, Projects. Add topics. See CI in `.github/workflows/ci.yml`.
+
+Tarpaulin coverage in CI runs without optional LLVM/MLIR features by default. To collect feature-specific coverage, define the repository variable `ENABLE_OPTIONAL_FEATURE_COVERAGE=true` and ensure the runners provide the necessary LLVM/MLIR toolchains before enabling the optional coverage job matrix.


### PR DESCRIPTION
## Summary
- avoid running cargo tarpaulin with `--all-features` in the default coverage job
- add an optional feature matrix for llvm/mlir coverage that can be enabled via repository variables
- document the updated coverage expectations in the GitHub setup guide

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_690cae9085d0832a97a26856bcc8a736