### PR TITLE
Phase 1: basic shape inference + tensor stdlib stubs (tests, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,11 +249,13 @@ mind run examples/hello_tensor.mind
 - [x] Language design document v0.3 ([docs/design/v0.3.md](docs/design/v0.3.md))
 - [x] Core syntax specification
 - [x] Lexer and parser
-- [ ] Type checker with shape inference
+- [x] Type checker with shape inference ✅ *(basic unify)*
 - [x] Basic autodiff prototype
 - [x] MLIR IR generation ✅ *(stub)*
-- [ ] Basic tensor operations stdlib
+- [x] Basic tensor operations stdlib ✅ *(stubs)*
 </details>
+
+*Note:* Tensor stdlib and shape inference are minimal placeholders to keep the pipeline compiling; real semantics come in Phase 2–3.
 
 *Note:* `mlir` feature provides a stubbed lowering (no deps). Real MLIR integration will use `mlir_backend` (melior) in a later phase.
 

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -16,3 +16,13 @@
 ## 5. Module System and Stdlib Surface
 ## 6. IR Mapping to MLIR
 ## 7. Safety, Errors, Diagnostics
+
+## 2.1 Shape Inference (Phase 1)
+Left-biased unification:
+- Known==Known → Known
+- Known↔Sym → Known
+- Sym↔Sym → left symbol
+- Rank mismatch → missing dims become `UNK` (left-biased)
+
+## 5.1 Stdlib (Phase 1)
+`Tensor<T>` placeholder with `zeros/ones/reshape/shape/sum/mean` (no storage).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod lexer;
 pub mod parser;
 pub mod types;
 pub mod type_checker;
+pub mod stdlib;
 #[cfg(feature = "autodiff")]
 pub mod autodiff;
 

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,0 +1,1 @@
+pub mod tensor;

--- a/src/stdlib/tensor.rs
+++ b/src/stdlib/tensor.rs
@@ -1,0 +1,23 @@
+use std::marker::PhantomData;
+
+/// Minimal placeholder tensor for Phase 1 (no data buffer).
+#[derive(Clone, Debug, PartialEq)]
+pub struct Tensor<T> {
+    shape: Vec<usize>,
+    _t: PhantomData<T>,
+}
+
+impl<T> Tensor<T> {
+    pub fn zeros(shape: &[usize]) -> Self {
+        Self { shape: shape.to_vec(), _t: PhantomData }
+    }
+    pub fn ones(shape: &[usize]) -> Self {
+        Self { shape: shape.to_vec(), _t: PhantomData }
+    }
+    pub fn reshape(&self, new_shape: &[usize]) -> Self {
+        Self { shape: new_shape.to_vec(), _t: PhantomData }
+    }
+    pub fn shape(&self) -> &[usize] { &self.shape }
+    pub fn sum(&self) -> f64 { 0.0 }   // placeholder
+    pub fn mean(&self) -> f64 { 0.0 }  // placeholder
+}

--- a/src/types/infer.rs
+++ b/src/types/infer.rs
@@ -1,0 +1,24 @@
+use super::{TensorType, ShapeDim};
+
+/// Left-biased, minimal unifier for Phase 1.
+/// - Known==Known => Known
+/// - Known <-> Sym => Known
+/// - Sym <-> Sym  => left symbol
+/// - Different rank => left-biased "UNK" dims
+pub fn unify(a: &TensorType, b: &TensorType) -> TensorType {
+    let len = a.shape.len().max(b.shape.len());
+    let mut out = Vec::with_capacity(len);
+    for i in 0..len {
+        let x = a.shape.get(i).cloned().unwrap_or(ShapeDim::Sym("UNK"));
+        let y = b.shape.get(i).cloned().unwrap_or(ShapeDim::Sym("UNK"));
+        let r = match (x, y) {
+            (ShapeDim::Known(m), ShapeDim::Known(n)) if m == n => ShapeDim::Known(m),
+            (ShapeDim::Known(_), ShapeDim::Known(_)) => ShapeDim::Sym("UNK"),
+            (ShapeDim::Known(m), ShapeDim::Sym(_)) => ShapeDim::Known(m),
+            (ShapeDim::Sym(_), ShapeDim::Known(n)) => ShapeDim::Known(n),
+            (ShapeDim::Sym(s), ShapeDim::Sym(_)) => ShapeDim::Sym(s),
+        };
+        out.push(r);
+    }
+    TensorType { dtype: a.dtype.clone(), shape: out }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,5 @@
+pub mod infer;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DType { I32, F32, BF16, F16 }
 

--- a/tests/stdlib_tensor.rs
+++ b/tests/stdlib_tensor.rs
@@ -1,0 +1,16 @@
+use mind::stdlib::tensor::Tensor;
+
+#[test]
+fn tensor_shape_and_reshape() {
+    let t = Tensor::<f32>::zeros(&[2, 3]);
+    assert_eq!(t.shape(), &[2, 3]);
+    let r = t.reshape(&[3, 2]);
+    assert_eq!(r.shape(), &[3, 2]);
+}
+
+#[test]
+fn tensor_ops_placeholders_compile() {
+    let t = Tensor::<f32>::ones(&[2, 3]);
+    let _ = t.sum();
+    let _ = t.mean();
+}

--- a/tests/type_infer.rs
+++ b/tests/type_infer.rs
@@ -1,0 +1,18 @@
+use mind::types::{TensorType, DType, ShapeDim};
+use mind::types::infer::unify;
+
+#[test]
+fn unify_known_and_sym() {
+    let a = TensorType::new(DType::F32, vec![ShapeDim::Known(32), ShapeDim::Sym("B")]);
+    let b = TensorType::new(DType::F32, vec![ShapeDim::Known(32), ShapeDim::Known(8)]);
+    let u = unify(&a, &b);
+    assert_eq!(u.shape, vec![ShapeDim::Known(32), ShapeDim::Known(8)]);
+}
+
+#[test]
+fn unify_rank_mismatch_left_biased() {
+    let a = TensorType::new(DType::F32, vec![ShapeDim::Known(4), ShapeDim::Sym("N")]);
+    let b = TensorType::new(DType::F32, vec![ShapeDim::Known(4)]);
+    let u = unify(&a, &b);
+    assert_eq!(u.shape[0], ShapeDim::Known(4));
+}


### PR DESCRIPTION
Adds a minimal shape unifier and a tiny pure-Rust tensor stdlib to complete Phase 1. Includes unit tests and README/spec updates. No optional features or binaries; CI builds with `--no-default-features`.

------
https://chatgpt.com/codex/tasks/task_b_690cbc3c8ca8832aaafc0cadf5da2f89