### PR TITLE
Phase 4H: Strided slicing & gather (preview + reverse-mode grads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,29 @@ cargo run --quiet -- eval "let X: Tensor[f32,(3,6)] = 0; grad(tensor.sum(tensor.
 # → grad{ X: Tensor[F32,(3,6)] … }
 ```
 
+### Strided slicing & gather (Phase 4H)
+
+```bash
+cargo run --quiet -- eval "let x: Tensor[f32,(5,10)] = 3; tensor.slice_stride(x, axis=1, start=0, end=10, step=2)"
+# → Tensor[F32,(5,5)] fill=3
+
+cargo run --quiet -- eval "
+  let X: Tensor[f32,(3,4)] = 1;
+  let idx: Tensor[i32,(2)] = 0;
+  tensor.gather(X, axis=1, idx)
+"
+# → Tensor[F32,(3,2)] fill=1
+```
+
+Gradients (preview):
+```bash
+cargo run --quiet -- eval "
+  let X: Tensor[f32,(5,10)] = 0;
+  grad(tensor.sum(tensor.slice_stride(X, axis=1, start=0, end=10, step=2)), wrt=[X])
+"
+# → grad{ X: Tensor[F32,(5,10)] … }
+```
+
 **Span-accurate type errors (Phase 3D):** carets now point to the exact token (identifier or operator) that triggered a type error.
 
 ### Hello, Tensor

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -66,6 +66,8 @@ pub enum Node {
     CallTranspose { x: Box<Node>, axes: Option<Vec<i32>>, span: Span },
     CallIndex { x: Box<Node>, axis: i32, i: i32, span: Span },
     CallSlice { x: Box<Node>, axis: i32, start: i32, end: i32, span: Span },
+    CallSliceStride { x: Box<Node>, axis: i32, start: i32, end: i32, step: i32, span: Span },
+    CallGather { x: Box<Node>, axis: i32, idx: Box<Node>, span: Span },
     CallDot { a: Box<Node>, b: Box<Node>, span: Span },
     CallMatMul { a: Box<Node>, b: Box<Node>, span: Span },
     Let { name: String, ann: Option<TypeAnn>, value: Box<Node>, span: Span },
@@ -89,6 +91,8 @@ impl Node {
             | Node::CallTranspose { span, .. }
             | Node::CallIndex { span, .. }
             | Node::CallSlice { span, .. }
+            | Node::CallSliceStride { span, .. }
+            | Node::CallGather { span, .. }
             | Node::CallDot { span, .. }
             | Node::CallMatMul { span, .. }
             | Node::Let { span, .. }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -283,6 +283,29 @@ pub(crate) fn eval_value_expr(
                 _ => Err(EvalError::Unsupported),
             }
         }
+        Node::CallSliceStride { x, axis, start, end, step, .. } => {
+            let value = eval_value_expr(x, env, tensor_env)?;
+            match value {
+                Value::Tensor(t) => {
+                    let result = stdlib::tensor::slice_stride_tensor_preview(
+                        &t, *axis, *start, *end, *step,
+                    )?;
+                    Ok(Value::Tensor(result))
+                }
+                _ => Err(EvalError::Unsupported),
+            }
+        }
+        Node::CallGather { x, axis, idx, .. } => {
+            let base = eval_value_expr(x, env, tensor_env)?;
+            let indices = eval_value_expr(idx, env, tensor_env)?;
+            match (base, indices) {
+                (Value::Tensor(t), Value::Tensor(i)) => {
+                    let result = stdlib::tensor::gather_tensor_preview(&t, *axis, &i)?;
+                    Ok(Value::Tensor(result))
+                }
+                _ => Err(EvalError::Unsupported),
+            }
+        }
         Node::CallDot { a, b, .. } => {
             let left = eval_value_expr(a, env, tensor_env)?;
             let right = eval_value_expr(b, env, tensor_env)?;

--- a/tests/gather_preview.rs
+++ b/tests/gather_preview.rs
@@ -1,0 +1,14 @@
+#[test]
+fn gather_inserts_idx_shape() {
+    let src = r#"
+        let x: Tensor[f32,(3,4)] = 5;
+        let idx: Tensor[i32,(2)] = 0;
+        tensor.gather(x, axis=1, idx)
+    "#;
+    let m = mind::parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let v = mind::eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = mind::eval::format_value_human(&v);
+    assert!(s.contains("(3,2)"));
+    assert!(s.contains("fill=5"));
+}

--- a/tests/stride_gather_grad.rs
+++ b/tests/stride_gather_grad.rs
@@ -1,0 +1,14 @@
+#[test]
+fn grad_through_stride_and_gather_shapes() {
+    let src = r#"
+        let X: Tensor[f32,(5,10)] = 0;
+        let I: Tensor[i32,(4)] = 0;
+        let y = tensor.sum(tensor.gather(tensor.slice_stride(X, axis=1, start=0, end=10, step=2), axis=1, idx=I));
+        grad(y, wrt=[X])
+    "#;
+    let m = mind::parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let v = mind::eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = mind::eval::format_value_human(&v);
+    assert!(s.contains("X: Tensor[F32,(5,10)]"));
+}

--- a/tests/stride_preview.rs
+++ b/tests/stride_preview.rs
@@ -1,0 +1,10 @@
+#[test]
+fn stride_pos_step_len() {
+    let src = r#" let x: Tensor[f32,(2,10)] = 7; tensor.slice_stride(x, axis=1, start=0, end=10, step=2) "#;
+    let m = mind::parser::parse(src).unwrap();
+    let mut env = std::collections::HashMap::new();
+    let v = mind::eval::eval_module_value_with_env(&m, &mut env, Some(src)).unwrap();
+    let s = mind::eval::format_value_human(&v);
+    assert!(s.contains("(2,5)"));
+    assert!(s.contains("fill=7"));
+}

--- a/tests/stride_types.rs
+++ b/tests/stride_types.rs
@@ -1,0 +1,7 @@
+#[test]
+fn zero_step_is_error() {
+    let src = r#" let x: Tensor[f32,(2,10)] = 0; tensor.slice_stride(x, axis=1, start=0, end=10, step=0) "#;
+    let m = mind::parser::parse(src).unwrap();
+    let diags = mind::type_checker::check_module_types(&m, src, &std::collections::HashMap::new());
+    assert!(!diags.is_empty());
+}


### PR DESCRIPTION
Adds `tensor.slice_stride` (positive/negative step) and `tensor.gather` with shape-correct previews, safe `fill` propagation, and reverse-mode gradients via scatter semantics. Keeps `--no-default-features` green; optional real scatter under `cpu-buffers`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106c500ab483228bf809887cc49835)