### PR TITLE
Phase 1C: autodiff prototype (feature-gated) + CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,16 @@ jobs:
       with:
         files: ./cobertura.xml
         fail_ci_if_error: false
+  autodiff_tests:
+    name: Tests (feature: autodiff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run tests (autodiff feature)
+        run: cargo test --workspace --all-targets --features autodiff --verbose

--- a/README.md
+++ b/README.md
@@ -250,12 +250,14 @@ mind run examples/hello_tensor.mind
 - [x] Core syntax specification
 - [x] Lexer and parser
 - [ ] Type checker with shape inference
-- [ ] Basic autodiff prototype
+- [x] Basic autodiff prototype
 - [ ] MLIR IR generation
 - [ ] Basic tensor operations stdlib
 </details>
 
 _Phase 1 scaffold complete (parses identifiers/integers; type checker stubbed)._ 
+
+Autodiff API is a placeholder (feature-gated). Real gradients arrive in Phase 2–3.
 
 <details>
 <summary><b>Phase 2: Compilation (Q1 2026)</b></summary>

--- a/src/autodiff/mod.rs
+++ b/src/autodiff/mod.rs
@@ -1,0 +1,25 @@
+//! Minimal autodiff prototype (Phase 1).
+//!
+//! `grad(f)` returns a closure that runs `f()` and also returns a placeholder
+//! gradient marker. This is a stub to unblock examples/tests and API design.
+//!
+//! # Example
+//! ```
+//! #[cfg(feature = "autodiff")]
+//! {
+//!     let g = mind::autodiff::grad(|| 21 + 21);
+//!     let (v, d) = g();
+//!     assert_eq!(v, 42);
+//!     assert!(d.contains("placeholder"));
+//! }
+//! ```
+
+pub fn grad<F, T>(f: F) -> impl Fn() -> (T, &'static str)
+where
+    F: Fn() -> T,
+{
+    move || {
+        let v = f();
+        (v, "∂(placeholder)")
+    }
+}

--- a/tests/autodiff.rs
+++ b/tests/autodiff.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "autodiff")]
+#[test]
+fn grad_placeholder_runs() {
+    let g = mind::autodiff::grad(|| 40 + 2);
+    let (v, d) = g();
+    assert_eq!(v, 42);
+    assert!(d.contains("placeholder"));
+}


### PR DESCRIPTION
Adds a minimal `autodiff::grad` API behind the `autodiff` feature, a test exercising it, and a CI job that runs with `--features autodiff`. No LLVM/MLIR required. README updated to mark Phase 1 autodiff prototype complete.

------
https://chatgpt.com/codex/tasks/task_b_690cb6840c2c832a9dac4e94e024daf0