### PR TITLE
Phase 2D: REPL (`mind repl`) with persistent env + integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,18 @@ cargo run --quiet -- eval "let x = 2; x = x + 5; x * 3"
 # → 21
 ```
 
+### REPL (interactive)
+
+```bash
+cargo run --quiet -- repl
+# MIND REPL — type :quit to exit
+# MIND> let x = 2;
+# 2
+# MIND> x * 3
+# 6
+# MIND> :quit
+```
+
 ### Diagnostics
 
 Pretty parse errors now include line/col and carets:

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -35,6 +35,11 @@
 - Errors report 1-based line/col and a single-line caret highlight.
 - Multi-line spans degrade to single-line best-effort (to be improved later).
 
+## 7.1 REPL (Phase subset)
+- Stateful environment: variables persist across inputs.
+- Input is parsed as a mini-module (statements separated by `;` or newline).
+- Result = last statement/expression value.
+
 ## 2.1 Shape Inference (Phase 1)
 Left-biased unification:
 - Known==Known → Known

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -40,22 +40,29 @@ fn eval_expr(node: &Node, env: &HashMap<String, i64>) -> Result<i64, EvalError> 
     }
 }
 
-pub fn eval_module(m: &Module) -> Result<i64, EvalError> {
-    let mut env: HashMap<String, i64> = HashMap::new();
+pub fn eval_module_with_env(
+    m: &Module,
+    env: &mut HashMap<String, i64>,
+) -> Result<i64, EvalError> {
     let mut last = 0_i64;
     for item in &m.items {
         match item {
             Node::Let { name, value } | Node::Assign { name, value } => {
-                let v = eval_expr(value, &env)?;
+                let v = eval_expr(value, env)?;
                 env.insert(name.clone(), v);
                 last = v;
             }
             _ => {
-                last = eval_expr(item, &env)?;
+                last = eval_expr(item, env)?;
             }
         }
     }
     Ok(last)
+}
+
+pub fn eval_module(m: &Module) -> Result<i64, EvalError> {
+    let mut env: HashMap<String, i64> = HashMap::new();
+    eval_module_with_env(m, &mut env)
 }
 
 pub fn eval_first_expr(m: &Module) -> Result<i64, EvalError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,38 @@
 //! Command-line entry point for MIND.
 //!
 //! Usage:
-//! ```bash
-//! mind eval "1 + 2 * 3"
-//! ```
+//!   mind eval "1 + 2 * 3"
+//!   mind repl
 
-use mind::{diagnostics, eval, parser};
-use std::env;
+use mind::{parser, eval, diagnostics};
+use std::collections::HashMap;
+use std::io::{self, Write};
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
+    let args: Vec<String> = std::env::args().collect();
 
-    if args.len() < 3 || args[1] != "eval" {
-        eprintln!("Usage: mind eval \"<expression or statements>\"");
-        std::process::exit(1);
+    if args.len() >= 2 && args[1] == "eval" {
+        if args.len() < 3 {
+            eprintln!("Usage: mind eval \"<expression or statements>\"");
+            std::process::exit(1);
+        }
+        let src = &args[2];
+        run_eval_once(src);
+        return;
     }
 
-    let src = &args[2];
+    if args.len() >= 2 && args[1] == "repl" {
+        run_repl();
+        return;
+    }
+
+    eprintln!("Usage:");
+    eprintln!("  mind eval \"<expression or statements>\"");
+    eprintln!("  mind repl");
+    std::process::exit(1);
+}
+
+fn run_eval_once(src: &str) {
     match parser::parse_with_diagnostics(src) {
         Ok(module) => match eval::eval_first_expr(&module) {
             Ok(result) => println!("{result}"),
@@ -28,6 +44,40 @@ fn main() {
                 eprintln!("{msg}");
             }
             std::process::exit(2);
+        }
+    }
+}
+
+fn run_repl() {
+    let mut env: HashMap<String, i64> = HashMap::new();
+    let stdin = io::stdin();
+    let mut line = String::new();
+
+    println!("MIND REPL — type :quit to exit");
+    loop {
+        print!("MIND> ");
+        let _ = io::stdout().flush();
+
+        line.clear();
+        if stdin.read_line(&mut line).is_err() {
+            eprintln!("Input error");
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() { continue; }
+        if matches!(trimmed, ":quit" | ":q" | ":exit") { break; }
+
+        match parser::parse_with_diagnostics(trimmed) {
+            Ok(module) => match eval::eval_module_with_env(&module, &mut env) {
+                Ok(result) => println!("{result}"),
+                Err(e) => eprintln!("Evaluation error: {e}"),
+            },
+            Err(diags) => {
+                for d in diags {
+                    let msg = diagnostics::render(trimmed, &d);
+                    eprintln!("{msg}");
+                }
+            }
         }
     }
 }

--- a/tests/repl_basic.rs
+++ b/tests/repl_basic.rs
@@ -1,0 +1,28 @@
+use std::process::{Command, Stdio};
+use std::io::Write;
+
+#[test]
+fn repl_accepts_statements_and_expressions() {
+    let mut child = Command::new("cargo")
+        .args(&["run", "--quiet", "--"])
+        .arg("repl")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn repl");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    // Feed a small session
+    writeln!(stdin, "let x = 2;").unwrap();
+    writeln!(stdin, "x * 3").unwrap();
+    writeln!(stdin, ":quit").unwrap();
+    drop(stdin);
+
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Expect to see the result '6' somewhere in the output
+    assert!(stdout.contains("6"), "stdout was: {}", stdout);
+}


### PR DESCRIPTION
Adds an interactive REPL (`mind repl`) that preserves variables across inputs and prints pretty diagnostics. Provides `eval_module_with_env` for stateful sessions, an integration test that feeds stdin, and README/spec updates. Text-only; no optional features.

------
https://chatgpt.com/codex/tasks/task_b_690cd899aca8832a8db4aec3f47a544c