### PR TITLE
chore(fmt): stable-only rustfmt config + show formatter version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt
+      - name: rustfmt version
+        run: rustfmt --version
       - name: rustfmt check
         run: cargo fmt --all -- --check
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 max_width = 100
 use_small_heuristics = "Max"
-imports_granularity = "Crate"
-group_imports = "StdExternalCrate"
 format_code_in_doc_comments = true
+reorder_imports = true
+newline_style = "Unix"


### PR DESCRIPTION
## Summary
- update rustfmt.toml to remove nightly-only options and stick to stable settings
- extend the rustfmt CI job to print the formatter version for better visibility

## Testing
- not run (config-only changes)


------
https://chatgpt.com/codex/tasks/task_b_690cc73faf68832a8346a10ed4f993f1