### PR TITLE
Phase 3C: tensor typing rules with broadcasting (type-check only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ cargo run --quiet -- eval 'let x: Tensor[f32,(B,3,224,224)] = 0; x + 1'
 # → type error (tensor vs scalar)
 ```
 
+**Tensor typing & broadcasting (Phase 3C, type-check only)**
+- Elementwise `Tensor ⊕ Tensor` and `Tensor ⊕ Scalar` follow NumPy-style broadcasting.
+- Dtypes must match (`f32 + f32`); `i32` scalar can be promoted when adding to `Tensor[f32,...]`.
+- Mismatched shapes or dtypes produce pretty compile-time diagnostics.
+
 ### REPL (interactive)
 
 ```bash

--- a/docs/specs/v1.0.md
+++ b/docs/specs/v1.0.md
@@ -66,3 +66,9 @@ Left-biased unification:
 - `let name: Tensor[dtype,(dims...)] = expr` where `dims` are ints or symbols.
 - Annotation seeds the type environment and is validated against the inferred type of `expr`.
 - For now, expressions type-check only as scalar arithmetic; tensor annotations are enforced but tensor arithmetic is not yet implemented.
+
+## 4.3 Tensor binary ops & broadcasting (Phase 3C)
+- Dtype: `Tensor[f32, S] ⊕ Tensor[f32, T]` → `Tensor[f32, broadcast(S,T))`.
+- Scalar promotion: `Scalar(i32) ⊕ Tensor[f32,S]` → `Tensor[f32,S]` (type-level promotion).
+- Broadcasting: right-aligned; dim matches if equal, or one is `1`. Symbols must match exactly, or match with `1`.
+- On mismatch (dtype or shape), emit type error.

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::ast::{Literal, Module, Node};
+use crate::ast::{BinOp, Literal, Module, Node};
 use crate::diagnostics::{Diagnostic as Pretty, Location, Span};
 use crate::types::{DType, ShapeDim, TensorType, ValueType};
 
@@ -16,6 +16,121 @@ pub enum TypeError {
 
 pub type TypeEnv = HashMap<String, ValueType>;
 
+fn dtype_name(dtype: &DType) -> &'static str {
+    match dtype {
+        DType::I32 => "i32",
+        DType::F32 => "f32",
+        DType::BF16 => "bf16",
+        DType::F16 => "f16",
+    }
+}
+
+fn format_shape(shape: &[ShapeDim]) -> String {
+    let dims: Vec<String> = shape
+        .iter()
+        .map(|d| match d {
+            ShapeDim::Known(n) => n.to_string(),
+            ShapeDim::Sym(sym) => sym.to_string(),
+        })
+        .collect();
+    format!("({})", dims.join(","))
+}
+
+fn describe_tensor(tensor: &TensorType) -> String {
+    format!("Tensor[{}, {}]", dtype_name(&tensor.dtype), format_shape(&tensor.shape))
+}
+
+fn describe_value_type(v: &ValueType) -> String {
+    match v {
+        ValueType::ScalarI32 => "Scalar[i32]".to_string(),
+        ValueType::Tensor(tensor) => describe_tensor(tensor),
+    }
+}
+
+fn binop_display(op: &BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+",
+        BinOp::Sub => "-",
+        BinOp::Mul => "*",
+        BinOp::Div => "/",
+    }
+}
+
+fn promote_scalar_to(dtype: DType) -> Option<ValueType> {
+    match dtype {
+        DType::F32 => Some(ValueType::ScalarI32),
+        DType::I32 => Some(ValueType::ScalarI32),
+        _ => None,
+    }
+}
+
+fn combine_dtypes(lhs: &ValueType, rhs: &ValueType) -> Option<DType> {
+    match (lhs, rhs) {
+        (ValueType::Tensor(tl), ValueType::Tensor(tr)) => {
+            if tl.dtype == tr.dtype {
+                Some(tl.dtype.clone())
+            } else {
+                None
+            }
+        }
+        (ValueType::Tensor(t), ValueType::ScalarI32)
+        | (ValueType::ScalarI32, ValueType::Tensor(t)) => {
+            if t.dtype == DType::F32 {
+                promote_scalar_to(t.dtype.clone()).map(|_| DType::F32)
+            } else {
+                None
+            }
+        }
+        (ValueType::ScalarI32, ValueType::ScalarI32) => None,
+    }
+}
+
+fn broadcast_shapes(a: &[ShapeDim], b: &[ShapeDim]) -> Option<Vec<ShapeDim>> {
+    let mut out = Vec::new();
+    let mut i = a.len() as isize - 1;
+    let mut j = b.len() as isize - 1;
+
+    while i >= 0 || j >= 0 {
+        let da = if i >= 0 { a[i as usize].clone() } else { ShapeDim::Known(1) };
+        let db = if j >= 0 { b[j as usize].clone() } else { ShapeDim::Known(1) };
+
+        let dim = match (da, db) {
+            (ShapeDim::Known(x), ShapeDim::Known(y)) => {
+                if x == y {
+                    ShapeDim::Known(x)
+                } else if x == 1 {
+                    ShapeDim::Known(y)
+                } else if y == 1 {
+                    ShapeDim::Known(x)
+                } else {
+                    return None;
+                }
+            }
+            (ShapeDim::Sym(s1), ShapeDim::Sym(s2)) => {
+                if s1 == s2 {
+                    ShapeDim::Sym(s1)
+                } else {
+                    return None;
+                }
+            }
+            (ShapeDim::Sym(sym), ShapeDim::Known(n)) | (ShapeDim::Known(n), ShapeDim::Sym(sym)) => {
+                if n == 1 {
+                    ShapeDim::Sym(sym)
+                } else {
+                    return None;
+                }
+            }
+        };
+
+        out.push(dim);
+        i -= 1;
+        j -= 1;
+    }
+
+    out.reverse();
+    Some(out)
+}
+
 fn infer_expr(node: &Node, env: &TypeEnv) -> Result<ValueType, TypeError> {
     match node {
         Node::Lit(Literal::Int(_)) => Ok(ValueType::ScalarI32),
@@ -23,11 +138,54 @@ fn infer_expr(node: &Node, env: &TypeEnv) -> Result<ValueType, TypeError> {
             env.get(name).cloned().ok_or_else(|| TypeError::UnknownIdent(name.clone()))
         }
         Node::Paren(inner) => infer_expr(inner, env),
-        Node::Binary { left, right, .. } => {
+        Node::Binary { op, left, right } => {
             let lt = infer_expr(left, env)?;
             let rt = infer_expr(right, env)?;
-            match (lt, rt) {
-                (ValueType::ScalarI32, ValueType::ScalarI32) => Ok(ValueType::ScalarI32),
+            if matches!((&lt, &rt), (ValueType::ScalarI32, ValueType::ScalarI32)) {
+                return Ok(ValueType::ScalarI32);
+            }
+
+            match (&lt, &rt) {
+                (ValueType::Tensor(tl), ValueType::Tensor(tr)) => {
+                    if let Some(dtype) = combine_dtypes(&lt, &rt) {
+                        if let Some(shape) = broadcast_shapes(&tl.shape, &tr.shape) {
+                            Ok(ValueType::Tensor(TensorType::new(dtype, shape)))
+                        } else {
+                            Err(TypeError::Msg(format!(
+                                "cannot broadcast shapes {} and {} for `{}`",
+                                format_shape(&tl.shape),
+                                format_shape(&tr.shape),
+                                binop_display(op)
+                            )))
+                        }
+                    } else {
+                        Err(TypeError::Msg(format!(
+                            "dtype mismatch for `{}`: left {} vs right {}",
+                            binop_display(op),
+                            describe_tensor(tl),
+                            describe_tensor(tr)
+                        )))
+                    }
+                }
+                (ValueType::Tensor(t), ValueType::ScalarI32)
+                | (ValueType::ScalarI32, ValueType::Tensor(t)) => {
+                    if let Some(dtype) = combine_dtypes(&lt, &rt) {
+                        Ok(ValueType::Tensor(TensorType::new(dtype, t.shape.clone())))
+                    } else {
+                        let dtype_str = dtype_name(&t.dtype);
+                        let message = match promote_scalar_to(t.dtype.clone()) {
+                            Some(_) => format!(
+                                "cannot apply `{}`: scalar promotion to tensor dtype `{}` is not supported",
+                                binop_display(op), dtype_str
+                            ),
+                            None => format!(
+                                "cannot apply `{}`: tensor dtype `{}` does not support scalar operands",
+                                binop_display(op), dtype_str
+                            ),
+                        };
+                        Err(TypeError::Msg(message))
+                    }
+                }
                 _ => Err(TypeError::BadBinop),
             }
         }
@@ -80,12 +238,14 @@ pub fn check_module_types(module: &Module, src: &str, env: &TypeEnv) -> Vec<Pret
                             Ok(vt) => {
                                 if vt_ann != vt {
                                     errs.push(pretty_whole_input(
-                                            src,
-                                            TypeError::Msg(format!(
-                                                "type mismatch for `{}`: annotation {:?} vs inferred {:?}",
-                                                name, vt_ann, vt
-                                            )),
-                                        ));
+                                        src,
+                                        TypeError::Msg(format!(
+                                            "type mismatch for `{}`: annotation {} vs inferred {}",
+                                            name,
+                                            describe_value_type(&vt_ann),
+                                            describe_value_type(&vt)
+                                        )),
+                                    ));
                                 }
                             }
                             Err(e) => errs.push(pretty_whole_input(src, e)),
@@ -112,8 +272,10 @@ pub fn check_module_types(module: &Module, src: &str, env: &TypeEnv) -> Vec<Pret
                             errs.push(pretty_whole_input(
                                 src,
                                 TypeError::Msg(format!(
-                                    "cannot assign `{}`: expected {:?} but found {:?}",
-                                    name, vt_lhs, vt_rhs
+                                    "cannot assign `{}`: expected {} but found {}",
+                                    name,
+                                    describe_value_type(&vt_lhs),
+                                    describe_value_type(&vt_rhs)
                                 )),
                             ));
                         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,6 +10,7 @@
 pub mod infer;
 pub mod value;
 
+pub use infer::*;
 pub use value::ValueType;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/tensor_broadcast.rs
+++ b/tests/tensor_broadcast.rs
@@ -1,0 +1,113 @@
+use mind::{
+    parser, type_checker,
+    types::{DType, ShapeDim, TensorType, ValueType},
+};
+use std::collections::HashMap;
+
+#[test]
+fn tensor_plus_tensor_same_shape() {
+    let src = "a + b";
+    let m = parser::parse(src).unwrap();
+    let mut env: HashMap<String, ValueType> = HashMap::new();
+    env.insert(
+        "a".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(2), ShapeDim::Known(3)],
+        )),
+    );
+    env.insert(
+        "b".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(2), ShapeDim::Known(3)],
+        )),
+    );
+    let diags = type_checker::check_module_types(&m, src, &env);
+    assert!(diags.is_empty(), "{:?}", diags);
+}
+
+#[test]
+fn tensor_plus_tensor_broadcast_tail() {
+    let src = "a + b";
+    let m = parser::parse(src).unwrap();
+    let mut env: HashMap<String, ValueType> = HashMap::new();
+    env.insert(
+        "a".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(2), ShapeDim::Known(1), ShapeDim::Known(3)],
+        )),
+    );
+    env.insert(
+        "b".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(1), ShapeDim::Known(4), ShapeDim::Known(3)],
+        )),
+    );
+    let diags = type_checker::check_module_types(&m, src, &env);
+    assert!(diags.is_empty(), "{:?}", diags);
+}
+
+#[test]
+fn tensor_plus_scalar_promote_i32_to_f32() {
+    let src = "a + 1";
+    let m = parser::parse(src).unwrap();
+    let mut env: HashMap<String, ValueType> = HashMap::new();
+    env.insert(
+        "a".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(2), ShapeDim::Known(3)],
+        )),
+    );
+    let diags = type_checker::check_module_types(&m, src, &env);
+    assert!(diags.is_empty(), "{:?}", diags);
+}
+
+#[test]
+fn dtype_mismatch_rejected() {
+    let src = "a + b";
+    let m = parser::parse(src).unwrap();
+    let mut env: HashMap<String, ValueType> = HashMap::new();
+    env.insert(
+        "a".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(2), ShapeDim::Known(3)],
+        )),
+    );
+    env.insert(
+        "b".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::I32,
+            vec![ShapeDim::Known(2), ShapeDim::Known(3)],
+        )),
+    );
+    let diags = type_checker::check_module_types(&m, src, &env);
+    assert!(!diags.is_empty(), "expected dtype mismatch");
+}
+
+#[test]
+fn shape_mismatch_rejected() {
+    let src = "a + b";
+    let m = parser::parse(src).unwrap();
+    let mut env: HashMap<String, ValueType> = HashMap::new();
+    env.insert(
+        "a".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(2), ShapeDim::Known(3)],
+        )),
+    );
+    env.insert(
+        "b".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Known(4), ShapeDim::Known(3)],
+        )),
+    );
+    let diags = type_checker::check_module_types(&m, src, &env);
+    assert!(!diags.is_empty(), "expected shape mismatch");
+}

