### PR TITLE
test: cover types module (unit + doctest) to satisfy patch coverage

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,12 @@
+//! Basic tensor type definitions.
+//!
+//! # Example
+//! ```
+//! use mind::types::{TensorType, DType, ShapeDim};
+//! let ty = TensorType::new(DType::F32, vec![ShapeDim::Known(2), ShapeDim::Known(3)]);
+//! assert_eq!(ty.shape.len(), 2);
+//! ```
+
 pub mod infer;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,4 +23,23 @@ pub struct TensorType {
 
 impl TensorType {
     pub fn new(dtype: DType, shape: Vec<ShapeDim>) -> Self { Self { dtype, shape } }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DType, ShapeDim, TensorType};
+
+    #[test]
+    fn tensor_type_new_covers_constructor() {
+        let t = TensorType::new(DType::F32, vec![ShapeDim::Known(2), ShapeDim::Known(3)]);
+        assert_eq!(t.dtype, DType::F32);
+        assert_eq!(t.shape, vec![ShapeDim::Known(2), ShapeDim::Known(3)]);
+    }
+
+    #[test]
+    fn tensor_type_with_symbolic_dim() {
+        let t = TensorType::new(DType::I32, vec![ShapeDim::Sym("B"), ShapeDim::Known(128)]);
+        assert!(matches!(t.shape[0], ShapeDim::Sym("B")));
+        assert!(matches!(t.shape[1], ShapeDim::Known(128)));
+    }
 }


### PR DESCRIPTION
## Summary
- add module-level documentation with a doctest for `TensorType::new`
- add unit tests to cover the constructor and symbolic dimensions in `src/types/mod.rs`

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_690cc1178348832a93b6b88076489c2a