### PR TITLE
Phase 4C: CPU buffer tensors (feature-gated), materialization & sampling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ debug = true
 
 [features]
 default = []
+cpu-buffers = []
 mlir = []
 mlir_backend = ["melior"]
 llvm = ["inkwell"]

--- a/README.md
+++ b/README.md
@@ -228,6 +228,19 @@ Additional helpers:
 - `tensor.shape(t)` → returns a preview tuple such as `(2,3)`
 - `tensor.dtype(t)` → returns the dtype string such as `f32`
 
+### Buffers (feature-gated)
+
+Opt in to concrete CPU buffers with `--features cpu-buffers`. Small tensors (≤1,024 elements) automatically materialize, and you
+can request buffers explicitly:
+
+```bash
+cargo run --features cpu-buffers -- eval 'let x: Tensor[f32,(2,3)] = 1; tensor.materialize(x)'
+# → Tensor[F32,(2,3)] materialized (sample=[1,1,1,1,1,1])
+```
+
+Use `tensor.materialize(t)` to force allocation, `tensor.sample(t, k)` to grab up to `k` linear elements, and
+`tensor.is_materialized(t)` to check if a buffer exists. Without the feature flag, tensors remain lightweight previews.
+
 **Quick install via Docker:**
 ```bash
 docker pull mindlang/mind:latest

--- a/tests/cli_buffers.rs
+++ b/tests/cli_buffers.rs
@@ -1,0 +1,19 @@
+#[cfg(feature = "cpu-buffers")]
+#[test]
+fn cli_shows_materialized_note() {
+    let out = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--features",
+            "cpu-buffers",
+            "--",
+            "eval",
+            "let x: Tensor[f32,(2,3)] = 1; tensor.materialize(x)",
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("materialized"));
+}

--- a/tests/tensor_buffers.rs
+++ b/tests/tensor_buffers.rs
@@ -1,0 +1,35 @@
+#[cfg(feature = "cpu-buffers")]
+#[test]
+fn materializes_small_filled_tensor() {
+    let src = "let x: Tensor[f32,(2,3)] = 1; tensor.materialize(x)";
+    let m = mind::parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let v = mind::eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = mind::eval::format_value_human(&v);
+    assert!(s.contains("materialized"));
+    assert!(s.contains("(2,3)"));
+}
+
+#[cfg(feature = "cpu-buffers")]
+#[test]
+fn tensor_sample_uses_materialized_data() {
+    let src = "let x: Tensor[f32,(2,3)] = 1; tensor.sample(tensor.materialize(x), 4)";
+    let m = mind::parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let v = mind::eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = mind::eval::format_value_human(&v);
+    assert!(s.contains("materialized"));
+    assert!(s.contains("(4)"));
+}
+
+#[cfg(not(feature = "cpu-buffers"))]
+#[test]
+fn preview_only_without_buffers() {
+    let src = "let x: Tensor[f32,(2,3)] = 1; x";
+    let m = mind::parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let v = mind::eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = mind::eval::format_value_human(&v);
+    assert!(s.contains("fill=1"));
+    assert!(!s.contains("materialized"));
+}

--- a/tests/tensor_eval.rs
+++ b/tests/tensor_eval.rs
@@ -11,7 +11,11 @@ fn annotated_tensor_plus_scalar_yields_tensor_preview() {
     assert!(preview.contains("Tensor["));
     assert!(preview.contains("(2,3)"));
     assert!(preview.contains("F32") || preview.contains("f32"));
-    assert!(preview.contains("fill=1"), "got: {preview}");
+    if cfg!(feature = "cpu-buffers") {
+        assert!(preview.contains("materialized"), "got: {preview}");
+    } else {
+        assert!(preview.contains("fill=1"), "got: {preview}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
* Adds `cpu-buffers` feature introducing optional concrete buffers in `TensorVal`.
* Automatic materialization for small tensors and explicit `tensor.materialize` intrinsic.
* CLI/REPL prints “materialized” note with small sample.
* `--no-default-features` remains preview-only and green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69100a8d0c20832285c60d48f28e1e46)