### PR TITLE
Phase 2B: variables (let/assign) + constant folding (+ tests, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ cargo run --quiet -- eval "1 + 2 * 3"
 # → 7
 ```
 
+### Variables & assignment
+```bash
+cargo run --quiet -- eval "let x = 2; x = x + 5; x * 3"
+# → 21
+```
+
 ### Hello, Tensor
 ```mind
 import std.tensor;

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -17,6 +17,15 @@
 - Literals: `Int`, `Ident`
 - Binary ops: `+`, `-`, `*`, `/` with precedence `*` & `/` over `+` & `-`, all left-associative
 - Parentheses override precedence
+
+## 3.1 Statements (Phase subset)
+- `let <ident> = <expr>`
+- `<ident> = <expr>`
+- Semicolons/newlines as separators.
+- Result value = value of the last statement/expression.
+
+## 3.2 Constant Folding (Phase subset)
+- Bottom-up on integer `+ - * /` (skip `÷0`).
 ## 4. Autodiff Primitives (grad, vjp, jvp)
 ## 5. Module System and Stdlib Surface
 ## 6. IR Mapping to MLIR

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -17,6 +17,8 @@ pub enum Node {
     Lit(Literal),
     Binary { op: BinOp, left: Box<Node>, right: Box<Node> },
     Paren(Box<Node>),
+    Let { name: String, value: Box<Node> },
+    Assign { name: String, value: Box<Node> },
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ast;
 #[cfg(feature = "autodiff")]
 pub mod autodiff;
 pub mod eval;
+pub mod opt;
 pub mod lexer;
 pub mod parser;
 pub mod stdlib;

--- a/src/opt/fold.rs
+++ b/src/opt/fold.rs
@@ -1,0 +1,41 @@
+use crate::ast::{BinOp, Literal, Node};
+
+/// Fold constant integer subtrees bottom-up. Pure function; no env.
+pub fn fold(node: &Node) -> Node {
+    match node {
+        Node::Binary { op, left, right } => {
+            let l = fold(left);
+            let r = fold(right);
+            if let (Node::Lit(Literal::Int(a)), Node::Lit(Literal::Int(b))) = (&l, &r) {
+                let v = match op {
+                    BinOp::Add => a + b,
+                    BinOp::Sub => a - b,
+                    BinOp::Mul => a * b,
+                    BinOp::Div => {
+                        if *b == 0 {
+                            return Node::Binary {
+                                op: op.clone(),
+                                left: Box::new(l),
+                                right: Box::new(r),
+                            };
+                        } else {
+                            a / b
+                        }
+                    }
+                };
+                Node::Lit(Literal::Int(v))
+            } else {
+                Node::Binary {
+                    op: op.clone(),
+                    left: Box::new(l),
+                    right: Box::new(r),
+                }
+            }
+        }
+        Node::Paren(inner) => {
+            let f = fold(inner);
+            Node::Paren(Box::new(f))
+        }
+        other => other.clone(),
+    }
+}

--- a/src/opt/mod.rs
+++ b/src/opt/mod.rs
@@ -1,0 +1,1 @@
+pub mod fold;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,9 +9,13 @@ use chumsky::prelude::*;
 
 use crate::ast::{BinOp, Literal, Module, Node};
 
+fn kw(s: &'static str) -> impl Parser<char, &'static str, Error = Simple<char>> {
+    text::keyword(s).to(s)
+}
+
 pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
     let int = text::int(10).map(|s: String| Node::Lit(Literal::Int(s.parse().unwrap())));
-    let ident = text::ident().map(|s: String| Node::Lit(Literal::Ident(s)));
+    let ident = text::ident().map(|s: String| Node::Lit(Literal::Ident(s.clone())));
 
     let expr = recursive(|expr| {
         let atom = choice((
@@ -20,36 +24,73 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             just('(')
                 .ignore_then(expr.clone())
                 .then_ignore(just(')'))
-                .map(|node| Node::Paren(Box::new(node))),
+                .map(|e| Node::Paren(Box::new(e))),
         ))
         .padded();
 
         let product = atom
             .clone()
             .then(
-                (choice((just('*').to(BinOp::Mul), just('/').to(BinOp::Div))).then(atom.clone()))
-                    .repeated(),
+                (choice((just('*').to(BinOp::Mul), just('/').to(BinOp::Div)))
+                    .padded()
+                    .then(atom.clone()))
+                .repeated(),
             )
-            .foldl(|left, (op, right)| Node::Binary {
+            .foldl(|l, (op, r)| Node::Binary {
                 op,
-                left: Box::new(left),
-                right: Box::new(right),
+                left: Box::new(l),
+                right: Box::new(r),
             });
 
         product
             .clone()
             .then(
-                (choice((just('+').to(BinOp::Add), just('-').to(BinOp::Sub))).then(product))
-                    .repeated(),
+                (choice((just('+').to(BinOp::Add), just('-').to(BinOp::Sub)))
+                    .padded()
+                    .then(product))
+                .repeated(),
             )
-            .foldl(|left, (op, right)| Node::Binary {
+            .foldl(|l, (op, r)| Node::Binary {
                 op,
-                left: Box::new(left),
-                right: Box::new(right),
+                left: Box::new(l),
+                right: Box::new(r),
             })
     });
 
-    expr.repeated().at_least(1).map(|items| Module { items })
+    let ident_str = ident.clone().map(|n| {
+        if let Node::Lit(Literal::Ident(s)) = n {
+            s
+        } else {
+            unreachable!()
+        }
+    });
+
+    let let_stmt = kw("let")
+        .padded()
+        .ignore_then(ident_str.clone())
+        .then_ignore(just('=').padded())
+        .then(expr.clone())
+        .map(|(name, value)| Node::Let {
+            name,
+            value: Box::new(value),
+        });
+
+    let assign_stmt = ident_str
+        .then_ignore(just('=').padded())
+        .then(expr.clone())
+        .map(|(name, value)| Node::Assign {
+            name,
+            value: Box::new(value),
+        });
+
+    let stmt = choice((let_stmt, assign_stmt, expr.clone())).padded();
+
+    let stmts = stmt
+        .separated_by(one_of(";\n").repeated().at_least(1))
+        .allow_trailing()
+        .at_least(1);
+
+    stmts.map(|items| Module { items })
 }
 
 pub fn parse(input: &str) -> Result<Module, Vec<Simple<char>>> {

--- a/tests/const_folding.rs
+++ b/tests/const_folding.rs
@@ -1,0 +1,13 @@
+use mind::{ast::Node, opt::fold, parser};
+
+#[test]
+fn folds_simple_arith() {
+    let m = parser::parse("1 + 2 * 3").unwrap();
+    let node = &m.items[0];
+    let f = fold::fold(node);
+    if let Node::Lit(_) = f {
+        // folded to literal
+    } else {
+        panic!("not folded");
+    }
+}

--- a/tests/vars_assign.rs
+++ b/tests/vars_assign.rs
@@ -1,0 +1,15 @@
+use mind::{eval, parser};
+
+#[test]
+fn let_and_use_variable() {
+    let m = parser::parse("let x = 2; x * 3 + 1").unwrap();
+    let v = eval::eval_module(&m).unwrap();
+    assert_eq!(v, 7);
+}
+
+#[test]
+fn assign_updates_value() {
+    let m = parser::parse("let x = 1; x = x + 4; x * 2").unwrap();
+    let v = eval::eval_module(&m).unwrap();
+    assert_eq!(v, 10);
+}


### PR DESCRIPTION
## Summary
- extend the AST and parser to support statements, let-bindings, and assignments with semicolons or newlines
- evaluate modules through a simple integer environment and reuse the result of the last statement
- add a constant-folding pass, regression tests, and documentation updates covering variables and folding

## Testing
- cargo test --no-default-features
- cargo run --quiet --no-default-features -- eval "let x = 2; x = x + 5; x * 3"


------
https://chatgpt.com/codex/tasks/task_b_690cd0661de0832a8490dca2e4a3811d