### PR TITLE
Add MLIR file export options and lowering presets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0"
 [dev-dependencies]
 criterion = "0.5"
 proptest = "1.4"
+tempfile = "3"
 
 [[bin]]
 name = "mind"

--- a/README.md
+++ b/README.md
@@ -436,6 +436,28 @@ module {
 }
 ```
 
+### Phase 5C — MLIR file export and lowering presets
+
+You can now dump MLIR to stdout or write a `.mlir` file:
+
+```bash
+# stdout
+cargo run --quiet --no-default-features -- eval "1+2" --emit-mlir --mlir-lower none
+
+# file
+cargo run --quiet --no-default-features -- eval \
+  "let x: Tensor[f32,(2,3)] = 0; x + 1" \
+  --emit-mlir-file /tmp/out.mlir --mlir-lower arith-linalg
+```
+
+`--mlir-lower` supports:
+
+* `none` — raw exporter output
+* `arith-linalg` — normalizes common patterns (textual)
+* `cpu-demo` — lightweight cosmetic rewrites for demos
+
+> These are **textual** passes (no MLIR libs). Later phases can swap them for real `mlir-opt` pipelines behind a feature.
+
 **Span-accurate type errors (Phase 3D):** carets now point to the exact token (identifier or operator) that triggered a type error.
 
 ### Hello, Tensor

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -15,8 +15,23 @@ pub mod value;
 
 pub use ir_interp::eval_ir;
 pub use lower::lower_to_ir;
-pub use mlir_export::to_mlir;
+pub use mlir_export::{to_mlir, MlirLowerPreset};
 pub use value::{format_value_human, TensorVal, Value, VarId};
+
+pub fn emit_mlir_string(ir: &crate::ir::IRModule, preset: mlir_export::MlirLowerPreset) -> String {
+    let txt = mlir_export::to_mlir_text(ir);
+    mlir_export::apply_textual_lowering(txt, preset)
+}
+
+pub fn emit_mlir_to_file(
+    ir: &crate::ir::IRModule,
+    preset: mlir_export::MlirLowerPreset,
+    path: &std::path::Path,
+) -> std::io::Result<()> {
+    let txt = emit_mlir_string(ir, preset);
+    std::fs::create_dir_all(path.parent().unwrap_or_else(|| std::path::Path::new(".")))?;
+    std::fs::write(path, txt)
+}
 
 #[cfg(feature = "cpu-buffers")]
 pub(crate) fn num_elems(shape: &[ShapeDim]) -> Option<usize> {

--- a/tests/mlir_file_and_lower.rs
+++ b/tests/mlir_file_and_lower.rs
@@ -1,0 +1,52 @@
+use std::{fs, process::Command};
+
+use tempfile::tempdir;
+
+#[test]
+fn stdout_emit_default_lowering() {
+    let out = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--no-default-features",
+            "--",
+            "eval",
+            "1+2",
+            "--emit-mlir",
+            "--mlir-lower",
+            "none",
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "stdout run failed: {:?}", out);
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(s.contains("module"));
+    assert!(s.contains("arith.constant"));
+}
+
+#[test]
+fn file_emit_with_preset() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("out.mlir");
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--no-default-features",
+            "--",
+            "eval",
+            "let x: Tensor[f32,(2,3)] = 0; x+1",
+            "--emit-mlir-file",
+            path.to_str().unwrap(),
+            "--mlir-lower",
+            "arith-linalg",
+        ])
+        .status()
+        .expect("run");
+    assert!(status.success());
+
+    let txt = fs::read_to_string(&path).expect("read");
+    assert!(txt.contains("tensor.empty") || txt.contains("linalg.fill"));
+    assert!(txt.contains("arith.constant"));
+}


### PR DESCRIPTION
## Summary
- add textual lowering presets and helpers to the MLIR exporter, including a file output API
- extend the CLI with --emit-mlir-file and --mlir-lower flags to control MLIR emission
- document the new capabilities and cover them with CLI integration tests

## Testing
- `cargo test --no-default-features`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69115160236483228351be4207503499)