### PR TITLE
Add optional MLIR external execution backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ anyhow = "1.0"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+which = { version = "6", optional = true }
+tempfile = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -49,4 +51,5 @@ mlir = []
 mlir_backend = ["melior"]
 llvm = ["inkwell"]
 autodiff = []
-mlir-subprocess = []
+mlir-subprocess = ["which"]
+mlir-exec = ["mlir-subprocess", "tempfile"]

--- a/README.md
+++ b/README.md
@@ -510,6 +510,25 @@ Flags and environment variables:
 The feature is disabled by default so `cargo run --no-default-features` stays dependency-free. When the binary is missing or
 times out, the compiler prints a warning and falls back to the original MLIR text.
 
+### MLIR External Execution (Phase 7A)
+
+Round-trip through the MLIR toolchain and execute programs with `mlir-cpu-runner`:
+
+```bash
+cargo run --features mlir-exec -- eval --mlir-exec "1 + 2"
+# -> 3
+```
+
+You can configure the toolchain via CLI flags or environment variables:
+
+- `--mlir-opt PATH` / env `MLIR_OPT`
+- `--mlir-cpu-runner PATH` / env `MLIR_CPU_RUNNER`
+- `--mlir-passes "--canonicalize --cse"`
+- `--mlir-timeout-ms 15000`
+
+If the optional MLIR tools are missing the evaluator reports a friendly error. Building without
+`--features mlir-exec` keeps the default (`--no-default-features`) target green.
+
 ### Phase 6A — CPU Execution (optional)
 
 Enable a tiny CPU backend to execute materialized `f32` tensors directly in the interpreter:

--- a/src/eval/mlir_run.rs
+++ b/src/eval/mlir_run.rs
@@ -1,0 +1,163 @@
+#[cfg(feature = "mlir-exec")]
+use std::path::PathBuf;
+
+#[cfg(feature = "mlir-exec")]
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "mlir-exec")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MlirExecConfig {
+    pub mlir_opt: Option<PathBuf>,
+    pub mlir_cpu_runner: Option<PathBuf>,
+    pub opt_passes: Vec<String>,
+    pub timeout: Duration,
+}
+
+#[cfg(feature = "mlir-exec")]
+impl Default for MlirExecConfig {
+    fn default() -> Self {
+        Self {
+            mlir_opt: None,
+            mlir_cpu_runner: None,
+            opt_passes: vec![String::from("--canonicalize"), String::from("--cse")],
+            timeout: Duration::from_secs(15),
+        }
+    }
+}
+
+#[cfg(feature = "mlir-exec")]
+pub fn exec_mlir_text(mlir: &str, cfg: &MlirExecConfig) -> Result<String, String> {
+    use std::env;
+    use std::io::Write;
+    use std::process::{Child, Command, Stdio};
+
+    use tempfile::NamedTempFile;
+
+    fn resolve(
+        env_var: &str,
+        configured: &Option<PathBuf>,
+        fallback: &str,
+    ) -> Result<PathBuf, String> {
+        if let Some(path) = configured {
+            return Ok(path.clone());
+        }
+        if let Ok(value) = env::var(env_var) {
+            if !value.trim().is_empty() {
+                return Ok(PathBuf::from(value));
+            }
+        }
+        which::which(fallback)
+            .map_err(|_| format!("Cannot find {fallback} (set {env_var} or adjust PATH)"))
+    }
+
+    fn wait_with_timeout(
+        child: &mut Child,
+        limit: Duration,
+    ) -> Result<std::process::ExitStatus, String> {
+        let start = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => return Ok(status),
+                Ok(None) => {
+                    if start.elapsed() >= limit {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(format!(
+                            "mlir-cpu-runner timed out after {}s",
+                            limit.as_secs()
+                        ));
+                    }
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Err(err) => return Err(err.to_string()),
+            }
+        }
+    }
+
+    let mlir_opt = resolve("MLIR_OPT", &cfg.mlir_opt, "mlir-opt")?;
+    let mlir_cpu_runner = resolve("MLIR_CPU_RUNNER", &cfg.mlir_cpu_runner, "mlir-cpu-runner")?;
+
+    let mut temp = NamedTempFile::new().map_err(|e| e.to_string())?;
+    temp.write_all(mlir.as_bytes()).map_err(|e| e.to_string())?;
+    let input_path = temp.path().to_path_buf();
+
+    let mut opt_cmd = Command::new(&mlir_opt);
+    opt_cmd.arg(input_path);
+    for pass in &cfg.opt_passes {
+        if !pass.trim().is_empty() {
+            opt_cmd.arg(pass);
+        }
+    }
+    opt_cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let opt_output = opt_cmd.output().map_err(|e| format!("mlir-opt failed to spawn: {e}"))?;
+    if !opt_output.status.success() {
+        return Err(format!(
+            "mlir-opt failed: {}\n{}",
+            opt_output.status,
+            String::from_utf8_lossy(&opt_output.stderr)
+        ));
+    }
+
+    let optimized_mlir = String::from_utf8(opt_output.stdout.clone())
+        .unwrap_or_else(|_| String::from_utf8_lossy(&opt_output.stdout).to_string());
+
+    let mut runner_cmd = Command::new(&mlir_cpu_runner);
+    runner_cmd
+        .arg("-O0")
+        .arg("--entry-point-result=void")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child =
+        runner_cmd.spawn().map_err(|e| format!("mlir-cpu-runner failed to spawn: {e}"))?;
+    {
+        let stdin = child.stdin.as_mut().ok_or("Failed to open stdin for mlir-cpu-runner")?;
+        stdin.write_all(optimized_mlir.as_bytes()).map_err(|e| e.to_string())?;
+    }
+
+    let mut child_stdout = child.stdout.take().ok_or("Failed to capture mlir-cpu-runner stdout")?;
+    let mut child_stderr = child.stderr.take().ok_or("Failed to capture mlir-cpu-runner stderr")?;
+
+    use std::io::Read;
+
+    // Spawn threads to read stdout/stderr to avoid blocking.
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stdout.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stderr.read_to_end(&mut buf);
+        buf
+    });
+
+    let status = wait_with_timeout(&mut child, cfg.timeout)?;
+
+    let stdout_data = stdout_handle.join().unwrap_or_default();
+    let stderr_data = stderr_handle.join().unwrap_or_default();
+
+    if !status.success() {
+        let msg = if !stderr_data.is_empty() {
+            String::from_utf8_lossy(&stderr_data).to_string()
+        } else {
+            String::new()
+        };
+        return Err(format!("mlir-cpu-runner failed: {}\n{}", status, msg));
+    }
+
+    let stdout_string = if !stdout_data.is_empty() {
+        match String::from_utf8(stdout_data) {
+            Ok(s) => s,
+            Err(err) => {
+                let bytes = err.into_bytes();
+                String::from_utf8_lossy(&bytes).to_string()
+            }
+        }
+    } else {
+        String::new()
+    };
+
+    Ok(stdout_string.trim().to_string())
+}

