### PR TITLE
Add preview tensor stdlib intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ cargo run --quiet -- eval 'let a: Tensor[f32,(2,1,3)] = 0; let b: Tensor[f32,(1,
 # → Tensor[F32,(2,4,3)] fill=0
 ```
 
+### Tensor intrinsics (Phase 4B)
+
+```mind
+let z = tensor.zeros(f32, (2,3));
+let o = tensor.ones(f32, (2,3));
+tensor.print(o);
+# → Tensor[F32,(2,3)] fill=1
+```
+
+Additional helpers:
+
+- `tensor.shape(t)` → returns a preview tuple such as `(2,3)`
+- `tensor.dtype(t)` → returns the dtype string such as `f32`
+
 **Quick install via Docker:**
 ```bash
 docker pull mindlang/mind:latest

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -55,6 +55,8 @@ pub enum Node {
     Lit(Literal, Span),
     Binary { op: BinOp, left: Box<Node>, right: Box<Node>, span: Span },
     Paren(Box<Node>, Span),
+    Tuple { elements: Vec<Node>, span: Span },
+    Call { callee: String, args: Vec<Node>, span: Span },
     Let { name: String, ann: Option<TypeAnn>, value: Box<Node>, span: Span },
     Assign { name: String, value: Box<Node>, span: Span },
 }
@@ -65,6 +67,8 @@ impl Node {
             Node::Lit(_, span)
             | Node::Binary { span, .. }
             | Node::Paren(_, span)
+            | Node::Tuple { span, .. }
+            | Node::Call { span, .. }
             | Node::Let { span, .. }
             | Node::Assign { span, .. } => *span,
         }

--- a/src/eval/stdlib/mod.rs
+++ b/src/eval/stdlib/mod.rs
@@ -1,0 +1,1 @@
+pub mod tensor;

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+
+use crate::ast::{Literal, Node};
+use crate::eval::{eval_value_expr, format_value_human, EvalError, TensorVal, Value};
+use crate::types::{DType, ShapeDim};
+
+pub fn dispatch(
+    callee: &str,
+    args: &[Node],
+    env: &HashMap<String, Value>,
+) -> Result<Value, EvalError> {
+    match callee {
+        "tensor.zeros" => construct(args, env, 0.0),
+        "tensor.ones" => construct(args, env, 1.0),
+        "tensor.shape" => tensor_shape(args, env),
+        "tensor.dtype" => tensor_dtype(args, env),
+        "tensor.print" => tensor_print(args, env),
+        _ => Err(EvalError::Unsupported),
+    }
+}
+
+fn construct(args: &[Node], env: &HashMap<String, Value>, fill: f64) -> Result<Value, EvalError> {
+    if args.len() != 2 {
+        return Err(EvalError::Unsupported);
+    }
+    let dtype = parse_dtype(&args[0])?;
+    let shape = parse_shape(&args[1], env)?;
+    Ok(Value::Tensor(TensorVal::new(dtype, shape, Some(fill))))
+}
+
+fn tensor_shape(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+    if args.len() != 1 {
+        return Err(EvalError::Unsupported);
+    }
+    let value = eval_value_expr(&args[0], env)?;
+    if let Value::Tensor(t) = value {
+        let mut items = Vec::with_capacity(t.shape.len());
+        for dim in &t.shape {
+            match dim {
+                ShapeDim::Known(n) => items.push(Value::Int(*n as i64)),
+                ShapeDim::Sym(sym) => items.push(Value::Str(sym.to_string())),
+            }
+        }
+        Ok(Value::Tuple(items))
+    } else {
+        Err(EvalError::Unsupported)
+    }
+}
+
+fn tensor_dtype(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+    if args.len() != 1 {
+        return Err(EvalError::Unsupported);
+    }
+    let value = eval_value_expr(&args[0], env)?;
+    if let Value::Tensor(t) = value {
+        Ok(Value::Str(t.dtype.as_str().to_string()))
+    } else {
+        Err(EvalError::Unsupported)
+    }
+}
+
+fn tensor_print(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+    if args.len() != 1 {
+        return Err(EvalError::Unsupported);
+    }
+    let value = eval_value_expr(&args[0], env)?;
+    println!("{}", format_value_human(&value));
+    Ok(value)
+}
+
+fn parse_dtype(node: &Node) -> Result<DType, EvalError> {
+    match node {
+        Node::Lit(Literal::Ident(name), _) => DType::from_str(name).ok_or(EvalError::Unsupported),
+        _ => Err(EvalError::Unsupported),
+    }
+}
+
+fn parse_shape(node: &Node, env: &HashMap<String, Value>) -> Result<Vec<ShapeDim>, EvalError> {
+    match node {
+        Node::Tuple { elements, .. } => {
+            let mut dims = Vec::with_capacity(elements.len());
+            for el in elements {
+                dims.push(parse_shape_dim(el, env)?);
+            }
+            Ok(dims)
+        }
+        Node::Paren(inner, _) => parse_shape(inner, env),
+        Node::Lit(Literal::Ident(name), _) => {
+            if let Some(value) = env.get(name) {
+                shape_from_value(value)
+            } else {
+                Ok(vec![ShapeDim::Sym(leak_symbol(name))])
+            }
+        }
+        Node::Lit(Literal::Int(_), _) => Ok(vec![parse_shape_dim(node, env)?]),
+        _ => {
+            let value = eval_value_expr(node, env)?;
+            shape_from_value(&value)
+        }
+    }
+}
+
+fn parse_shape_dim(node: &Node, env: &HashMap<String, Value>) -> Result<ShapeDim, EvalError> {
+    match node {
+        Node::Lit(Literal::Int(n), _) => {
+            if *n < 0 {
+                return Err(EvalError::Unsupported);
+            }
+            Ok(ShapeDim::Known(*n as usize))
+        }
+        Node::Lit(Literal::Ident(name), _) => {
+            if let Some(value) = env.get(name) {
+                shape_dim_from_value(value)
+            } else {
+                Ok(ShapeDim::Sym(leak_symbol(name)))
+            }
+        }
+        _ => {
+            let value = eval_value_expr(node, env)?;
+            shape_dim_from_value(&value)
+        }
+    }
+}
+
+fn shape_from_value(value: &Value) -> Result<Vec<ShapeDim>, EvalError> {
+    match value {
+        Value::Tuple(items) => {
+            let mut dims = Vec::with_capacity(items.len());
+            for item in items {
+                dims.push(shape_dim_from_value(item)?);
+            }
+            Ok(dims)
+        }
+        _ => Ok(vec![shape_dim_from_value(value)?]),
+    }
+}
+
+fn shape_dim_from_value(value: &Value) -> Result<ShapeDim, EvalError> {
+    match value {
+        Value::Int(n) => {
+            if *n < 0 {
+                return Err(EvalError::Unsupported);
+            }
+            Ok(ShapeDim::Known(*n as usize))
+        }
+        Value::Str(sym) => Ok(ShapeDim::Sym(leak_symbol(sym))),
+        Value::Tensor(t) => {
+            if t.shape.len() == 1 {
+                match t.shape[0] {
+                    ShapeDim::Known(n) => Ok(ShapeDim::Known(n)),
+                    ShapeDim::Sym(sym) => Ok(ShapeDim::Sym(sym)),
+                }
+            } else {
+                Err(EvalError::Unsupported)
+            }
+        }
+        Value::Tuple(_) => Err(EvalError::Unsupported),
+    }
+}
+
+fn leak_symbol(name: &str) -> &'static str {
+    Box::leak(name.to_string().into_boxed_str())
+}

