### PR TITLE
Phase 1D: MLIR lowering stub (feature = mlir), CI job, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,16 @@ jobs:
           override: true
       - name: Run tests (autodiff feature)
         run: cargo test --workspace --all-targets --features autodiff --verbose
+  mlir_stub_tests:
+    name: Tests (feature: mlir stub)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run tests (mlir stub)
+        run: cargo test --workspace --all-targets --features mlir --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ debug = true
 
 [features]
 default = []
-mlir = ["melior"]
+mlir = []
+mlir_backend = ["melior"]
 llvm = ["inkwell"]
 autodiff = []

--- a/README.md
+++ b/README.md
@@ -251,9 +251,11 @@ mind run examples/hello_tensor.mind
 - [x] Lexer and parser
 - [ ] Type checker with shape inference
 - [x] Basic autodiff prototype
-- [ ] MLIR IR generation
+- [x] MLIR IR generation ✅ *(stub)*
 - [ ] Basic tensor operations stdlib
 </details>
+
+*Note:* `mlir` feature provides a stubbed lowering (no deps). Real MLIR integration will use `mlir_backend` (melior) in a later phase.
 
 _Phase 1 scaffold complete (parses identifiers/integers; type checker stubbed)._ 
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,0 +1,10 @@
+//! MLIR lowering stub (Phase 1).
+//!
+//! Feature `mlir` enables this pure-Rust placeholder with no external deps.
+//! For the real integration, use feature `mlir_backend` (melior) in a future PR.
+
+#[cfg(feature = "mlir")]
+pub fn lower_placeholder(source: &str) -> String {
+    let one_line = source.lines().collect::<Vec<_>>().join(" ");
+    format!("mlir.module {{ // lowered from: {} }}", one_line)
+}

--- a/tests/ir_stub.rs
+++ b/tests/ir_stub.rs
@@ -1,0 +1,7 @@
+#[cfg(feature = "mlir")]
+#[test]
+fn lower_placeholder_contains_mlir_module() {
+    let mlir = mind::ir::lower_placeholder("x 123");
+    assert!(mlir.contains("mlir.module"));
+    assert!(mlir.contains("x 123"));
+}


### PR DESCRIPTION
## Summary
- split Cargo features so `mlir` enables a dependency-free stub and `mlir_backend` gates the future melior integration
- add a pure-Rust MLIR lowering placeholder under `src/ir` with a simple feature-gated test
- extend CI with a job that exercises the `mlir` feature and document the stubbed status in the roadmap

## Testing
- cargo test --no-default-features
- cargo test --features mlir

------
https://chatgpt.com/codex/tasks/task_b_690cb89203c0832aba711a365808d3db