--- a/tests/tensor_symbolic.rs
+++ b/tests/tensor_symbolic.rs
@@ -1,0 +1,51 @@
+use mind::{
+    parser, type_checker,
+    types::{DType, ShapeDim, TensorType, ValueType},
+};
+use std::collections::HashMap;
+
+#[test]
+fn broadcast_with_symbols_equal_symbols_ok() {
+    let src = "a + b";
+    let m = parser::parse(src).unwrap();
+    let mut env: HashMap<String, ValueType> = HashMap::new();
+    env.insert(
+        "a".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Sym("B"), ShapeDim::Known(3)],
+        )),
+    );
+    env.insert(
+        "b".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Sym("B"), ShapeDim::Known(1)],
+        )),
+    );
+    let diags = type_checker::check_module_types(&m, src, &env);
+    assert!(diags.is_empty(), "{:?}", diags);
+}
+
+#[test]
+fn broadcast_with_symbols_mismatch_fails() {
+    let src = "a + b";
+    let m = parser::parse(src).unwrap();
+    let mut env: HashMap<String, ValueType> = HashMap::new();
+    env.insert(
+        "a".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Sym("B"), ShapeDim::Known(3)],
+        )),
+    );
+    env.insert(
+        "b".to_string(),
+        ValueType::Tensor(TensorType::new(
+            DType::F32,
+            vec![ShapeDim::Sym("C"), ShapeDim::Known(3)],
+        )),
+    );
+    let diags = type_checker::check_module_types(&m, src, &env);
+    assert!(!diags.is_empty(), "expected symbol mismatch");
+}


### PR DESCRIPTION
Implements elementwise tensor typing with NumPy-style broadcasting and basic dtype rules. `Tensor ⊕ Tensor` and `Tensor ⊕ Scalar` now type-check (no runtime tensors yet). Adds tests for equal shapes, broadcasting, dtype and shape mismatches, and symbol handling. Docs updated. Text-only; `--no-default-features`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e9c7dc8b8832aa5413b7c31496f90)