### PR TITLE
Phase 4E: Reductions (sum/mean) + shape ops (reshape/expand/squeeze) with autodiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,18 @@ cargo run --quiet -- eval "let x: Tensor[f32,(2,3)] = 0; grad(tensor.sum(x + 1),
 # → grad{ x: Tensor[F32,(2,3)] fill=1 }
 ```
 
+### Reductions & Shape ops (Phase 4E)
+
+```bash
+cargo run --quiet -- eval "let x: Tensor[f32,(2,3)] = 1; tensor.sum(x)"
+# → Tensor[F32,()] fill=6
+
+cargo run --quiet -- eval "let x: Tensor[f32,(2,3)] = 0; grad(tensor.mean(x), wrt=[x])"
+# → grad{ x: Tensor[F32,(2,3)] fill=0.166666 }
+```
+
+Operators: `tensor.sum/mean(x, axes=[...], keepdims=bool)`, `tensor.reshape`, `tensor.expand_dims`, `tensor.squeeze`.
+
 **Span-accurate type errors (Phase 3D):** carets now point to the exact token (identifier or operator) that triggered a type error.
 
 ### Hello, Tensor

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -58,6 +58,11 @@ pub enum Node {
     Tuple { elements: Vec<Node>, span: Span },
     Call { callee: String, args: Vec<Node>, span: Span },
     CallGrad { loss: Box<Node>, wrt: Vec<String>, span: Span },
+    CallTensorSum { x: Box<Node>, axes: Vec<i32>, keepdims: bool, span: Span },
+    CallTensorMean { x: Box<Node>, axes: Vec<i32>, keepdims: bool, span: Span },
+    CallReshape { x: Box<Node>, dims: Vec<String>, span: Span },
+    CallExpandDims { x: Box<Node>, axis: i32, span: Span },
+    CallSqueeze { x: Box<Node>, axes: Vec<i32>, span: Span },
     Let { name: String, ann: Option<TypeAnn>, value: Box<Node>, span: Span },
     Assign { name: String, value: Box<Node>, span: Span },
 }
@@ -71,6 +76,11 @@ impl Node {
             | Node::Tuple { span, .. }
             | Node::Call { span, .. }
             | Node::CallGrad { span, .. }
+            | Node::CallTensorSum { span, .. }
+            | Node::CallTensorMean { span, .. }
+            | Node::CallReshape { span, .. }
+            | Node::CallExpandDims { span, .. }
+            | Node::CallSqueeze { span, .. }
             | Node::Let { span, .. }
             | Node::Assign { span, .. } => *span,
         }

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use crate::ast::{Literal, Node};
+use crate::eval::autodiff::TensorEnvEntry;
 use crate::eval::{eval_value_expr, format_value_human, EvalError, TensorVal, Value};
 #[cfg(feature = "cpu-buffers")]
 use crate::eval::{materialize_filled, num_elems, MATERIALIZE_MAX};
@@ -13,38 +14,48 @@ pub fn dispatch(
     callee: &str,
     args: &[Node],
     env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
 ) -> Result<Value, EvalError> {
     match callee {
-        "tensor.zeros" => construct(args, env, 0.0),
-        "tensor.ones" => construct(args, env, 1.0),
-        "tensor.shape" => tensor_shape(args, env),
-        "tensor.dtype" => tensor_dtype(args, env),
-        "tensor.sum" => tensor_sum(args, env),
-        "tensor.print" => tensor_print(args, env),
+        "tensor.zeros" => construct(args, env, tensor_env, 0.0),
+        "tensor.ones" => construct(args, env, tensor_env, 1.0),
+        "tensor.shape" => tensor_shape(args, env, tensor_env),
+        "tensor.dtype" => tensor_dtype(args, env, tensor_env),
+        "tensor.sum" => tensor_sum(args, env, tensor_env),
+        "tensor.print" => tensor_print(args, env, tensor_env),
         #[cfg(feature = "cpu-buffers")]
-        "tensor.materialize" => tensor_materialize(args, env),
+        "tensor.materialize" => tensor_materialize(args, env, tensor_env),
         #[cfg(feature = "cpu-buffers")]
-        "tensor.sample" => tensor_sample(args, env),
+        "tensor.sample" => tensor_sample(args, env, tensor_env),
         #[cfg(feature = "cpu-buffers")]
-        "tensor.is_materialized" => tensor_is_materialized(args, env),
+        "tensor.is_materialized" => tensor_is_materialized(args, env, tensor_env),
         _ => Err(EvalError::Unsupported),
     }
 }
 
-fn construct(args: &[Node], env: &HashMap<String, Value>, fill: f64) -> Result<Value, EvalError> {
+fn construct(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+    fill: f64,
+) -> Result<Value, EvalError> {
     if args.len() != 2 {
         return Err(EvalError::Unsupported);
     }
     let dtype = parse_dtype(&args[0])?;
-    let shape = parse_shape(&args[1], env)?;
+    let shape = parse_shape(&args[1], env, tensor_env)?;
     Ok(Value::Tensor(TensorVal::new(dtype, shape, Some(fill))))
 }
 
-fn tensor_shape(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+fn tensor_shape(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Value, EvalError> {
     if args.len() != 1 {
         return Err(EvalError::Unsupported);
     }
-    let value = eval_value_expr(&args[0], env)?;
+    let value = eval_value_expr(&args[0], env, tensor_env)?;
     if let Value::Tensor(t) = value {
         let mut items = Vec::with_capacity(t.shape.len());
         for dim in &t.shape {
@@ -59,11 +70,15 @@ fn tensor_shape(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, Ev
     }
 }
 
-fn tensor_dtype(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+fn tensor_dtype(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Value, EvalError> {
     if args.len() != 1 {
         return Err(EvalError::Unsupported);
     }
-    let value = eval_value_expr(&args[0], env)?;
+    let value = eval_value_expr(&args[0], env, tensor_env)?;
     if let Value::Tensor(t) = value {
         Ok(Value::Str(t.dtype.as_str().to_string()))
     } else {
@@ -71,22 +86,23 @@ fn tensor_dtype(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, Ev
     }
 }
 
-fn tensor_sum(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+fn tensor_sum(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Value, EvalError> {
     if args.len() != 1 {
         return Err(EvalError::Unsupported);
     }
-    let value = eval_value_expr(&args[0], env)?;
+    let value = eval_value_expr(&args[0], env, tensor_env)?;
     if let Value::Tensor(t) = value {
-        let mut result = TensorVal::new(t.dtype.clone(), Vec::new(), None);
-        if let Some(fill) = t.fill {
-            if let Some(count) = known_num_elems(&t.shape) {
-                result.fill = Some(fill * count as f64);
-            }
-        }
+        let result = sum_tensor_preview(&t, &[], false)?;
         #[cfg(feature = "cpu-buffers")]
         {
-            if result.fill.is_some() {
-                crate::eval::materialize_filled(&mut result);
+            let mut result_clone = result.clone();
+            if result_clone.fill.is_some() {
+                crate::eval::materialize_filled(&mut result_clone);
+                return Ok(Value::Tensor(result_clone));
             }
         }
         Ok(Value::Tensor(result))
@@ -95,21 +111,29 @@ fn tensor_sum(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, Eval
     }
 }
 
-fn tensor_print(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+fn tensor_print(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Value, EvalError> {
     if args.len() != 1 {
         return Err(EvalError::Unsupported);
     }
-    let value = eval_value_expr(&args[0], env)?;
+    let value = eval_value_expr(&args[0], env, tensor_env)?;
     println!("{}", format_value_human(&value));
     Ok(value)
 }
 
 #[cfg(feature = "cpu-buffers")]
-fn tensor_materialize(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+fn tensor_materialize(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Value, EvalError> {
     if args.len() != 1 {
         return Err(EvalError::Unsupported);
     }
-    let value = eval_value_expr(&args[0], env)?;
+    let value = eval_value_expr(&args[0], env, tensor_env)?;
     if let Value::Tensor(mut t) = value {
         materialize_filled(&mut t);
         Ok(Value::Tensor(t))
@@ -119,11 +143,15 @@ fn tensor_materialize(args: &[Node], env: &HashMap<String, Value>) -> Result<Val
 }
 
 #[cfg(feature = "cpu-buffers")]
-fn tensor_is_materialized(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+fn tensor_is_materialized(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Value, EvalError> {
     if args.len() != 1 {
         return Err(EvalError::Unsupported);
     }
-    let value = eval_value_expr(&args[0], env)?;
+    let value = eval_value_expr(&args[0], env, tensor_env)?;
     if let Value::Tensor(t) = value {
         Ok(Value::Int(if t.buf.is_some() { 1 } else { 0 }))
     } else {
@@ -132,12 +160,16 @@ fn tensor_is_materialized(args: &[Node], env: &HashMap<String, Value>) -> Result
 }
 
 #[cfg(feature = "cpu-buffers")]
-fn tensor_sample(args: &[Node], env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+fn tensor_sample(
+    args: &[Node],
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Value, EvalError> {
     if args.len() != 2 {
         return Err(EvalError::Unsupported);
     }
-    let value = eval_value_expr(&args[0], env)?;
-    let count = eval_value_expr(&args[1], env)?;
+    let value = eval_value_expr(&args[0], env, tensor_env)?;
+    let count = eval_value_expr(&args[1], env, tensor_env)?;
     let requested = match count {
         Value::Int(n) => {
             if n < 0 {
@@ -197,16 +229,20 @@ fn parse_dtype(node: &Node) -> Result<DType, EvalError> {
     }
 }
 
-fn parse_shape(node: &Node, env: &HashMap<String, Value>) -> Result<Vec<ShapeDim>, EvalError> {
+fn parse_shape(
+    node: &Node,
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<Vec<ShapeDim>, EvalError> {
     match node {
         Node::Tuple { elements, .. } => {
             let mut dims = Vec::with_capacity(elements.len());
             for el in elements {
-                dims.push(parse_shape_dim(el, env)?);
+                dims.push(parse_shape_dim(el, env, tensor_env)?);
             }
             Ok(dims)
         }
-        Node::Paren(inner, _) => parse_shape(inner, env),
+        Node::Paren(inner, _) => parse_shape(inner, env, tensor_env),
         Node::Lit(Literal::Ident(name), _) => {
             if let Some(value) = env.get(name) {
                 shape_from_value(value)
@@ -214,15 +250,19 @@ fn parse_shape(node: &Node, env: &HashMap<String, Value>) -> Result<Vec<ShapeDim
                 Ok(vec![ShapeDim::Sym(leak_symbol(name))])
             }
         }
-        Node::Lit(Literal::Int(_), _) => Ok(vec![parse_shape_dim(node, env)?]),
+        Node::Lit(Literal::Int(_), _) => Ok(vec![parse_shape_dim(node, env, tensor_env)?]),
         _ => {
-            let value = eval_value_expr(node, env)?;
+            let value = eval_value_expr(node, env, tensor_env)?;
             shape_from_value(&value)
         }
     }
 }
 
-fn parse_shape_dim(node: &Node, env: &HashMap<String, Value>) -> Result<ShapeDim, EvalError> {
+fn parse_shape_dim(
+    node: &Node,
+    env: &HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+) -> Result<ShapeDim, EvalError> {
     match node {
         Node::Lit(Literal::Int(n), _) => {
             if *n < 0 {
@@ -238,7 +278,7 @@ fn parse_shape_dim(node: &Node, env: &HashMap<String, Value>) -> Result<ShapeDim
             }
         }
         _ => {
-            let value = eval_value_expr(node, env)?;
+            let value = eval_value_expr(node, env, tensor_env)?;
             shape_dim_from_value(&value)
         }
     }
@@ -296,4 +336,197 @@ fn shape_dim_from_value(value: &Value) -> Result<ShapeDim, EvalError> {
 
 fn leak_symbol(name: &str) -> &'static str {
     Box::leak(name.to_string().into_boxed_str())
+}
+
+fn normalize_axis(axis: i32, rank: usize) -> Result<usize, EvalError> {
+    let rank_i32 = rank as i32;
+    let idx = if axis < 0 { rank_i32 + axis } else { axis };
+    if idx < 0 || idx >= rank_i32 {
+        Err(EvalError::Unsupported)
+    } else {
+        Ok(idx as usize)
+    }
+}
+
+fn normalize_axes_list(axes: &[i32], rank: usize) -> Result<Vec<usize>, EvalError> {
+    let mut seen: BTreeSet<usize> = BTreeSet::new();
+    let mut normalized = Vec::new();
+    for &axis in axes {
+        let idx = normalize_axis(axis, rank)?;
+        if !seen.insert(idx) {
+            return Err(EvalError::Unsupported);
+        }
+        normalized.push(idx);
+    }
+    normalized.sort_unstable();
+    Ok(normalized)
+}
+
+fn normalize_reduce_axes(axes: &[i32], rank: usize) -> Result<Vec<usize>, EvalError> {
+    if axes.is_empty() {
+        return Ok((0..rank).collect());
+    }
+    normalize_axes_list(axes, rank)
+}
+
+fn reduce_shape(shape: &[ShapeDim], axes: &[usize], keepdims: bool) -> Vec<ShapeDim> {
+    if keepdims {
+        let mut out = shape.to_vec();
+        for &axis in axes {
+            if axis < out.len() {
+                out[axis] = ShapeDim::Known(1);
+            }
+        }
+        out
+    } else {
+        let axis_set: BTreeSet<usize> = axes.iter().cloned().collect();
+        let mut out = Vec::new();
+        for (idx, dim) in shape.iter().enumerate() {
+            if !axis_set.contains(&idx) {
+                out.push(dim.clone());
+            }
+        }
+        out
+    }
+}
+
+fn product_of_axes(shape: &[ShapeDim], axes: &[usize]) -> Option<usize> {
+    if axes.is_empty() {
+        return Some(1);
+    }
+    let mut total = 1usize;
+    for &axis in axes {
+        match shape.get(axis)? {
+            ShapeDim::Known(n) => {
+                total = total.checked_mul(*n)?;
+            }
+            ShapeDim::Sym(_) => return None,
+        }
+    }
+    Some(total)
+}
+
+fn known_product(shape: &[ShapeDim]) -> Option<usize> {
+    let mut total = 1usize;
+    for dim in shape {
+        match dim {
+            ShapeDim::Known(n) => {
+                total = total.checked_mul(*n)?;
+            }
+            ShapeDim::Sym(_) => return None,
+        }
+    }
+    Some(total)
+}
+
+fn normalize_expand_axis(axis: i32, rank: usize) -> Result<usize, EvalError> {
+    let extended = rank + 1;
+    let idx = if axis < 0 { (extended as i32) + axis } else { axis };
+    if idx < 0 || idx > extended as i32 - 1 {
+        Err(EvalError::Unsupported)
+    } else {
+        Ok(idx as usize)
+    }
+}
+
+fn compute_squeeze_axes(shape: &[ShapeDim], axes: &[i32]) -> Result<Vec<usize>, EvalError> {
+    if axes.is_empty() {
+        let mut remove = Vec::new();
+        for (idx, dim) in shape.iter().enumerate() {
+            if matches!(dim, ShapeDim::Known(1)) {
+                remove.push(idx);
+            }
+        }
+        return Ok(remove);
+    }
+    let normalized = normalize_axes_list(axes, shape.len())?;
+    for &axis in &normalized {
+        match shape.get(axis) {
+            Some(ShapeDim::Known(1)) => {}
+            _ => return Err(EvalError::Unsupported),
+        }
+    }
+    Ok(normalized)
+}
+
+fn dims_from_strings(dims: &[String]) -> Vec<ShapeDim> {
+    dims.iter()
+        .map(|d| {
+            if let Ok(n) = d.parse::<usize>() {
+                ShapeDim::Known(n)
+            } else {
+                ShapeDim::Sym(leak_symbol(d))
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn sum_tensor_preview(
+    tensor: &TensorVal,
+    axes: &[i32],
+    keepdims: bool,
+) -> Result<TensorVal, EvalError> {
+    let axes_norm = normalize_reduce_axes(axes, tensor.shape.len())?;
+    let shape = reduce_shape(&tensor.shape, &axes_norm, keepdims);
+    let mut result = TensorVal::new(tensor.dtype.clone(), shape, None);
+    if let Some(fill) = tensor.fill {
+        if let Some(count) = product_of_axes(&tensor.shape, &axes_norm) {
+            result.fill = Some(fill * count as f64);
+        }
+    }
+    Ok(result)
+}
+
+pub(crate) fn mean_tensor_preview(
+    tensor: &TensorVal,
+    axes: &[i32],
+    keepdims: bool,
+) -> Result<TensorVal, EvalError> {
+    let axes_norm = normalize_reduce_axes(axes, tensor.shape.len())?;
+    let shape = reduce_shape(&tensor.shape, &axes_norm, keepdims);
+    let mut result = TensorVal::new(tensor.dtype.clone(), shape, tensor.fill);
+    result.fill = tensor.fill;
+    Ok(result)
+}
+
+pub(crate) fn reshape_tensor_preview(
+    tensor: &TensorVal,
+    dims: &[String],
+) -> Result<TensorVal, EvalError> {
+    let new_shape = dims_from_strings(dims);
+    if new_shape.len() != tensor.shape.len() {
+        return Err(EvalError::Unsupported);
+    }
+    if let (Some(old), Some(new)) = (known_product(&tensor.shape), known_product(&new_shape)) {
+        if old != new {
+            return Err(EvalError::Unsupported);
+        }
+    }
+    Ok(TensorVal::new(tensor.dtype.clone(), new_shape, tensor.fill))
+}
+
+pub(crate) fn expand_dims_tensor_preview(
+    tensor: &TensorVal,
+    axis: i32,
+) -> Result<TensorVal, EvalError> {
+    let rank = tensor.shape.len();
+    let axis = normalize_expand_axis(axis, rank)?;
+    let mut shape = tensor.shape.clone();
+    shape.insert(axis, ShapeDim::Known(1));
+    Ok(TensorVal::new(tensor.dtype.clone(), shape, tensor.fill))
+}
+
+pub(crate) fn squeeze_tensor_preview(
+    tensor: &TensorVal,
+    axes: &[i32],
+) -> Result<TensorVal, EvalError> {
+    let axes_to_remove = compute_squeeze_axes(&tensor.shape, axes)?;
+    let axis_set: BTreeSet<usize> = axes_to_remove.iter().cloned().collect();
+    let mut shape = Vec::new();
+    for (idx, dim) in tensor.shape.iter().enumerate() {
+        if !axis_set.contains(&idx) {
+            shape.push(dim.clone());
+        }
+    }
+    Ok(TensorVal::new(tensor.dtype.clone(), shape, tensor.fill))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! MIND core library (Phase 1 scaffold)
 pub mod ast;
-pub mod parser;
-pub mod eval;
 pub mod diagnostics;
-pub mod opt;
-pub mod stdlib;
-pub mod types;
-pub mod type_checker;
+pub mod eval;
 pub mod lexer;
+pub mod opt;
+pub mod parser;
+pub mod stdlib;
+pub mod type_checker;
+pub mod types;
 
 #[cfg(feature = "mlir")]
 pub mod ir;

--- a/tests/reductions_grad.rs
+++ b/tests/reductions_grad.rs
@@ -1,0 +1,29 @@
+use mind::{eval, parser};
+use std::collections::HashMap;
+
+#[test]
+fn grad_sum_is_ones() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 0;
+        grad(tensor.sum(x), wrt=[x])
+    "#;
+    let m = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let v = eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = eval::format_value_human(&v);
+    assert!(s.contains("x: Tensor[F32,(2,3)]"));
+    assert!(s.contains("fill=1"));
+}
+
+#[test]
+fn grad_mean_is_1_over_n() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 0;
+        grad(tensor.mean(x), wrt=[x])
+    "#;
+    let m = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let v = eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = eval::format_value_human(&v);
+    assert!(s.contains("fill=0.166666") || s.contains("fill=0.166667"));
+}

--- a/tests/reductions_preview.rs
+++ b/tests/reductions_preview.rs
@@ -1,0 +1,30 @@
+use mind::{eval, parser};
+use std::collections::HashMap;
+
+#[test]
+fn sum_all_axes_preview() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 1;
+        tensor.sum(x)
+    "#;
+    let m = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let v = eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = eval::format_value_human(&v);
+    assert!(s.contains("Tensor[F32,()]"));
+    assert!(s.contains("fill=6"));
+}
+
+#[test]
+fn mean_keepdims_preview() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 2;
+        tensor.mean(x, axes=[1], keepdims=true)
+    "#;
+    let m = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let v = eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = eval::format_value_human(&v);
+    assert!(s.contains("Tensor[F32,(2,1)]"));
+    assert!(s.contains("fill=2"));
+}

--- a/tests/shape_ops_preview.rs
+++ b/tests/shape_ops_preview.rs
@@ -1,0 +1,17 @@
+use mind::{eval, parser};
+use std::collections::HashMap;
+
+#[test]
+fn reshape_and_back_grad_shape_only() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 5;
+        let y = tensor.reshape(x, (3,2));
+        grad(tensor.sum(y), wrt=[x])
+    "#;
+    let m = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let v = eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = eval::format_value_human(&v);
+    assert!(s.contains("x: Tensor[F32,(2,3)]"));
+    assert!(s.contains("fill=1"));
+}


### PR DESCRIPTION
## Summary
- add parser, type-checker, and evaluator support for `tensor.sum/mean`, `tensor.reshape`, `tensor.expand_dims`, and `tensor.squeeze`
- extend autodiff to expand let-bound tensor aliases so gradients flow through reductions and shape-only ops
- cover the new operators with preview/autodiff tests and document them in the README

## Testing
- `cargo test --no-default-features`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105b2966408322b75832d6657d744a)