--- a/tests/mlir_exec.rs
+++ b/tests/mlir_exec.rs
@@ -1,0 +1,57 @@
+#[cfg(feature = "mlir-exec")]
+#[test]
+fn mlir_exec_scalar_add() {
+    if which::which("mlir-opt").is_err() || which::which("mlir-cpu-runner").is_err() {
+        eprintln!("skipping: mlir tools not found");
+        return;
+    }
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--features",
+            "mlir-exec",
+            "--",
+            "eval",
+            "--mlir-exec",
+            "1",
+            "+",
+            "2",
+        ])
+        .output()
+        .expect("run mlir exec");
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("3"), "stdout: {}", stdout);
+}
+
+#[cfg(all(feature = "mlir-exec", feature = "cpu-exec"))]
+#[test]
+fn parity_cpu_vs_mlir_exec_simple() {
+    if which::which("mlir-opt").is_err() || which::which("mlir-cpu-runner").is_err() {
+        eprintln!("skipping: mlir tools not found");
+        return;
+    }
+    let src = "let x: Tensor[f32,(2,2)] = 1; tensor.sum(x + 2)";
+
+    let cpu = std::process::Command::new("cargo")
+        .args(["run", "--quiet", "--features", "cpu-exec", "--", "eval", "--exec", src])
+        .output()
+        .expect("run cpu exec");
+    assert!(cpu.status.success(), "cpu stderr: {}", String::from_utf8_lossy(&cpu.stderr));
+    let cpu_stdout = String::from_utf8_lossy(&cpu.stdout).trim().to_string();
+
+    let mlir = std::process::Command::new("cargo")
+        .args(["run", "--quiet", "--features", "mlir-exec", "--", "eval", "--mlir-exec", src])
+        .output()
+        .expect("run mlir exec");
+    assert!(mlir.status.success(), "mlir stderr: {}", String::from_utf8_lossy(&mlir.stderr));
+    let mlir_stdout = String::from_utf8_lossy(&mlir.stdout).trim().to_string();
+
+    assert!(
+        !cpu_stdout.is_empty(),
+        "cpu stdout empty: stderr={}",
+        String::from_utf8_lossy(&cpu.stderr)
+    );
+    assert_eq!(cpu_stdout, mlir_stdout, "cpu vs mlir mismatch");
+}


### PR DESCRIPTION
## Summary
- add an optional `mlir-exec` feature with a subprocess-based MLIR runner
- extend the MLIR exporter with an executable mode and wire MLIR execution into evaluation
- move the CLI to clap parsing, expose `--mlir-exec` configuration flags, and document the new flow
- add feature-gated tests that exercise MLIR execution when tools are available

## Testing
- cargo test --no-default-features
- cargo check --features mlir-exec --no-default-features

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117ba22d088322b49607c15605b624)