--- a/src/eval/value.rs
+++ b/src/eval/value.rs
@@ -21,6 +21,8 @@ impl TensorVal {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Int(i64),
+    Str(String),
+    Tuple(Vec<Value>),
     Tensor(TensorVal),
 }
 
@@ -41,6 +43,18 @@ impl Value {
 pub fn format_value_human(v: &Value) -> String {
     match v {
         Value::Int(n) => format!("{n}"),
+        Value::Str(s) => s.clone(),
+        Value::Tuple(items) => {
+            let mut out = String::from("(");
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&format_value_human(item));
+            }
+            out.push(')');
+            out
+        }
         Value::Tensor(t) => {
             let mut shape = String::from("(");
             for (i, d) in t.shape.iter().enumerate() {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -21,6 +21,27 @@ pub enum DType {
     F16,
 }
 
+impl DType {
+    pub fn from_str(name: &str) -> Option<Self> {
+        match name.to_ascii_lowercase().as_str() {
+            "i32" => Some(DType::I32),
+            "f32" => Some(DType::F32),
+            "bf16" => Some(DType::BF16),
+            "f16" => Some(DType::F16),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DType::I32 => "i32",
+            DType::F32 => "f32",
+            DType::BF16 => "bf16",
+            DType::F16 => "f16",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ShapeDim {
     Known(usize),

--- a/tests/tensor_stdlib.rs
+++ b/tests/tensor_stdlib.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use mind::{eval, parser};
+
+fn eval_source(src: &str) -> eval::Value {
+    let module = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    eval::eval_module_value_with_env(&module, &mut env, Some(src)).unwrap()
+}
+
+#[test]
+fn zeros_and_ones_create_expected_previews() {
+    let src = "tensor.zeros(f32, (2,3))";
+    let value = eval_source(src);
+    let preview = eval::format_value_human(&value);
+    assert!(preview.contains("Tensor"));
+    assert!(preview.contains("(2,3)"));
+    assert!(preview.contains("fill=0"));
+
+    let src2 = "tensor.ones(f32, (4,1))";
+    let value2 = eval_source(src2);
+    let preview2 = eval::format_value_human(&value2);
+    assert!(preview2.contains("fill=1"));
+}
+
+#[test]
+fn shape_and_dtype_return_preview_values() {
+    let src = "let t = tensor.ones(f32, (2,3)); tensor.shape(t)";
+    let module = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let value = eval::eval_module_value_with_env(&module, &mut env, Some(src)).unwrap();
+    let preview = eval::format_value_human(&value);
+    assert!(preview.contains("(2,3)"));
+
+    let src_dtype = "let t = tensor.zeros(bf16, (5,)); tensor.dtype(t)";
+    let module_dtype = parser::parse(src_dtype).unwrap();
+    let mut env_dtype = HashMap::new();
+    let value_dtype =
+        eval::eval_module_value_with_env(&module_dtype, &mut env_dtype, Some(src_dtype)).unwrap();
+    let preview_dtype = eval::format_value_human(&value_dtype);
+    assert_eq!(preview_dtype, "bf16");
+}


### PR DESCRIPTION
## Summary
- add AST and parser support for tuple literals and calls to drive tensor intrinsics
- implement preview-only tensor stdlib functions (zeros/ones/shape/dtype/print) and evaluator plumbing
- extend type checker, dtype helpers, and docs; add regression tests for tensor stdlib previews

## Testing
- cargo test --no-default-features

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f2f3132d8832ab20489b9db10ccad)