### PR TITLE
Phase 2: expression parser (+,-,*,/, parens) + int evaluator, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,16 @@ import std.tensor;
 fn main() {
     let x = tensor.zeros[f32, (2, 3)];
     let y = x + 1.0;
-    
+
     on(gpu0) {
         print(y.sum());  // 6.0 (2*3 elements, all = 1.0)
     }
 }
 ```
+
+**Example (expressions):**
+The Phase 2 parser prototype can now understand and evaluate simple integer expressions for development tests: `1 + 2 * 3`
+evaluates to `7`, while `(1 + 2) * 3` evaluates to `9`.
 
 **Run it:**
 ```bash

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -12,6 +12,11 @@
 
 ### Phase 1 subset
 - `Node::Lit(Ident|Int)`, `Module { items: Vec<Node> }`
+
+### Phase 2 subset (prototype)
+- Literals: `Int`, `Ident`
+- Binary ops: `+`, `-`, `*`, `/` with precedence `*` & `/` over `+` & `-`, all left-associative
+- Parentheses override precedence
 ## 4. Autodiff Primitives (grad, vjp, jvp)
 ## 5. Module System and Stdlib Surface
 ## 6. IR Mapping to MLIR

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5,9 +5,18 @@ pub enum Literal {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Node {
     Lit(Literal),
-    // TODO: add expressions/statements in Phase 2
+    Binary { op: BinOp, left: Box<Node>, right: Box<Node> },
+    Paren(Box<Node>),
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,0 +1,37 @@
+use crate::ast::{BinOp, Literal, Module, Node};
+
+#[derive(Debug, thiserror::Error)]
+pub enum EvalError {
+    #[error("unsupported node")]
+    Unsupported,
+    #[error("division by zero")]
+    DivZero,
+}
+
+pub fn eval_int(node: &Node) -> Result<i64, EvalError> {
+    match node {
+        Node::Lit(Literal::Int(value)) => Ok(*value),
+        Node::Paren(inner) => eval_int(inner),
+        Node::Binary { op, left, right } => {
+            let left = eval_int(left)?;
+            let right = eval_int(right)?;
+            match op {
+                BinOp::Add => Ok(left + right),
+                BinOp::Sub => Ok(left - right),
+                BinOp::Mul => Ok(left * right),
+                BinOp::Div => {
+                    if right == 0 {
+                        Err(EvalError::DivZero)
+                    } else {
+                        Ok(left / right)
+                    }
+                }
+            }
+        }
+        _ => Err(EvalError::Unsupported),
+    }
+}
+
+pub fn eval_first_expr(module: &Module) -> Result<i64, EvalError> {
+    module.items.first().map(eval_int).unwrap_or(Ok(0))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 //! MIND core library (Phase 1 scaffold)
 pub mod ast;
-pub mod lexer;
-pub mod parser;
-pub mod types;
-pub mod type_checker;
-pub mod stdlib;
 #[cfg(feature = "autodiff")]
 pub mod autodiff;
+pub mod eval;
+pub mod lexer;
+pub mod parser;
+pub mod stdlib;
+pub mod type_checker;
+pub mod types;
 
 #[cfg(feature = "mlir")]
 pub mod ir;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,15 +1,55 @@
+//! # Example
+//! ```
+//! use mind::{parser, eval};
+//! let module = parser::parse("1 + 2 * 3").unwrap();
+//! assert_eq!(eval::eval_first_expr(&module).unwrap(), 7);
+//! ```
+
 use chumsky::prelude::*;
-use crate::ast::{Literal, Node, Module};
+
+use crate::ast::{BinOp, Literal, Module, Node};
 
 pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
+    let int = text::int(10).map(|s: String| Node::Lit(Literal::Int(s.parse().unwrap())));
     let ident = text::ident().map(|s: String| Node::Lit(Literal::Ident(s)));
-    let int   = text::int(10).map(|s: String| Node::Lit(Literal::Int(s.parse().unwrap())));
-    let node  = choice((ident, int));
 
-    node
-        .repeated()
-        .at_least(1)
-        .map(|items| Module { items })
+    let expr = recursive(|expr| {
+        let atom = choice((
+            int.clone(),
+            ident.clone(),
+            just('(')
+                .ignore_then(expr.clone())
+                .then_ignore(just(')'))
+                .map(|node| Node::Paren(Box::new(node))),
+        ))
+        .padded();
+
+        let product = atom
+            .clone()
+            .then(
+                (choice((just('*').to(BinOp::Mul), just('/').to(BinOp::Div))).then(atom.clone()))
+                    .repeated(),
+            )
+            .foldl(|left, (op, right)| Node::Binary {
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+            });
+
+        product
+            .clone()
+            .then(
+                (choice((just('+').to(BinOp::Add), just('-').to(BinOp::Sub))).then(product))
+                    .repeated(),
+            )
+            .foldl(|left, (op, right)| Node::Binary {
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+    });
+
+    expr.repeated().at_least(1).map(|items| Module { items })
 }
 
 pub fn parse(input: &str) -> Result<Module, Vec<Simple<char>>> {

--- a/tests/expr_parser.rs
+++ b/tests/expr_parser.rs
@@ -1,0 +1,19 @@
+use mind::{eval, parser};
+
+#[test]
+fn precedence_and_parens() {
+    let module = parser::parse("1 + 2 * 3").unwrap();
+    assert_eq!(eval::eval_first_expr(&module).unwrap(), 7);
+
+    let module = parser::parse("(1 + 2) * 3").unwrap();
+    assert_eq!(eval::eval_first_expr(&module).unwrap(), 9);
+}
+
+#[test]
+fn division_and_zero_guard() {
+    let module = parser::parse("8 / 2").unwrap();
+    assert_eq!(eval::eval_first_expr(&module).unwrap(), 4);
+
+    let module = parser::parse("1 / 0").unwrap();
+    assert!(eval::eval_first_expr(&module).is_err());
+}


### PR DESCRIPTION
Extends AST and parser with binary expressions and precedence; adds a tiny integer evaluator for tests. Includes unit + doc-tests and docs updates. No optional features; CI stays on `--no-default-features`.

------
https://chatgpt.com/codex/tasks/task_b_690cc2b07ab0832a80de7d678f38a23d