### PR TITLE
Phase 1 (fast-track): scaffold lexer/parser/types + stub checker + smoke tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ debug = true
 default = []
 mlir = ["melior"]
 llvm = ["inkwell"]
+autodiff = []

--- a/README.md
+++ b/README.md
@@ -248,12 +248,14 @@ mind run examples/hello_tensor.mind
 
 - [x] Language design document v0.3 ([docs/design/v0.3.md](docs/design/v0.3.md))
 - [x] Core syntax specification
-- [ ] Lexer and parser
+- [x] Lexer and parser
 - [ ] Type checker with shape inference
 - [ ] Basic autodiff prototype
 - [ ] MLIR IR generation
 - [ ] Basic tensor operations stdlib
 </details>
+
+_Phase 1 scaffold complete (parses identifiers/integers; type checker stubbed)._ 
 
 <details>
 <summary><b>Phase 2: Compilation (Q1 2026)</b></summary>

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -3,8 +3,15 @@
 > Status: Draft; evolves via RFCs in `docs/rfcs/`.
 
 ## 1. Lexical Grammar
+
+### Phase 1 subset
+- Ident: `[a-zA-Z_][a-zA-Z0-9_]*`
+- Int: `[0-9]+`
 ## 2. Types (Tensor[T, Shape], device placement, effects)
 ## 3. Expressions and Statements
+
+### Phase 1 subset
+- `Node::Lit(Ident|Int)`, `Module { items: Vec<Node> }`
 ## 4. Autodiff Primitives (grad, vjp, jvp)
 ## 5. Module System and Stdlib Surface
 ## 6. IR Mapping to MLIR

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Literal {
+    Int(i64),
+    Ident(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Node {
+    Lit(Literal),
+    // TODO: add expressions/statements in Phase 2
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Module {
+    pub items: Vec<Node>,
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,0 +1,20 @@
+use logos::Logos;
+
+#[derive(Logos, Debug, Clone, PartialEq)]
+#[logos(skip r"[ \t\r\n]+")]
+pub enum Token {
+    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", |lex| lex.slice().to_string())]
+    Ident(String),
+
+    #[regex(r"[0-9]+", |lex| lex.slice().parse::<i64>().unwrap())]
+    Int(i64),
+
+    #[token("(")] LParen,
+    #[token(")")] RParen,
+}
+
+pub fn lex(input: &str) -> Vec<Token> {
+    Token::lexer(input)
+        .filter_map(Result::ok)
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+//! MIND core library (Phase 1 scaffold)
+pub mod ast;
+pub mod lexer;
+pub mod parser;
+pub mod types;
+pub mod type_checker;
+#[cfg(feature = "autodiff")]
+pub mod autodiff;
+
+#[cfg(feature = "mlir")]
+pub mod ir;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,17 @@
+use chumsky::prelude::*;
+use crate::ast::{Literal, Node, Module};
+
+pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
+    let ident = text::ident().map(|s: String| Node::Lit(Literal::Ident(s)));
+    let int   = text::int(10).map(|s: String| Node::Lit(Literal::Int(s.parse().unwrap())));
+    let node  = choice((ident, int));
+
+    node
+        .repeated()
+        .at_least(1)
+        .map(|items| Module { items })
+}
+
+pub fn parse(input: &str) -> Result<Module, Vec<Simple<char>>> {
+    parser().parse(input)
+}

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -1,0 +1,12 @@
+use crate::ast::Module;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TypeError {
+    #[error("type checking not implemented (Phase 1 scaffold)")]
+    Unimplemented,
+}
+
+/// Phase 1: accept everything (stub) so pipeline compiles.
+pub fn check(_m: &Module) -> Result<(), TypeError> {
+    Ok(())
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DType { I32, F32, BF16, F16 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShapeDim { Known(usize), Sym(&'static str) }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TensorType {
+    pub dtype: DType,
+    pub shape: Vec<ShapeDim>,
+}
+
+impl TensorType {
+    pub fn new(dtype: DType, shape: Vec<ShapeDim>) -> Self { Self { dtype, shape } }
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,9 @@
+use mind::{lexer, parser, type_checker};
+
+#[test]
+fn lex_parse_check_minimal() {
+    let toks = lexer::lex("x 123");
+    assert!(toks.len() >= 2);
+    let m = parser::parse("x 123").expect("parse");
+    type_checker::check(&m).expect("check");
+}


### PR DESCRIPTION
## Summary
- add the Phase 1 library scaffold covering the AST, lexer, parser, and tensor type definitions
- introduce a stubbed type checker module and define the placeholder `autodiff` feature flag
- add a smoke test for the lex/parse/check pipeline and document the Phase 1 checklist/spec updates

## Testing
- cargo test --no-default-features

------
https://chatgpt.com/codex/tasks/task_b_690cb2fabbe8832a899a7a4c2b645ac2