### PR TITLE
Phase 4A: Minimal tensor runtime (shape/dtype preview, broadcasting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,22 @@ More details: [/benchmarks/resnet.md](benchmarks/resnet.md)
 - **Build fails?** Ensure LLVM 15+ is in `PATH`
 - **Rust version mismatch?** Run `rustup update stable`
 
+### Tensor previews (Phase 4A)
+
+MIND now evaluates tensor expressions as lightweight previews (dtype + shape + optional fill), without materializing data buffers.
+
+```bash
+cargo run --quiet -- eval 'let x: Tensor[f32,(2,3)] = 0; x + 1'
+# → Tensor[F32,(2,3)] fill=1
+```
+
+Broadcasting support previews combined shapes:
+
+```bash
+cargo run --quiet -- eval 'let a: Tensor[f32,(2,1,3)] = 0; let b: Tensor[f32,(1,4,3)] = 0; a + b'
+# → Tensor[F32,(2,4,3)] fill=0
+```
+
 **Quick install via Docker:**
 ```bash
 docker pull mindlang/mind:latest

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -36,7 +36,7 @@ pub enum Literal {
     Ident(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOp {
     Add,
     Sub,

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 
-use crate::ast::{BinOp, Literal, Module, Node};
-use crate::types::ValueType;
+use crate::ast::{BinOp, Literal, Module, Node, TypeAnn};
+use crate::types::{DType, ShapeDim, ValueType};
+
+pub mod value;
+
+pub use value::{format_value_human, TensorVal, Value};
 
 #[derive(Debug, thiserror::Error)]
 pub enum EvalError {
-    #[error("unsupported node")]
+    #[error("unsupported operation")]
     Unsupported,
     #[error("division by zero")]
     DivZero,
@@ -15,38 +19,11 @@ pub enum EvalError {
     TypeError(String),
 }
 
-fn eval_expr(node: &Node, env: &HashMap<String, i64>) -> Result<i64, EvalError> {
-    match node {
-        Node::Lit(Literal::Int(n), _) => Ok(*n),
-        Node::Lit(Literal::Ident(name), _) => {
-            env.get(name).copied().ok_or_else(|| EvalError::UnknownVar(name.clone()))
-        }
-        Node::Paren(inner, _) => eval_expr(inner, env),
-        Node::Binary { op, left, right, .. } => {
-            let l = eval_expr(left, env)?;
-            let r = eval_expr(right, env)?;
-            Ok(match op {
-                BinOp::Add => l + r,
-                BinOp::Sub => l - r,
-                BinOp::Mul => l * r,
-                BinOp::Div => {
-                    if r == 0 {
-                        return Err(EvalError::DivZero);
-                    } else {
-                        l / r
-                    }
-                }
-            })
-        }
-        _ => Err(EvalError::Unsupported),
-    }
-}
-
-pub fn eval_module_with_env(
+pub fn eval_module_value_with_env(
     m: &Module,
     env: &mut HashMap<String, i64>,
     src_for_types: Option<&str>,
-) -> Result<i64, EvalError> {
+) -> Result<Value, EvalError> {
     if let Some(src) = src_for_types {
         let mut tenv: HashMap<String, ValueType> = HashMap::new();
         for (name, _value) in env.iter() {
@@ -59,20 +36,62 @@ pub fn eval_module_with_env(
         }
     }
 
-    let mut last = 0_i64;
+    let mut venv: HashMap<String, Value> =
+        env.iter().map(|(name, value)| (name.clone(), Value::Int(*value))).collect();
+
+    let mut last = Value::Int(0_i64);
     for item in &m.items {
         match item {
-            Node::Let { name, value, .. } | Node::Assign { name, value, .. } => {
-                let v = eval_expr(value, env)?;
-                env.insert(name.clone(), v);
-                last = v;
+            Node::Let { name, ann, value, .. } => {
+                let rhs = eval_value_expr(value, &venv)?;
+                let stored = match ann {
+                    Some(TypeAnn::Tensor { dtype, dims }) => {
+                        let (dtype, shape) = parse_tensor_ann(dtype, dims)?;
+                        let fill = match rhs {
+                            Value::Int(n) => Some(n as f64),
+                            Value::Tensor(ref t) => t.fill,
+                        };
+                        Value::Tensor(TensorVal::new(dtype, shape, fill))
+                    }
+                    Some(TypeAnn::ScalarI32) | None => rhs,
+                };
+                if let Value::Int(n) = stored {
+                    env.insert(name.clone(), n);
+                    venv.insert(name.clone(), Value::Int(n));
+                    last = Value::Int(n);
+                } else {
+                    venv.insert(name.clone(), stored.clone());
+                    last = stored;
+                }
+            }
+            Node::Assign { name, value, .. } => {
+                let rhs = eval_value_expr(value, &venv)?;
+                if let Value::Int(n) = rhs {
+                    env.insert(name.clone(), n);
+                    venv.insert(name.clone(), Value::Int(n));
+                    last = Value::Int(n);
+                } else {
+                    venv.insert(name.clone(), rhs.clone());
+                    last = rhs;
+                }
             }
             _ => {
-                last = eval_expr(item, env)?;
+                last = eval_value_expr(item, &venv)?;
             }
         }
     }
     Ok(last)
+}
+
+pub fn eval_module_with_env(
+    m: &Module,
+    env: &mut HashMap<String, i64>,
+    src_for_types: Option<&str>,
+) -> Result<i64, EvalError> {
+    match eval_module_value_with_env(m, env, src_for_types)? {
+        Value::Int(n) => Ok(n),
+        Value::Tensor(_) => Err(EvalError::Unsupported),
+    }
 }
 
 pub fn eval_module(m: &Module) -> Result<i64, EvalError> {
@@ -82,4 +101,184 @@ pub fn eval_module(m: &Module) -> Result<i64, EvalError> {
 
 pub fn eval_first_expr(m: &Module) -> Result<i64, EvalError> {
     eval_module(m)
+}
+
+fn eval_value_expr(node: &Node, env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+    match node {
+        Node::Lit(Literal::Int(n), _) => Ok(Value::Int(*n)),
+        Node::Lit(Literal::Ident(name), _) => {
+            env.get(name).cloned().ok_or_else(|| EvalError::UnknownVar(name.clone()))
+        }
+        Node::Paren(inner, _) => eval_value_expr(inner, env),
+        Node::Binary { op, left, right, .. } => {
+            let lv = eval_value_expr(left, env)?;
+            let rv = eval_value_expr(right, env)?;
+            apply_binary(*op, lv, rv)
+        }
+        Node::Let { value, .. } | Node::Assign { value, .. } => eval_value_expr(value, env),
+    }
+}
+
+fn apply_binary(op: BinOp, left: Value, right: Value) -> Result<Value, EvalError> {
+    match (left, right) {
+        (Value::Int(l), Value::Int(r)) => apply_int_op(op, l, r).map(Value::Int),
+        (Value::Tensor(t), Value::Int(s)) => apply_tensor_scalar(op, t, s as f64, true),
+        (Value::Int(s), Value::Tensor(t)) => apply_tensor_scalar(op, t, s as f64, false),
+        (Value::Tensor(a), Value::Tensor(b)) => apply_tensor_tensor(op, a, b),
+    }
+}
+
+fn apply_int_op(op: BinOp, left: i64, right: i64) -> Result<i64, EvalError> {
+    Ok(match op {
+        BinOp::Add => left + right,
+        BinOp::Sub => left - right,
+        BinOp::Mul => left * right,
+        BinOp::Div => {
+            if right == 0 {
+                return Err(EvalError::DivZero);
+            }
+            left / right
+        }
+    })
+}
+
+fn apply_tensor_scalar(
+    op: BinOp,
+    tensor: TensorVal,
+    scalar: f64,
+    tensor_on_left: bool,
+) -> Result<Value, EvalError> {
+    if matches!(op, BinOp::Div) && tensor_on_left && scalar == 0.0 {
+        return Err(EvalError::DivZero);
+    }
+
+    let TensorVal { dtype, shape, fill } = tensor;
+
+    let result_fill = match fill {
+        Some(f) => {
+            if matches!(op, BinOp::Div) && !tensor_on_left && f == 0.0 {
+                return Err(EvalError::DivZero);
+            }
+            Some(match op {
+                BinOp::Add => f + scalar,
+                BinOp::Sub => {
+                    if tensor_on_left {
+                        f - scalar
+                    } else {
+                        scalar - f
+                    }
+                }
+                BinOp::Mul => f * scalar,
+                BinOp::Div => {
+                    if tensor_on_left {
+                        f / scalar
+                    } else {
+                        scalar / f
+                    }
+                }
+            })
+        }
+        None => None,
+    };
+
+    Ok(Value::Tensor(TensorVal::new(dtype, shape, result_fill)))
+}
+
+fn apply_tensor_tensor(op: BinOp, left: TensorVal, right: TensorVal) -> Result<Value, EvalError> {
+    if left.dtype != right.dtype {
+        return Err(EvalError::Unsupported);
+    }
+
+    let shape = broadcast_shapes(&left.shape, &right.shape).ok_or(EvalError::Unsupported)?;
+
+    if matches!(op, BinOp::Div) {
+        if let Some(fill) = right.fill {
+            if fill == 0.0 {
+                return Err(EvalError::DivZero);
+            }
+        }
+    }
+
+    let fill = match (left.fill, right.fill) {
+        (Some(a), Some(b)) => Some(match op {
+            BinOp::Add => a + b,
+            BinOp::Sub => a - b,
+            BinOp::Mul => a * b,
+            BinOp::Div => a / b,
+        }),
+        _ => None,
+    };
+
+    Ok(Value::Tensor(TensorVal::new(left.dtype, shape, fill)))
+}
+
+fn broadcast_shapes(a: &[ShapeDim], b: &[ShapeDim]) -> Option<Vec<ShapeDim>> {
+    let mut result = Vec::new();
+    let mut i = a.len() as isize - 1;
+    let mut j = b.len() as isize - 1;
+    while i >= 0 || j >= 0 {
+        let da = if i >= 0 { &a[i as usize] } else { &ShapeDim::Known(1) };
+        let db = if j >= 0 { &b[j as usize] } else { &ShapeDim::Known(1) };
+        let dim = match (da, db) {
+            (ShapeDim::Known(x), ShapeDim::Known(y)) if x == y => ShapeDim::Known(*x),
+            (ShapeDim::Known(1), ShapeDim::Known(y)) => ShapeDim::Known(*y),
+            (ShapeDim::Known(x), ShapeDim::Known(1)) => ShapeDim::Known(*x),
+            (ShapeDim::Sym(s1), ShapeDim::Sym(s2)) if s1 == s2 => ShapeDim::Sym(s1),
+            (ShapeDim::Sym(sym), ShapeDim::Known(1)) | (ShapeDim::Known(1), ShapeDim::Sym(sym)) => {
+                ShapeDim::Sym(sym)
+            }
+            _ => return None,
+        };
+        result.push(dim);
+        i -= 1;
+        j -= 1;
+    }
+    result.reverse();
+    Some(result)
+}
+
+fn parse_tensor_ann(dtype: &str, dims: &[String]) -> Result<(DType, Vec<ShapeDim>), EvalError> {
+    let dtype = str_to_dtype(dtype).ok_or(EvalError::Unsupported)?;
+    let mut shape = Vec::with_capacity(dims.len());
+    for dim in dims {
+        if let Ok(n) = dim.parse::<usize>() {
+            shape.push(ShapeDim::Known(n));
+        } else {
+            let leaked: &'static str = Box::leak(dim.clone().into_boxed_str());
+            shape.push(ShapeDim::Sym(leaked));
+        }
+    }
+    Ok((dtype, shape))
+}
+
+fn str_to_dtype(s: &str) -> Option<DType> {
+    match s.to_ascii_lowercase().as_str() {
+        "i32" => Some(DType::I32),
+        "f32" => Some(DType::F32),
+        "bf16" => Some(DType::BF16),
+        "f16" => Some(DType::F16),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser;
+
+    #[test]
+    fn eval_tensor_add_scalar_preview() {
+        let src = "let x: Tensor[f32,(2,3)] = 0; x + 1";
+        let module = parser::parse(src).unwrap();
+        let mut env = HashMap::new();
+        let value = eval_module_value_with_env(&module, &mut env, Some(src)).unwrap();
+        match value {
+            Value::Tensor(t) => {
+                assert_eq!(t.shape, vec![ShapeDim::Known(2), ShapeDim::Known(3)]);
+                assert_eq!(t.dtype, DType::F32);
+                assert_eq!(t.fill, Some(1.0));
+            }
+            _ => panic!("expected tensor"),
+        }
+    }
 }

--- a/src/eval/value.rs
+++ b/src/eval/value.rs
@@ -1,0 +1,92 @@
+use crate::types::{DType, ShapeDim, TensorType};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TensorVal {
+    pub dtype: DType,
+    pub shape: Vec<ShapeDim>,
+    /// Optional constant fill value for all elements (preview only).
+    pub fill: Option<f64>,
+}
+
+impl TensorVal {
+    pub fn from_type(t: &TensorType, fill: Option<f64>) -> Self {
+        Self { dtype: t.dtype.clone(), shape: t.shape.clone(), fill }
+    }
+
+    pub fn new(dtype: DType, shape: Vec<ShapeDim>, fill: Option<f64>) -> Self {
+        Self { dtype, shape, fill }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Int(i64),
+    Tensor(TensorVal),
+}
+
+impl Value {
+    pub fn is_int(&self) -> bool {
+        matches!(self, Value::Int(_))
+    }
+
+    pub fn as_int(&self) -> Option<i64> {
+        if let Value::Int(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+}
+
+pub fn format_value_human(v: &Value) -> String {
+    match v {
+        Value::Int(n) => format!("{n}"),
+        Value::Tensor(t) => {
+            let mut shape = String::from("(");
+            for (i, d) in t.shape.iter().enumerate() {
+                if i > 0 {
+                    shape.push(',');
+                }
+                match d {
+                    ShapeDim::Known(n) => shape.push_str(&n.to_string()),
+                    ShapeDim::Sym(sym) => shape.push_str(sym),
+                }
+            }
+            shape.push(')');
+            match t.fill {
+                Some(f) => format!(
+                    "Tensor[{dtype:?},{shape}] fill={fill}",
+                    dtype = t.dtype,
+                    shape = shape,
+                    fill = trim_float(f)
+                ),
+                None => format!("Tensor[{dtype:?},{shape}]", dtype = t.dtype, shape = shape),
+            }
+        }
+    }
+}
+
+fn trim_float(x: f64) -> String {
+    let s = format!("{:.6}", x);
+    s.trim_end_matches('0').trim_end_matches('.').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{DType, ShapeDim};
+
+    #[test]
+    fn format_tensor_fill_trim() {
+        let t = TensorVal::new(DType::F32, vec![ShapeDim::Known(2)], Some(1.2300001));
+        let s = format_value_human(&Value::Tensor(t));
+        assert!(s.contains("1.23"));
+    }
+
+    #[test]
+    fn format_tensor_shape_symbols() {
+        let t = TensorVal::new(DType::I32, vec![ShapeDim::Sym("B"), ShapeDim::Known(4)], None);
+        let s = format_value_human(&Value::Tensor(t));
+        assert!(s.contains("(B,4)"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,8 @@ fn run_eval_once(src: &str) {
     match parser::parse_with_diagnostics(src) {
         Ok(module) => {
             let mut env = HashMap::new();
-            match eval::eval_module_with_env(&module, &mut env, Some(src)) {
-                Ok(result) => println!("{result}"),
+            match eval::eval_module_value_with_env(&module, &mut env, Some(src)) {
+                Ok(result) => println!("{}", eval::format_value_human(&result)),
                 Err(e) => report_eval_error(e, src, &module),
             }
         }
@@ -75,10 +75,12 @@ fn run_repl() {
         }
 
         match parser::parse_with_diagnostics(trimmed) {
-            Ok(module) => match eval::eval_module_with_env(&module, &mut env, Some(trimmed)) {
-                Ok(result) => println!("{result}"),
-                Err(e) => report_eval_error(e, trimmed, &module),
-            },
+            Ok(module) => {
+                match eval::eval_module_value_with_env(&module, &mut env, Some(trimmed)) {
+                    Ok(result) => println!("{}", eval::format_value_human(&result)),
+                    Err(e) => report_eval_error(e, trimmed, &module),
+                }
+            }
             Err(diags) => {
                 for d in diags {
                     let msg = diagnostics::render(trimmed, &d);

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -247,7 +247,11 @@ pub fn check_module_types(module: &Module, src: &str, env: &TypeEnv) -> Vec<Pret
                     Some(vt_ann) => {
                         match infer_expr(value, &tenv) {
                             Ok((vt, _)) => {
-                                if vt_ann != vt {
+                                let allow_scalar_fill = matches!(
+                                    (&vt_ann, &vt),
+                                    (ValueType::Tensor(_), ValueType::ScalarI32)
+                                );
+                                if vt_ann != vt && !allow_scalar_fill {
                                     errs.push(diag_from_span(
                                         src,
                                         format!(

--- a/tests/cli_tensor.rs
+++ b/tests/cli_tensor.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+#[test]
+fn cli_prints_tensor_preview() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--no-default-features",
+            "--",
+            "eval",
+            "let x: Tensor[f32,(2,3)] = 0; x + 1",
+        ])
+        .output()
+        .expect("cargo run");
+    assert!(output.status.success(), "process failed: {:?}", output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Tensor["));
+    assert!(stdout.contains("(2,3)"));
+    assert!(stdout.contains("fill=1"));
+}

--- a/tests/tensor_eval.rs
+++ b/tests/tensor_eval.rs
@@ -1,0 +1,25 @@
+use mind::{eval, parser};
+use std::collections::HashMap;
+
+#[test]
+fn annotated_tensor_plus_scalar_yields_tensor_preview() {
+    let src = "let x: Tensor[f32,(2,3)] = 0; x + 1";
+    let module = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let value = eval::eval_module_value_with_env(&module, &mut env, Some(src)).unwrap();
+    let preview = eval::format_value_human(&value);
+    assert!(preview.contains("Tensor["));
+    assert!(preview.contains("(2,3)"));
+    assert!(preview.contains("F32") || preview.contains("f32"));
+    assert!(preview.contains("fill=1"), "got: {preview}");
+}
+
+#[test]
+fn tensor_tensor_broadcast_preview() {
+    let src = "let a: Tensor[f32,(2,1,3)] = 0; let b: Tensor[f32,(1,4,3)] = 0; a + b";
+    let module = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let value = eval::eval_module_value_with_env(&module, &mut env, Some(src)).unwrap();
+    let preview = eval::format_value_human(&value);
+    assert!(preview.contains("(2,4,3)"), "got: {preview}");
+}

--- a/tests/type_ann_check.rs
+++ b/tests/type_ann_check.rs
@@ -15,6 +15,5 @@ fn tensor_ann_blocks_scalar_ops() {
     let m = parser::parse(src).unwrap();
     let mut env = std::collections::HashMap::new();
     let err = eval::eval_module_with_env(&m, &mut env, Some(src)).unwrap_err();
-    let s = format!("{err}");
-    assert!(s.to_lowercase().contains("type"), "got: {s}");
+    assert!(matches!(err, eval::EvalError::Unsupported), "got: {err}");
 }


### PR DESCRIPTION
## Summary
- introduce TensorVal runtime values carrying dtype, shape, and optional fill previews
- extend the evaluator to produce tensor Value results for annotated lets and tensor arithmetic while keeping scalar API compatibility
- update CLI/REPL output formatting and add README notes plus tests covering tensor previews and CLI behavior

## Testing
- `cargo test --no-default-features`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f2768b110832ab1f885d1f48e4169)