### PR TITLE
Phase 5D: MLIR export for reductions, shape ops, linalg, and indexing/slicing

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -4,15 +4,36 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ValueId(pub usize);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SliceSpec {
+    pub axis: i64,
+    pub start: i64,
+    pub end: Option<i64>,
+    pub stride: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSpec {
+    pub axis: i64,
+    pub index: i64,
+}
+
 #[derive(Debug, Clone)]
 pub enum Instr {
     ConstI64(ValueId, i64),
     ConstTensor(ValueId, DType, Vec<ShapeDim>, Option<f64>),
     BinOp { dst: ValueId, op: BinOp, lhs: ValueId, rhs: ValueId },
-    Sum { dst: ValueId, src: ValueId },
+    Sum { dst: ValueId, src: ValueId, axes: Vec<i64>, keepdims: bool },
+    Mean { dst: ValueId, src: ValueId, axes: Vec<i64>, keepdims: bool },
     Reshape { dst: ValueId, src: ValueId, new_shape: Vec<ShapeDim> },
+    ExpandDims { dst: ValueId, src: ValueId, axis: i64 },
+    Squeeze { dst: ValueId, src: ValueId, axes: Vec<i64> },
+    Transpose { dst: ValueId, src: ValueId, perm: Vec<i64> },
+    Dot { dst: ValueId, a: ValueId, b: ValueId },
     MatMul { dst: ValueId, a: ValueId, b: ValueId },
-    Slice { dst: ValueId, src: ValueId, axis: usize, start: usize, end: usize, stride: usize },
+    Index { dst: ValueId, src: ValueId, indices: Vec<IndexSpec> },
+    Slice { dst: ValueId, src: ValueId, dims: Vec<SliceSpec> },
+    Gather { dst: ValueId, src: ValueId, indices: ValueId, axis: i64 },
     Output(ValueId),
 }
 

--- a/tests/mlir_export_indexing.rs
+++ b/tests/mlir_export_indexing.rs
@@ -1,0 +1,21 @@
+use mind::{eval, parser};
+
+#[test]
+fn mlir_export_handles_index_slice_and_gather() {
+    let src = r#"
+        let x: Tensor[f32,(4,4)] = 0;
+        let idxs: Tensor[i32,(2)] = 0;
+        let slice = tensor.slice(x, axis=0, start=1, end=3);
+        let strided = tensor.slice_stride(x, axis=1, start=0, end=4, step=2);
+        let picked = tensor.index(strided, axis=0, i=1);
+        tensor.gather(slice, axis=0, idx=idxs)
+    "#;
+    let module = parser::parse(src).expect("parse indexing module");
+    let ir = eval::lower_to_ir(&module);
+    let mlir = eval::to_mlir(&ir, "main");
+
+    assert!(mlir.contains("tensor.extract"), "expected tensor.extract in {mlir}");
+    assert!(mlir.contains("tensor.extract_slice"), "expected tensor.extract_slice in {mlir}");
+    assert!(mlir.contains("tensor.insert"), "expected tensor.insert in {mlir}");
+    assert!(mlir.contains("scf.for"), "expected scf.for in {mlir}");
+}

--- a/tests/mlir_export_linalg.rs
+++ b/tests/mlir_export_linalg.rs
@@ -1,0 +1,20 @@
+use mind::{eval, parser};
+
+#[test]
+fn mlir_export_emits_linalg_dot_and_matmul() {
+    let src = r#"
+        let a: Tensor[f32,(2)] = 1;
+        let b: Tensor[f32,(2)] = 1;
+        let dot_val = tensor.dot(a, b);
+        let m: Tensor[f32,(2,3)] = 1;
+        let n: Tensor[f32,(3,4)] = 1;
+        let mat = tensor.matmul(m, n);
+        mat
+    "#;
+    let module = parser::parse(src).expect("parse linalg module");
+    let ir = eval::lower_to_ir(&module);
+    let mlir = eval::to_mlir(&ir, "main");
+
+    assert!(mlir.contains("linalg.dot"), "expected linalg.dot in {mlir}");
+    assert!(mlir.contains("linalg.matmul"), "expected linalg.matmul in {mlir}");
+}

--- a/tests/mlir_export_reductions.rs
+++ b/tests/mlir_export_reductions.rs
@@ -1,0 +1,17 @@
+use mind::{eval, parser};
+
+#[test]
+fn mlir_export_reductions_cover_sum_and_mean() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 1;
+        let s = tensor.sum(x, axes=[1], keepdims=false);
+        tensor.mean(s, axes=[0], keepdims=false)
+    "#;
+    let module = parser::parse(src).expect("parse reductions module");
+    let ir = eval::lower_to_ir(&module);
+    let mlir = eval::to_mlir(&ir, "main");
+
+    assert!(mlir.contains("tensor.reduce"), "expected tensor.reduce in {mlir}");
+    assert!(mlir.contains("arith.addf"), "expected arith.addf in {mlir}");
+    assert!(mlir.contains("arith.divf"), "expected arith.divf in {mlir}");
+}

--- a/tests/mlir_export_shape.rs
+++ b/tests/mlir_export_shape.rs
@@ -1,0 +1,18 @@
+use mind::{eval, parser};
+
+#[test]
+fn mlir_export_covers_shape_ops() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 0;
+        let reshaped = tensor.reshape(x, (3,2));
+        let expanded = tensor.expand_dims(reshaped, axis=1);
+        let squeezed = tensor.squeeze(expanded, axes=[1]);
+        tensor.transpose(squeezed, axes=[1,0])
+    "#;
+    let module = parser::parse(src).expect("parse shape module");
+    let ir = eval::lower_to_ir(&module);
+    let mlir = eval::to_mlir(&ir, "main");
+
+    assert!(mlir.contains("tensor.reshape"), "expected tensor.reshape in {mlir}");
+    assert!(mlir.contains("linalg.transpose"), "expected linalg.transpose in {mlir}");
+}


### PR DESCRIPTION
Extends the MLIR exporter to cover `sum/mean`, `reshape/expand_dims/squeeze/transpose`, `dot/matmul`, `index/slice/slice_stride/gather`. Keeps to core dialects (`tensor`, `arith`, `linalg`, `shape`, `scf`). CLI flags unchanged. Adds targeted tests asserting presence of key ops. `--no-default-features` stays green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69115eb406e88322acfadf07b51e965d)