### PR TITLE
Phase 3D: span-accurate type error diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ let = 2
 
 ```
 
+**Span-accurate type errors (Phase 3D):** carets now point to the exact token (identifier or operator) that triggered a type error.
+
 ### Hello, Tensor
 ```mind
 import std.tensor;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,3 +1,35 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    start: usize,
+    end: usize,
+}
+
+impl Span {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    pub fn end(&self) -> usize {
+        self.end
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Spanned<T> {
+    pub node: T,
+    pub span: Span,
+}
+
+impl<T> Spanned<T> {
+    pub fn new(node: T, span: Span) -> Self {
+        Self { node, span }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Literal {
     Int(i64),
@@ -20,11 +52,31 @@ pub enum TypeAnn {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Node {
-    Lit(Literal),
-    Binary { op: BinOp, left: Box<Node>, right: Box<Node> },
-    Paren(Box<Node>),
-    Let { name: String, ann: Option<TypeAnn>, value: Box<Node> },
-    Assign { name: String, value: Box<Node> },
+    Lit(Literal, Span),
+    Binary { op: BinOp, left: Box<Node>, right: Box<Node>, span: Span },
+    Paren(Box<Node>, Span),
+    Let { name: String, ann: Option<TypeAnn>, value: Box<Node>, span: Span },
+    Assign { name: String, value: Box<Node>, span: Span },
+}
+
+impl Node {
+    pub fn span(&self) -> Span {
+        match self {
+            Node::Lit(_, span)
+            | Node::Binary { span, .. }
+            | Node::Paren(_, span)
+            | Node::Let { span, .. }
+            | Node::Assign { span, .. } => *span,
+        }
+    }
+
+    pub fn span_start(&self) -> usize {
+        self.span().start()
+    }
+
+    pub fn span_end(&self) -> usize {
+        self.span().end()
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -17,12 +17,12 @@ pub enum EvalError {
 
 fn eval_expr(node: &Node, env: &HashMap<String, i64>) -> Result<i64, EvalError> {
     match node {
-        Node::Lit(Literal::Int(n)) => Ok(*n),
-        Node::Lit(Literal::Ident(name)) => {
+        Node::Lit(Literal::Int(n), _) => Ok(*n),
+        Node::Lit(Literal::Ident(name), _) => {
             env.get(name).copied().ok_or_else(|| EvalError::UnknownVar(name.clone()))
         }
-        Node::Paren(inner) => eval_expr(inner, env),
-        Node::Binary { op, left, right } => {
+        Node::Paren(inner, _) => eval_expr(inner, env),
+        Node::Binary { op, left, right, .. } => {
             let l = eval_expr(left, env)?;
             let r = eval_expr(right, env)?;
             Ok(match op {
@@ -62,7 +62,7 @@ pub fn eval_module_with_env(
     let mut last = 0_i64;
     for item in &m.items {
         match item {
-            Node::Let { name, value, .. } | Node::Assign { name, value } => {
+            Node::Let { name, value, .. } | Node::Assign { name, value, .. } => {
                 let v = eval_expr(value, env)?;
                 env.insert(name.clone(), v);
                 last = v;

--- a/src/opt/fold.rs
+++ b/src/opt/fold.rs
@@ -3,10 +3,10 @@ use crate::ast::{BinOp, Literal, Node};
 /// Fold constant integer subtrees bottom-up. Pure function; no env.
 pub fn fold(node: &Node) -> Node {
     match node {
-        Node::Binary { op, left, right } => {
+        Node::Binary { op, left, right, span } => {
             let l = fold(left);
             let r = fold(right);
-            if let (Node::Lit(Literal::Int(a)), Node::Lit(Literal::Int(b))) = (&l, &r) {
+            if let (Node::Lit(Literal::Int(a), _), Node::Lit(Literal::Int(b), _)) = (&l, &r) {
                 let v = match op {
                     BinOp::Add => a + b,
                     BinOp::Sub => a - b,
@@ -17,20 +17,21 @@ pub fn fold(node: &Node) -> Node {
                                 op: op.clone(),
                                 left: Box::new(l),
                                 right: Box::new(r),
+                                span: *span,
                             };
                         } else {
                             a / b
                         }
                     }
                 };
-                Node::Lit(Literal::Int(v))
+                Node::Lit(Literal::Int(v), *span)
             } else {
-                Node::Binary { op: op.clone(), left: Box::new(l), right: Box::new(r) }
+                Node::Binary { op: op.clone(), left: Box::new(l), right: Box::new(r), span: *span }
             }
         }
-        Node::Paren(inner) => {
+        Node::Paren(inner, span) => {
             let f = fold(inner);
-            Node::Paren(Box::new(f))
+            Node::Paren(Box::new(f), *span)
         }
         other => other.clone(),
     }

--- a/tests/const_folding.rs
+++ b/tests/const_folding.rs
@@ -5,7 +5,7 @@ fn folds_simple_arith() {
     let m = parser::parse("1 + 2 * 3").unwrap();
     let node = &m.items[0];
     let f = fold::fold(node);
-    if let Node::Lit(_) = f {
+    if let Node::Lit(_, _) = f {
         // folded to literal
     } else {
         panic!("not folded");

--- a/tests/type_error_spans.rs
+++ b/tests/type_error_spans.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+
+use mind::{diagnostics, parser, type_checker};
+
+#[test]
+fn unknown_ident_points_to_name() {
+    let src = "let n: i32 = x + 1";
+    let module = parser::parse_with_diagnostics(src).expect("parse failed");
+    let diags = type_checker::check_module_types(&module, src, &HashMap::new());
+    assert!(!diags.is_empty(), "expected type error diagnostic");
+    let rendered = diagnostics::render(src, &diags[0]);
+    assert!(rendered.contains("x + 1"), "diagnostic missing offending line: {rendered}");
+    let line = "let n: i32 = x + 1";
+    let x_idx = line.find('x').unwrap();
+    let caret_line = rendered.lines().last().unwrap_or("");
+    let caret_pos = caret_line.find('^').unwrap_or(usize::MAX);
+    assert!(caret_pos >= x_idx.saturating_sub(2), "caret not near identifier: {rendered}");
+}


### PR DESCRIPTION
Attach spans to AST nodes and emit type-check diagnostics with precise byte ranges. CLI/REPL re-run the checker on type errors to render carets at the exact offending token. Includes regression test and docs. Text-only; `--no-default-features`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690eab13c41c832aa46f7e19380f9785)