### PR TITLE
Phase 2C: pretty diagnostics (spans + caret highlights) and CLI error display

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,19 @@ cargo run --quiet -- eval "let x = 2; x = x + 5; x * 3"
 # → 21
 ```
 
+### Diagnostics
+
+Pretty parse errors now include line/col and carets:
+
+```
+$ mind eval "let = 2"
+error: expected identifier
+--> line 1, col 5
+let = 2
+^
+
+```
+
 ### Hello, Tensor
 ```mind
 import std.tensor;

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -31,6 +31,10 @@
 ## 6. IR Mapping to MLIR
 ## 7. Safety, Errors, Diagnostics
 
+### Phase subset (Diagnostics)
+- Errors report 1-based line/col and a single-line caret highlight.
+- Multi-line spans degrade to single-line best-effort (to be improved later).
+
 ## 2.1 Shape Inference (Phase 1)
 Left-biased unification:
 - Known==Known → Known

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -1,0 +1,76 @@
+//! Pretty diagnostics: spans, line/col, caret-highlights.
+
+use std::ops::Range;
+
+/// Byte-span in the original source (inclusive start, exclusive end).
+pub type Span = Range<usize>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Location {
+    pub line: usize,  // 1-based
+    pub col: usize,   // 1-based (Unicode-agnostic; counts bytes)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub message: String,
+    pub span: Span,
+    pub start: Location,
+    pub end: Location,
+}
+
+/// Compute (line, col) from byte offset.
+fn offset_to_loc(src: &str, offset: usize) -> Location {
+    let mut line = 1usize;
+    let mut col = 1usize;
+    let mut count = 0usize;
+    for ch in src.chars() {
+        if count >= offset { break; }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+        count += ch.len_utf8();
+    }
+    Location { line, col }
+}
+
+/// Extract the single source line containing `span.start`.
+fn line_at(src: &str, span: Span) -> (String, usize /*line_start_offset*/) {
+    let bytes = src.as_bytes();
+    let mut b = span.start;
+    while b > 0 && bytes[b - 1] != b'\n' { b -= 1; }
+    let mut e = span.start;
+    while e < bytes.len() && bytes[e] != b'\n' { e += 1; }
+    (src[b..e].to_string(), b)
+}
+
+/// Render caret-highlight under the selected span (single-line best effort).
+pub fn render(src: &str, diag: &Diagnostic) -> String {
+    let span = diag.span.clone();
+    let (line_str, line_off) = line_at(src, span.clone());
+    let caret_start = span.start.saturating_sub(line_off);
+    let caret_len = span.end.saturating_sub(span.start).max(1);
+
+    let mut carets = String::new();
+    for _ in 0..caret_start { carets.push(' '); }
+    for _ in 0..caret_len { carets.push('^'); }
+
+    format!(
+        "error: {}\n--> line {}, col {}\n{}\n{}",
+        diag.message, diag.start.line, diag.start.col, line_str, carets
+    )
+}
+
+impl Diagnostic {
+    /// Construct from a chumsky `Simple` error.
+    pub fn from_chumsky(src: &str, e: chumsky::error::Simple<char>) -> Self {
+        let span = e.span();
+        let start = offset_to_loc(src, span.start);
+        let end = offset_to_loc(src, span.end);
+        let message = e.to_string();
+        Diagnostic { message, span, start, end }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! MIND core library (Phase 1 scaffold)
 pub mod ast;
+pub mod diagnostics;
 #[cfg(feature = "autodiff")]
 pub mod autodiff;
 pub mod eval;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,23 +5,29 @@
 //! mind eval "1 + 2 * 3"
 //! ```
 
-use mind::{eval, parser};
+use mind::{diagnostics, eval, parser};
 use std::env;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 3 || args[1] != "eval" {
-        eprintln!("Usage: mind eval \"<expression>\"");
+        eprintln!("Usage: mind eval \"<expression or statements>\"");
         std::process::exit(1);
     }
 
-    let expr = &args[2];
-    match parser::parse(expr) {
+    let src = &args[2];
+    match parser::parse_with_diagnostics(src) {
         Ok(module) => match eval::eval_first_expr(&module) {
-            Ok(result) => println!("{}", result),
+            Ok(result) => println!("{result}"),
             Err(e) => eprintln!("Evaluation error: {e}"),
         },
-        Err(_) => eprintln!("Parse error"),
+        Err(diags) => {
+            for d in diags {
+                let msg = diagnostics::render(src, &d);
+                eprintln!("{msg}");
+            }
+            std::process::exit(2);
+        }
     }
 }

--- a/tests/diagnostics_parse.rs
+++ b/tests/diagnostics_parse.rs
@@ -1,0 +1,24 @@
+use mind::parser;
+
+#[test]
+fn shows_pretty_error_for_unexpected_paren() {
+    let src = ")";
+    let Err(diags) = parser::parse_with_diagnostics(src) else { panic!("expected error"); };
+    let joined = diags
+        .iter()
+        .map(|d| mind::diagnostics::render(src, d))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(joined.contains("error"));
+    assert!(joined.contains("line 1"));
+    assert!(joined.contains("^")); // caret present
+}
+
+#[test]
+fn shows_error_for_unclosed_paren() {
+    let src = "(";
+    let Err(diags) = parser::parse_with_diagnostics(src) else { panic!("expected error"); };
+    let s = mind::diagnostics::render(src, &diags[0]);
+    assert!(s.contains("line 1"));
+    assert!(s.contains("^"));
+}


### PR DESCRIPTION
Adds a diagnostics module (spans, line/col, caret rendering) and `parser::parse_with_diagnostics`. CLI now prints pretty errors. Includes regression tests and docs. Text-only; no feature deps.

------
https://chatgpt.com/codex/tasks/task_b_690cd653c1dc832a82ebd026df1aa370