### PR TITLE
Phase 3B: type annotations + tensor type syntax + checker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,15 @@ cargo run --quiet -- eval "let x = 2; x = x + 5; x * 3"
 - Binary ops require both sides to be scalar
 - Type errors are reported before execution
 
+### Typed let (Phase 3B)
+```bash
+cargo run --quiet -- eval 'let n: i32 = 3; n + 1'
+# → 4
+
+cargo run --quiet -- eval 'let x: Tensor[f32,(B,3,224,224)] = 0; x + 1'
+# → type error (tensor vs scalar)
+```
+
 ### REPL (interactive)
 
 ```bash

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -60,3 +60,9 @@ Left-biased unification:
 - Literals: `Int` → `Scalar(i32)`.
 - Identifiers: resolved from type environment.
 - Binary ops `+ - * /`: both operands must be `Scalar(i32)` → result `Scalar(i32)`.
+
+## 4.2 Type annotations (Phase 3B)
+- `let name: i32 = expr`
+- `let name: Tensor[dtype,(dims...)] = expr` where `dims` are ints or symbols.
+- Annotation seeds the type environment and is validated against the inferred type of `expr`.
+- For now, expressions type-check only as scalar arithmetic; tensor annotations are enforced but tensor arithmetic is not yet implemented.

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -13,11 +13,17 @@ pub enum BinOp {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeAnn {
+    ScalarI32,
+    Tensor { dtype: String, dims: Vec<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Node {
     Lit(Literal),
     Binary { op: BinOp, left: Box<Node>, right: Box<Node> },
     Paren(Box<Node>),
-    Let { name: String, value: Box<Node> },
+    Let { name: String, ann: Option<TypeAnn>, value: Box<Node> },
     Assign { name: String, value: Box<Node> },
 }
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -62,7 +62,7 @@ pub fn eval_module_with_env(
     let mut last = 0_i64;
     for item in &m.items {
         match item {
-            Node::Let { name, value } | Node::Assign { name, value } => {
+            Node::Let { name, value, .. } | Node::Assign { name, value } => {
                 let v = eval_expr(value, env)?;
                 env.insert(name.clone(), v);
                 last = v;

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::ast::{Literal, Module, Node};
 use crate::diagnostics::{Diagnostic as Pretty, Location, Span};
-use crate::types::ValueType;
+use crate::types::{DType, ShapeDim, TensorType, ValueType};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TypeError {
@@ -10,6 +10,8 @@ pub enum TypeError {
     UnknownIdent(String),
     #[error("incompatible types in binary operation")]
     BadBinop,
+    #[error("{0}")]
+    Msg(String),
 }
 
 pub type TypeEnv = HashMap<String, ValueType>;
@@ -33,6 +35,37 @@ fn infer_expr(node: &Node, env: &TypeEnv) -> Result<ValueType, TypeError> {
     }
 }
 
+fn dtype_from_str(s: &str) -> Option<DType> {
+    match s {
+        "i32" => Some(DType::I32),
+        "f32" => Some(DType::F32),
+        _ => None,
+    }
+}
+
+fn shape_from_dims(dims: &[String]) -> Vec<ShapeDim> {
+    dims.iter()
+        .map(|d| {
+            if let Ok(n) = d.parse::<usize>() {
+                ShapeDim::Known(n)
+            } else {
+                ShapeDim::Sym(Box::leak(d.clone().into_boxed_str()))
+            }
+        })
+        .collect()
+}
+
+fn valuetype_from_ann(ann: &crate::ast::TypeAnn) -> Option<ValueType> {
+    match ann {
+        crate::ast::TypeAnn::ScalarI32 => Some(ValueType::ScalarI32),
+        crate::ast::TypeAnn::Tensor { dtype, dims } => {
+            let dt = dtype_from_str(dtype)?;
+            let shape = shape_from_dims(dims);
+            Some(ValueType::Tensor(TensorType::new(dt, shape)))
+        }
+    }
+}
+
 /// Walk statements; extend env on let/assign; return pretty diags for any errors.
 pub fn check_module_types(module: &Module, src: &str, env: &TypeEnv) -> Vec<Pretty> {
     let mut errs = Vec::new();
@@ -40,12 +73,55 @@ pub fn check_module_types(module: &Module, src: &str, env: &TypeEnv) -> Vec<Pret
 
     for item in &module.items {
         match item {
-            Node::Let { name, value } | Node::Assign { name, value } => {
-                match infer_expr(value, &tenv) {
-                    Ok(t) => {
-                        tenv.insert(name.clone(), t);
+            Node::Let { name, ann, value } => match ann {
+                Some(annotation) => match valuetype_from_ann(annotation) {
+                    Some(vt_ann) => {
+                        match infer_expr(value, &tenv) {
+                            Ok(vt) => {
+                                if vt_ann != vt {
+                                    errs.push(pretty_whole_input(
+                                            src,
+                                            TypeError::Msg(format!(
+                                                "type mismatch for `{}`: annotation {:?} vs inferred {:?}",
+                                                name, vt_ann, vt
+                                            )),
+                                        ));
+                                }
+                            }
+                            Err(e) => errs.push(pretty_whole_input(src, e)),
+                        }
+                        tenv.insert(name.clone(), vt_ann);
+                    }
+                    None => errs.push(pretty_whole_input(
+                        src,
+                        TypeError::Msg(format!("unsupported annotation for `{}`", name)),
+                    )),
+                },
+                None => match infer_expr(value, &tenv) {
+                    Ok(vt) => {
+                        tenv.insert(name.clone(), vt);
                     }
                     Err(e) => errs.push(pretty_whole_input(src, e)),
+                },
+            },
+            Node::Assign { name, value } => {
+                let rhs = infer_expr(value, &tenv);
+                match (tenv.get(name).cloned(), rhs) {
+                    (Some(vt_lhs), Ok(vt_rhs)) => {
+                        if vt_lhs != vt_rhs {
+                            errs.push(pretty_whole_input(
+                                src,
+                                TypeError::Msg(format!(
+                                    "cannot assign `{}`: expected {:?} but found {:?}",
+                                    name, vt_lhs, vt_rhs
+                                )),
+                            ));
+                        }
+                    }
+                    (None, Ok(vt_rhs)) => {
+                        tenv.insert(name.clone(), vt_rhs);
+                    }
+                    (_, Err(e)) => errs.push(pretty_whole_input(src, e)),
                 }
             }
             other => {

--- a/tests/type_ann_check.rs
+++ b/tests/type_ann_check.rs
@@ -1,0 +1,20 @@
+use mind::{eval, parser};
+
+#[test]
+fn scalar_annotation_matches() {
+    let src = "let n: i32 = 3; n + 1";
+    let m = parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let out = eval::eval_module_with_env(&m, &mut env, Some(src)).unwrap();
+    assert_eq!(out, 4);
+}
+
+#[test]
+fn tensor_ann_blocks_scalar_ops() {
+    let src = "let x: Tensor[f32,(2,3)] = 0; x + 1";
+    let m = parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let err = eval::eval_module_with_env(&m, &mut env, Some(src)).unwrap_err();
+    let s = format!("{err}");
+    assert!(s.to_lowercase().contains("type"), "got: {s}");
+}

--- a/tests/type_ann_parse.rs
+++ b/tests/type_ann_parse.rs
@@ -1,0 +1,13 @@
+use mind::parser;
+
+#[test]
+fn parses_scalar_annotation() {
+    let m = parser::parse("let n: i32 = 3; n + 1").unwrap();
+    assert_eq!(m.items.len(), 2);
+}
+
+#[test]
+fn parses_tensor_annotation() {
+    let m = parser::parse("let x: Tensor[f32,(B,3,224,224)] = 0;").unwrap();
+    assert_eq!(m.items.len(), 1);
+}


### PR DESCRIPTION
Adds optional type annotations to `let` statements, with a parser for `i32` and `Tensor[f32,(...)]` syntax. Type checker now seeds and validates the type environment from annotations. Tensor annotations are enforced (and will reject scalar arithmetic against tensor-typed vars) while actual tensor operations remain future work. Includes tests and docs. Text-only; `--no-default-features`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e9169d9bc832a801af7b4453d200d)