### PR TITLE
Phase 5D: mlir-opt subprocess (feature-gated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 criterion = "0.5"
 proptest = "1.4"
 tempfile = "3"
+which = "6"
 
 [[bin]]
 name = "mind"
@@ -46,3 +47,4 @@ mlir = []
 mlir_backend = ["melior"]
 llvm = ["inkwell"]
 autodiff = []
+mlir-subprocess = []

--- a/README.md
+++ b/README.md
@@ -458,6 +458,27 @@ cargo run --quiet --no-default-features -- eval \
 
 > These are **textual** passes (no MLIR libs). Later phases can swap them for real `mlir-opt` pipelines behind a feature.
 
+### Phase 5D — Optional `mlir-opt` round-trip
+
+An opt-in Cargo feature runs the exported MLIR through the real `mlir-opt` tool:
+
+```bash
+cargo run --features mlir-subprocess -- eval \
+  --emit-mlir \
+  --mlir-opt \
+  --mlir-opt-passes canonicalize,cse \
+  'let x = 2; x + 3'
+```
+
+Flags and environment variables:
+
+* `--mlir-opt-bin /path/to/mlir-opt` (defaults to `$MLIR_OPT` or `mlir-opt`)
+* `--mlir-opt-passes canonicalize,cse` (comma-separated)
+* `--mlir-opt-timeout-ms 8000`
+
+The feature is disabled by default so `cargo run --no-default-features` stays dependency-free. When the binary is missing or
+times out, the compiler prints a warning and falls back to the original MLIR text.
+
 **Span-accurate type errors (Phase 3D):** carets now point to the exact token (identifier or operator) that triggered a type error.
 
 ### Hello, Tensor

--- a/src/eval/mlir_opt.rs
+++ b/src/eval/mlir_opt.rs
@@ -1,0 +1,98 @@
+use std::fmt;
+
+/// Result of running mlir-opt.
+#[derive(Debug)]
+pub struct MlirOptOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub status_ok: bool,
+}
+
+impl MlirOptOutput {
+    pub fn from_error<E: fmt::Display>(err: E) -> Self {
+        Self { stdout: String::new(), stderr: err.to_string(), status_ok: false }
+    }
+}
+
+#[cfg(feature = "mlir-subprocess")]
+use std::time::{Duration, Instant};
+#[cfg(feature = "mlir-subprocess")]
+use std::{
+    io::Write,
+    process::{Child, Command, Stdio},
+    thread,
+};
+
+#[cfg(feature = "mlir-subprocess")]
+pub fn run_mlir_opt(
+    mlir_input: &str,
+    bin: &str,
+    passes: &[String],
+    timeout_ms: u64,
+) -> std::io::Result<MlirOptOutput> {
+    let pipeline = passes.join(",");
+
+    let mut cmd = Command::new(bin);
+    if !pipeline.is_empty() {
+        cmd.arg(format!("--pass-pipeline={pipeline}"));
+    }
+
+    let mut child =
+        cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(mlir_input.as_bytes())?;
+    }
+
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            let (stdout, stderr) = collect_child_output(&mut child);
+            return Ok(MlirOptOutput { stdout, stderr, status_ok: status.success() });
+        }
+
+        if start.elapsed() > Duration::from_millis(timeout_ms) {
+            let _ = child.kill();
+            let _ = child.wait();
+            let (stdout, stderr) = collect_child_output(&mut child);
+            return Ok(MlirOptOutput {
+                stdout,
+                stderr: if stderr.is_empty() {
+                    "mlir-opt timed out".into()
+                } else {
+                    format!("mlir-opt timed out: {stderr}")
+                },
+                status_ok: false,
+            });
+        }
+
+        thread::sleep(Duration::from_millis(15));
+    }
+}
+
+#[cfg(feature = "mlir-subprocess")]
+fn collect_child_output(child: &mut Child) -> (String, String) {
+    use std::io::Read;
+
+    let mut stdout = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        let _ = out.read_to_string(&mut stdout);
+    }
+
+    let mut stderr = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        let _ = err.read_to_string(&mut stderr);
+    }
+
+    (stdout, stderr)
+}
+
+#[cfg(not(feature = "mlir-subprocess"))]
+pub fn run_mlir_opt(
+    _mlir_input: &str,
+    _bin: &str,
+    _passes: &[String],
+    _timeout_ms: u64,
+) -> std::io::Result<MlirOptOutput> {
+    Ok(MlirOptOutput::from_error("mlir-subprocess feature is disabled"))
+}

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -11,6 +11,7 @@ pub mod autodiff;
 pub mod ir_interp;
 pub mod lower;
 pub mod mlir_export;
+pub mod mlir_opt;
 pub mod value;
 
 pub use ir_interp::eval_ir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,32 @@ use mind::{diagnostics, eval, parser};
 use std::collections::HashMap;
 use std::io::{self, Write};
 
-#[derive(Default)]
 struct EmitOpts {
     emit_mlir_stdout: bool,
     emit_mlir_file: Option<String>,
     mlir_lower: eval::MlirLowerPreset,
+    run_mlir_opt: bool,
+    mlir_opt_bin: Option<String>,
+    mlir_opt_passes: Vec<String>,
+    mlir_opt_timeout_ms: u64,
+}
+
+impl Default for EmitOpts {
+    fn default() -> Self {
+        Self {
+            emit_mlir_stdout: false,
+            emit_mlir_file: None,
+            mlir_lower: eval::MlirLowerPreset::None,
+            run_mlir_opt: false,
+            mlir_opt_bin: None,
+            mlir_opt_passes: default_mlir_opt_passes(),
+            mlir_opt_timeout_ms: 5_000,
+        }
+    }
+}
+
+fn default_mlir_opt_passes() -> Vec<String> {
+    vec!["canonicalize".to_string(), "cse".to_string()]
 }
 
 fn parse_emit_flags(args: &[String]) -> EmitOpts {
@@ -34,9 +55,41 @@ fn parse_emit_flags(args: &[String]) -> EmitOpts {
                     i += 1;
                 }
             }
