### PR TITLE
Phase 6B: CPU vectorized kernels + Conv2D (+ ReLU)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ debug = true
 default = []
 cpu-buffers = []
 cpu-exec = ["cpu-buffers"]
+cpu-conv = ["cpu-exec"]
 mlir = []
 mlir_backend = ["melior"]
 llvm = ["inkwell"]

--- a/README.md
+++ b/README.md
@@ -527,6 +527,27 @@ Notes:
 * Symbolic dimensions fall back to preview semantics.
 * Without `--exec` or without the `cpu-exec` feature, CLI evaluation stays in preview mode.
 
+### Phase 6B — CPU ReLU and Conv2D
+
+- `tensor.relu(x)` keeps shape/dtype; in exec mode it clamps negative values.
+- `tensor.conv2d(x, w, stride_h=?, stride_w=?, padding="valid"|"same")`
+  - Layouts: `x` in NHWC, `w` in HWIO, result NHWC.
+  - Execute with `--features "cpu-exec cpu-conv"` and `--exec`.
+
+Examples:
+
+```bash
+# Preview only:
+cargo run --quiet -- eval 'let x: Tensor[f32,(2,3)] = 0; tensor.relu(x - 1)'
+
+# Execute ReLU on CPU:
+cargo run --quiet --features cpu-exec -- eval --exec 'let x: Tensor[f32,(1,4)] = 0; x = x - 3; tensor.relu(x + 1)'
+
+# Execute Conv2D on CPU:
+cargo run --quiet --features "cpu-exec cpu-conv" -- eval --exec \
+  'let x: Tensor[f32,(1,3,3,1)] = 1; let w: Tensor[f32,(2,2,1,1)] = 1; tensor.conv2d(x,w,stride_h=1,stride_w=1,padding="valid")'
+```
+
 **Span-accurate type errors (Phase 3D):** carets now point to the exact token (identifier or operator) that triggered a type error.
 
 ### Hello, Tensor

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,3 +1,5 @@
+use crate::types::ConvPadding;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Span {
     start: usize,
@@ -53,25 +55,119 @@ pub enum TypeAnn {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Node {
     Lit(Literal, Span),
-    Binary { op: BinOp, left: Box<Node>, right: Box<Node>, span: Span },
+    Binary {
+        op: BinOp,
+        left: Box<Node>,
+        right: Box<Node>,
+        span: Span,
+    },
     Paren(Box<Node>, Span),
-    Tuple { elements: Vec<Node>, span: Span },
-    Call { callee: String, args: Vec<Node>, span: Span },
-    CallGrad { loss: Box<Node>, wrt: Vec<String>, span: Span },
-    CallTensorSum { x: Box<Node>, axes: Vec<i32>, keepdims: bool, span: Span },
-    CallTensorMean { x: Box<Node>, axes: Vec<i32>, keepdims: bool, span: Span },
-    CallReshape { x: Box<Node>, dims: Vec<String>, span: Span },
-    CallExpandDims { x: Box<Node>, axis: i32, span: Span },
-    CallSqueeze { x: Box<Node>, axes: Vec<i32>, span: Span },
-    CallTranspose { x: Box<Node>, axes: Option<Vec<i32>>, span: Span },
-    CallIndex { x: Box<Node>, axis: i32, i: i32, span: Span },
-    CallSlice { x: Box<Node>, axis: i32, start: i32, end: i32, span: Span },
-    CallSliceStride { x: Box<Node>, axis: i32, start: i32, end: i32, step: i32, span: Span },
-    CallGather { x: Box<Node>, axis: i32, idx: Box<Node>, span: Span },
-    CallDot { a: Box<Node>, b: Box<Node>, span: Span },
-    CallMatMul { a: Box<Node>, b: Box<Node>, span: Span },
-    Let { name: String, ann: Option<TypeAnn>, value: Box<Node>, span: Span },
-    Assign { name: String, value: Box<Node>, span: Span },
+    Tuple {
+        elements: Vec<Node>,
+        span: Span,
+    },
+    Call {
+        callee: String,
+        args: Vec<Node>,
+        span: Span,
+    },
+    CallGrad {
+        loss: Box<Node>,
+        wrt: Vec<String>,
+        span: Span,
+    },
+    CallTensorSum {
+        x: Box<Node>,
+        axes: Vec<i32>,
+        keepdims: bool,
+        span: Span,
+    },
+    CallTensorMean {
+        x: Box<Node>,
+        axes: Vec<i32>,
+        keepdims: bool,
+        span: Span,
+    },
+    CallReshape {
+        x: Box<Node>,
+        dims: Vec<String>,
+        span: Span,
+    },
+    CallExpandDims {
+        x: Box<Node>,
+        axis: i32,
+        span: Span,
+    },
+    CallSqueeze {
+        x: Box<Node>,
+        axes: Vec<i32>,
+        span: Span,
+    },
+    CallTranspose {
+        x: Box<Node>,
+        axes: Option<Vec<i32>>,
+        span: Span,
+    },
+    CallIndex {
+        x: Box<Node>,
+        axis: i32,
+        i: i32,
+        span: Span,
+    },
+    CallSlice {
+        x: Box<Node>,
+        axis: i32,
+        start: i32,
+        end: i32,
+        span: Span,
+    },
+    CallSliceStride {
+        x: Box<Node>,
+        axis: i32,
+        start: i32,
+        end: i32,
+        step: i32,
+        span: Span,
+    },
+    CallGather {
+        x: Box<Node>,
+        axis: i32,
+        idx: Box<Node>,
+        span: Span,
+    },
+    CallDot {
+        a: Box<Node>,
+        b: Box<Node>,
+        span: Span,
+    },
+    CallMatMul {
+        a: Box<Node>,
+        b: Box<Node>,
+        span: Span,
+    },
+    CallTensorRelu {
+        x: Box<Node>,
+        span: Span,
+    },
+    CallTensorConv2d {
+        x: Box<Node>,
+        w: Box<Node>,
+        stride_h: usize,
+        stride_w: usize,
+        padding: ConvPadding,
+        span: Span,
+    },
+    Let {
+        name: String,
+        ann: Option<TypeAnn>,
+        value: Box<Node>,
+        span: Span,
+    },
+    Assign {
+        name: String,
+        value: Box<Node>,
+        span: Span,
+    },
 }
 
 impl Node {
@@ -95,6 +191,8 @@ impl Node {
             | Node::CallGather { span, .. }
             | Node::CallDot { span, .. }
             | Node::CallMatMul { span, .. }
+            | Node::CallTensorRelu { span, .. }
+            | Node::CallTensorConv2d { span, .. }
             | Node::Let { span, .. }
             | Node::Assign { span, .. } => *span,
         }

--- a/src/exec/conv.rs
+++ b/src/exec/conv.rs
@@ -1,0 +1,134 @@
+use crate::eval::value::TensorVal;
+use crate::types::{ConvPadding, ShapeDim};
+
+use super::cpu::ExecError;
+
+fn shape_as_usize(shape: &[ShapeDim]) -> Result<Vec<usize>, ExecError> {
+    let mut out = Vec::with_capacity(shape.len());
+    for dim in shape {
+        match dim {
+            ShapeDim::Known(v) => out.push(*v),
+            ShapeDim::Sym(_) => return Err(ExecError::Shape("symbolic dims".into())),
+        }
+    }
+    Ok(out)
+}
+
+pub fn exec_conv2d(
+    input: &TensorVal,
+    weights: &TensorVal,
+    stride_h: usize,
+    stride_w: usize,
+    padding: ConvPadding,
+) -> Result<TensorVal, ExecError> {
+    if stride_h == 0 || stride_w == 0 {
+        return Err(ExecError::Shape("strides must be positive".into()));
+    }
+    if input.dtype != crate::types::DType::F32 || weights.dtype != crate::types::DType::F32 {
+        return Err(ExecError::Type("only f32 tensors supported in cpu-exec".into()));
+    }
+
+    let in_shape = shape_as_usize(&input.shape)?;
+    let wt_shape = shape_as_usize(&weights.shape)?;
+    if in_shape.len() != 4 || wt_shape.len() != 4 {
+        return Err(ExecError::Shape("`tensor.conv2d` expects NHWC x HWIO tensors".into()));
+    }
+
+    let n = in_shape[0];
+    let in_h = in_shape[1];
+    let in_w = in_shape[2];
+    let in_c = in_shape[3];
+
+    let kernel_h = wt_shape[0];
+    let kernel_w = wt_shape[1];
+    let kernel_c = wt_shape[2];
+    let out_c = wt_shape[3];
+
+    if kernel_h == 0 || kernel_w == 0 {
+        return Err(ExecError::Shape("kernel dimensions must be positive".into()));
+    }
+
+    if in_c != kernel_c {
+        return Err(ExecError::Shape("input/output channel mismatch".into()));
+    }
+
+    let (pad_top, pad_left, out_h, out_w) = match padding {
+        ConvPadding::Valid => {
+            if in_h < kernel_h || in_w < kernel_w {
+                return Err(ExecError::Shape("kernel larger than input".into()));
+            }
+            let out_h = (in_h - kernel_h) / stride_h + 1;
+            let out_w = (in_w - kernel_w) / stride_w + 1;
+            (0, 0, out_h, out_w)
+        }
+        ConvPadding::Same => {
+            let out_h = (in_h + stride_h - 1) / stride_h;
+            let out_w = (in_w + stride_w - 1) / stride_w;
+            let pad_h = out_h
+                .saturating_sub(1)
+                .saturating_mul(stride_h)
+                .saturating_add(kernel_h)
+                .saturating_sub(in_h);
+            let pad_w = out_w
+                .saturating_sub(1)
+                .saturating_mul(stride_w)
+                .saturating_add(kernel_w)
+                .saturating_sub(in_w);
+            let pad_top = pad_h / 2;
+            let pad_left = pad_w / 2;
+            (pad_top, pad_left, out_h, out_w)
+        }
+    };
+
+    let input_buf = input
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("input tensor not materialized".into()))?;
+    let weight_buf = weights
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("weight tensor not materialized".into()))?;
+
+    let mut output = vec![0.0f32; n * out_h * out_w * out_c];
+
+    let pad_top_i = pad_top as isize;
+    let pad_left_i = pad_left as isize;
+
+    for batch in 0..n {
+        for oh in 0..out_h {
+            for ow in 0..out_w {
+                let out_index = ((batch * out_h + oh) * out_w + ow) * out_c;
+                let out_slice = &mut output[out_index..out_index + out_c];
+                for val in out_slice.iter_mut() {
+                    *val = 0.0;
+                }
+
+                for kh in 0..kernel_h {
+                    let ih = oh * stride_h + kh;
+                    let ih_padded = ih as isize - pad_top_i;
+                    if ih_padded < 0 || ih_padded >= in_h as isize {
+                        continue;
+                    }
+                    for kw in 0..kernel_w {
+                        let iw = ow * stride_w + kw;
+                        let iw_padded = iw as isize - pad_left_i;
+                        if iw_padded < 0 || iw_padded >= in_w as isize {
+                            continue;
+                        }
+                        let input_offset = (((batch * in_h + ih_padded as usize) * in_w
+                            + iw_padded as usize)
+                            * in_c) as usize;
+                        let weight_offset_base = ((kh * kernel_w + kw) * in_c) * out_c;
+                        for ic in 0..in_c {
+                            let input_val = input_buf[input_offset + ic];
+                            let weight_offset = weight_offset_base + ic * out_c;
+                            for oc in 0..out_c {
+                                out_slice[oc] += input_val * weight_buf[weight_offset + oc];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(TensorVal::from_materialized_f32(vec![n, out_h, out_w, out_c], output))
+}

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -1,6 +1,15 @@
 #[cfg(feature = "cpu-exec")]
 pub mod cpu;
 
+#[cfg(feature = "cpu-conv")]
+pub mod conv;
+
+#[cfg(feature = "cpu-exec")]
+pub fn simd_chunks_mut(data: &mut [f32]) -> impl Iterator<Item = &mut [f32]> + '_ {
+    const CHUNK: usize = 1024;
+    data.chunks_mut(CHUNK)
+}
+
 #[cfg(not(feature = "cpu-exec"))]
 mod cpu_disabled {
     #[allow(dead_code)]

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -130,6 +130,47 @@ pub fn known_dim_value(dim: &ShapeDim) -> Option<usize> {
     }
 }
 
+pub fn conv_output_dim_valid(
+    input: Option<usize>,
+    kernel: Option<usize>,
+    stride: usize,
+) -> Result<Option<usize>, String> {
+    if stride == 0 {
+        return Err("stride must be positive".to_string());
+    }
+    if let Some(k) = kernel {
+        if k == 0 {
+            return Err("kernel size must be positive".to_string());
+        }
+    }
+    match (input, kernel) {
+        (Some(h), Some(k)) => {
+            if h < k {
+                return Err(format!("kernel size {k} exceeds input size {h}"));
+            }
+            let out = (h - k) / stride + 1;
+            Ok(Some(out))
+        }
+        _ => Ok(None),
+    }
+}
+
+pub fn conv_output_dim_same(input: Option<usize>, stride: usize) -> Result<Option<usize>, String> {
+    if stride == 0 {
+        return Err("stride must be positive".to_string());
+    }
+    match input {
+        Some(h) => {
+            if h == 0 {
+                return Err("input spatial dimension must be positive".to_string());
+            }
+            let out = (h + stride - 1) / stride;
+            Ok(Some(out))
+        }
+        None => Ok(None),
+    }
+}
+
 pub fn compute_matmul_shape_info(
     a_shape: &[ShapeDim],
     b_shape: &[ShapeDim],

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -48,6 +48,29 @@ pub enum ShapeDim {
     Sym(&'static str),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConvPadding {
+    Valid,
+    Same,
+}
+
+impl ConvPadding {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "valid" => Some(ConvPadding::Valid),
+            "same" => Some(ConvPadding::Same),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConvPadding::Valid => "valid",
+            ConvPadding::Same => "same",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TensorType {
     pub dtype: DType,

--- a/tests/conv2d_exec.rs
+++ b/tests/conv2d_exec.rs
@@ -1,0 +1,19 @@
+#[cfg(all(feature = "cpu-exec", feature = "cpu-conv"))]
+#[test]
+fn conv2d_valid_runs() {
+    use std::process::Command;
+
+    let src = r#"
+        let x: Tensor[f32,(1,3,3,1)] = 1;
+        let w: Tensor[f32,(2,2,1,1)] = 1;
+        tensor.conv2d(x, w, stride_h=1, stride_w=1, padding="valid")
+    "#;
+
+    let output = Command::new("cargo")
+        .args(["run", "--quiet", "--features", "cpu-exec cpu-conv", "--", "eval", "--exec", src])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("(1,2,2,1)"));
+}

--- a/tests/conv2d_types.rs
+++ b/tests/conv2d_types.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+#[test]
+fn conv2d_channel_mismatch_errors() {
+    let src = r#"
+        let x: Tensor[f32,(1,2,2,2)] = 0;
+        let w: Tensor[f32,(1,1,3,1)] = 0;
+        tensor.conv2d(x, w)
+    "#;
+    let module = mind::parser::parse(src).unwrap();
+    let diags = mind::type_checker::check_module_types(&module, src, &HashMap::new());
+    assert!(!diags.is_empty());
+}
+
+#[test]
+fn conv2d_same_padding_symbolic_shapes() {
+    let src = r#"
+        let x: Tensor[f32,(N,H,W,C)] = 0;
+        let w: Tensor[f32,(3,3,C,F)] = 0;
+        tensor.conv2d(x, w, stride_h=2, stride_w=2, padding="same")
+    "#;
+    let module = mind::parser::parse(src).unwrap();
+    let diags = mind::type_checker::check_module_types(&module, src, &HashMap::new());
+    assert!(diags.is_empty());
+}

--- a/tests/relu_exec.rs
+++ b/tests/relu_exec.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "cpu-exec")]
+#[test]
+fn relu_exec_non_negative() {
+    use std::process::Command;
+
+    let program = "let x: Tensor[f32,(1,4)] = 0; x = x - 3; tensor.relu(x + 1)";
+    let output = Command::new("cargo")
+        .args(["run", "--quiet", "--features", "cpu-exec", "--", "eval", "--exec", program])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Tensor[F32,(1,4)]"));
+}

--- a/tests/relu_preview.rs
+++ b/tests/relu_preview.rs
@@ -1,0 +1,12 @@
+use mind::{eval, parser};
+use std::collections::HashMap;
+
+#[test]
+fn relu_preview_keeps_shape() {
+    let src = "let x: Tensor[f32,(2,3)] = 0; tensor.relu(x - 1)";
+    let module = parser::parse(src).unwrap();
+    let mut env = HashMap::new();
+    let value = eval::eval_module_value_with_env(&module, &mut env, Some(src)).unwrap();
+    let rendered = eval::format_value_human(&value);
+    assert!(rendered.contains("Tensor[F32,(2,3)]"));
+}


### PR DESCRIPTION
## Summary
- add tensor.relu and tensor.conv2d surface syntax, typing, and autodiff support including new ConvPadding
- implement preview and CPU execution paths for ReLU and Conv2D, including a feature-gated NHWC×HWIO kernel and chunked elementwise loops
- document the new intrinsics and add regression tests for preview, execution, and conv2d diagnostics

## Testing
- cargo test --no-default-features
- cargo test --features cpu-exec
- cargo test --features "cpu-exec cpu-conv"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116d9bda1083228da98becb10496f8)