### PR TITLE
Phase 4G: Indexing & Slicing (preview + autodiff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,22 @@ cargo run --quiet -- eval "let A: Tensor[f32,(2,3)] = 0; let B: Tensor[f32,(3,4)
 # → grad{ A: Tensor[F32,(2,3)] fill=1, B: Tensor[F32,(3,4)] fill=1 }
 ```
 
+### Indexing & Slicing (Phase 4G)
+
+```bash
+cargo run --quiet -- eval "let x: Tensor[f32,(2,5)] = 1; tensor.index(x, axis=1, i=0)"
+# → Tensor[F32,(2)] fill=1
+
+cargo run --quiet -- eval "let x: Tensor[f32,(3,6)] = 2; tensor.slice(x, axis=1, start=1, end=4)"
+# → Tensor[F32,(3,3)] fill=2
+```
+
+Gradients (preview):
+```bash
+cargo run --quiet -- eval "let X: Tensor[f32,(3,6)] = 0; grad(tensor.sum(tensor.slice(X, axis=1, start=1, end=4)), wrt=[X])"
+# → grad{ X: Tensor[F32,(3,6)] … }
+```
+
 **Span-accurate type errors (Phase 3D):** carets now point to the exact token (identifier or operator) that triggered a type error.
 
 ### Hello, Tensor

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -64,6 +64,8 @@ pub enum Node {
     CallExpandDims { x: Box<Node>, axis: i32, span: Span },
     CallSqueeze { x: Box<Node>, axes: Vec<i32>, span: Span },
     CallTranspose { x: Box<Node>, axes: Option<Vec<i32>>, span: Span },
+    CallIndex { x: Box<Node>, axis: i32, i: i32, span: Span },
+    CallSlice { x: Box<Node>, axis: i32, start: i32, end: i32, span: Span },
     CallDot { a: Box<Node>, b: Box<Node>, span: Span },
     CallMatMul { a: Box<Node>, b: Box<Node>, span: Span },
     Let { name: String, ann: Option<TypeAnn>, value: Box<Node>, span: Span },
@@ -85,6 +87,8 @@ impl Node {
             | Node::CallExpandDims { span, .. }
             | Node::CallSqueeze { span, .. }
             | Node::CallTranspose { span, .. }
+            | Node::CallIndex { span, .. }
+            | Node::CallSlice { span, .. }
             | Node::CallDot { span, .. }
             | Node::CallMatMul { span, .. }
             | Node::Let { span, .. }

--- a/tests/index_slice_grad.rs
+++ b/tests/index_slice_grad.rs
@@ -1,0 +1,13 @@
+#[test]
+fn grad_through_slice_shapes_ok() {
+    let src = r#"
+        let X: Tensor[f32,(3,6)] = 0;
+        let y = tensor.sum(tensor.slice(X, axis=1, start=1, end=4));
+        grad(y, wrt=[X])
+    "#;
+    let m = mind::parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let v = mind::eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = mind::eval::format_value_human(&v);
+    assert!(s.contains("X: Tensor[F32,(3,6)]"));
+}

--- a/tests/index_slice_preview.rs
+++ b/tests/index_slice_preview.rs
@@ -1,0 +1,24 @@
+use mind::{eval, parser};
+use std::collections::HashMap;
+
+#[test]
+fn index_drops_axis() {
+    let src = r#" let x: Tensor[f32,(2,5)] = 1; tensor.index(x, axis=1, i=0) "#;
+    let m = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let v = eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = eval::format_value_human(&v);
+    assert!(s.contains("(2)"));
+    assert!(s.contains("fill=1"));
+}
+
+#[test]
+fn slice_changes_len() {
+    let src = r#" let x: Tensor[f32,(3,6)] = 2; tensor.slice(x, axis=1, start=1, end=4) "#;
+    let m = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let v = eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = eval::format_value_human(&v);
+    assert!(s.contains("(3,3)"));
+    assert!(s.contains("fill=2"));
+}

--- a/tests/index_slice_types.rs
+++ b/tests/index_slice_types.rs
@@ -1,0 +1,8 @@
+#[test]
+fn index_axis_bounds_checked() {
+    let src = r#" let x: Tensor[f32,(2,5)] = 0; tensor.index(x, axis=2, i=0) "#;
+    let m = mind::parser::parse(src).unwrap();
+    let tenv = std::collections::HashMap::new();
+    let diags = mind::type_checker::check_module_types(&m, src, &tenv);
+    assert!(!diags.is_empty());
+}


### PR DESCRIPTION
Adds `tensor.index` and `tensor.slice` with axis validation, correct preview shapes/fills, and tape-based gradients (scatter-style in reverse). Keeps `--no-default-features` green; buffer math remains optional.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691068d44c9c83229a0961b19f30826d)