+            "--mlir-opt" => {
+                out.run_mlir_opt = true;
+            }
+            "--mlir-opt-bin" => {
+                if i + 1 < args.len() {
+                    out.mlir_opt_bin = Some(args[i + 1].clone());
+                    i += 1;
+                }
+            }
+            "--mlir-opt-passes" => {
+                if i + 1 < args.len() {
+                    out.mlir_opt_passes = args[i + 1]
+                        .split(',')
+                        .filter_map(|p| {
+                            let trimmed = p.trim();
+                            (!trimmed.is_empty()).then(|| trimmed.to_string())
+                        })
+                        .collect();
+                    i += 1;
+                }
+            }
+            "--mlir-opt-timeout-ms" => {
+                if i + 1 < args.len() {
+                    if let Ok(value) = args[i + 1].parse::<u64>() {
+                        out.mlir_opt_timeout_ms = value;
+                    }
+                    i += 1;
+                }
+            }
             _ => {}
         }
         i += 1;
+    }
+    if out.mlir_opt_passes.is_empty() {
+        out.mlir_opt_passes = default_mlir_opt_passes();
     }
     out
 }
@@ -74,16 +127,44 @@ fn run_eval_once(src: &str, emit_opts: EmitOpts) {
                 Ok(_) => {
                     let ir = eval::lower_to_ir(&module);
                     if emit_opts.emit_mlir_stdout || emit_opts.emit_mlir_file.is_some() {
-                        let txt = eval::emit_mlir_string(&ir, emit_opts.mlir_lower);
+                        let mut mlir_text = eval::emit_mlir_string(&ir, emit_opts.mlir_lower);
+                        if emit_opts.run_mlir_opt {
+                            let bin = emit_opts
+                                .mlir_opt_bin
+                                .clone()
+                                .or_else(|| std::env::var("MLIR_OPT").ok())
+                                .unwrap_or_else(|| "mlir-opt".to_string());
+                            let passes = emit_opts.mlir_opt_passes.clone();
+                            let timeout = emit_opts.mlir_opt_timeout_ms;
+                            match eval::mlir_opt::run_mlir_opt(&mlir_text, &bin, &passes, timeout) {
+                                Ok(output)
+                                    if output.status_ok && !output.stdout.trim().is_empty() =>
+                                {
+                                    mlir_text = output.stdout;
+                                }
+                                Ok(output) => {
+                                    let msg = output.stderr.trim();
+                                    if msg.is_empty() {
+                                        eprintln!("[warn] mlir-opt failed without diagnostics");
+                                    } else {
+                                        eprintln!("[warn] mlir-opt failed: {msg}");
+                                    }
+                                }
+                                Err(err) => {
+                                    eprintln!("[warn] failed to spawn mlir-opt: {err}");
+                                }
+                            }
+                        }
                         if emit_opts.emit_mlir_stdout {
-                            println!("{txt}");
+                            println!("{mlir_text}");
                         }
                         if let Some(path) = emit_opts.emit_mlir_file.as_ref() {
-                            if let Err(e) = eval::emit_mlir_to_file(
-                                &ir,
-                                emit_opts.mlir_lower,
-                                std::path::Path::new(path),
-                            ) {
+                            let path_ref = std::path::Path::new(path);
+                            let parent =
+                                path_ref.parent().unwrap_or_else(|| std::path::Path::new("."));
+                            if let Err(e) = std::fs::create_dir_all(parent) {
+                                eprintln!("Failed to create directories for {}: {e}", path);
+                            } else if let Err(e) = std::fs::write(path_ref, &mlir_text) {
                                 eprintln!("Failed to write MLIR to {}: {e}", path);
                             }
                         }

--- a/tests/mlir_opt.rs
+++ b/tests/mlir_opt.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "mlir-subprocess")]
+
+use mind::{eval, parser};
+
+#[test]
+fn mlir_opt_runs_when_available() {
+    let bin = std::env::var("MLIR_OPT").unwrap_or_else(|_| "mlir-opt".into());
+    if which::which(&bin).is_err() {
+        eprintln!("mlir-opt not found, skipping test");
+        return;
+    }
+
+    let src = "let x = 1; x + 2";
+    let module = match parser::parse_with_diagnostics(src) {
+        Ok(module) => module,
+        Err(diags) => panic!("failed to parse input: {:?}", diags),
+    };
+    let ir = eval::lower_to_ir(&module);
+    let mlir = eval::emit_mlir_string(&ir, eval::MlirLowerPreset::None);
+
+    let result = eval::mlir_opt::run_mlir_opt(&mlir, &bin, &["canonicalize".into()], 2_000)
+        .expect("spawn mlir-opt");
+
+    if !result.status_ok {
+        panic!("mlir-opt invocation failed: {}", result.stderr);
+    }
+
+    assert!(
+        result.stdout.contains("module"),
+        "mlir-opt output missing module\nstdout: {}\nstderr: {}",
+        result.stdout,
+        result.stderr
+    );
+}


### PR DESCRIPTION
## Summary
- add the `mlir-subprocess` feature flag and subprocess helper to invoke `mlir-opt`
- expose CLI switches to opt into the pipeline, configure passes/bin/timeout, and surface warnings on failure
- document the workflow and add a feature-gated test that exercises the integration when `mlir-opt` is available

## Testing
- `cargo fmt`
- `cargo test --no-default-features` *(fails: unable to reach crates.io index due to 403 CONNECT tunnel error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691158c6a55c832283a0807232f16336)