### PR TITLE
Harden cargo registry fetch in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
     steps:
     - uses: actions/checkout@v4
@@ -45,6 +47,9 @@ jobs:
       with:
         cache-on-failure: true
         cache-all-crates: true
+
+    - name: Cargo metadata (smoke)
+      run: cargo metadata --format-version=1 --locked
 
     - name: Prime index & fetch (retry)
       run: |
@@ -78,6 +83,8 @@ jobs:
   coverage_core:
     name: Coverage (core – no optional features)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
     - uses: actions/checkout@v4
 
@@ -88,6 +95,9 @@ jobs:
       run: |
         git config --global --unset-all http.proxy  || true
         git config --global --unset-all https.proxy || true
+
+    - name: Cargo metadata (smoke)
+      run: cargo metadata --format-version=1 --locked
 
     - name: Prime index & fetch (retry)
       run: |
@@ -127,6 +137,8 @@ jobs:
           - "llvm"
           - "mlir,llvm"
           - "autodiff,mlir,llvm"
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
     - uses: actions/checkout@v4
 
@@ -137,6 +149,9 @@ jobs:
       run: |
         git config --global --unset-all http.proxy  || true
         git config --global --unset-all https.proxy || true
+
+    - name: Cargo metadata (smoke)
+      run: cargo metadata --format-version=1 --locked
 
     - name: Prime index & fetch (retry)
       run: |
@@ -167,6 +182,8 @@ jobs:
   autodiff_tests:
     name: Tests (feature: autodiff)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -176,6 +193,9 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
 
       - name: Prime index & fetch (retry)
         run: |
@@ -194,6 +214,8 @@ jobs:
   mlir_stub_tests:
     name: Tests (feature: mlir stub)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -203,6 +225,9 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
 
       - name: Prime index & fetch (retry)
         run: |
@@ -222,6 +247,8 @@ jobs:
   mlir_build_check:
     name: Check (feature: mlir-build)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -231,6 +258,9 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
 
       - name: Prime index & fetch (retry)
         run: |
@@ -250,6 +280,8 @@ jobs:
   fmt_check:
     name: Format (rustfmt)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.81.0
@@ -259,6 +291,8 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
       - name: Prime index & fetch (retry)
         run: |
           set -e
@@ -279,6 +313,8 @@ jobs:
   clippy_core:
     name: Clippy (no-default-features)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.81.0
@@ -288,6 +324,8 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
       - name: Prime index & fetch (retry)
         run: |
           set -e
@@ -316,6 +354,8 @@ jobs:
             args: "--no-default-features --features ffi-c"
           - label: ffi-full
             args: "--no-default-features --features \"ffi-c mlir-build cpu-exec ffi-examples\""
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -325,6 +365,9 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
 
       - name: Prime index & fetch (retry)
         run: |
@@ -344,6 +387,8 @@ jobs:
   supply_chain_check:
     name: Supply chain (cargo-deny & audit)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
 
@@ -354,6 +399,9 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
 
       - name: Prime index & fetch (retry)
         run: |
@@ -384,6 +432,8 @@ jobs:
     if: github.repository_owner == 'cputer'
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -392,6 +442,8 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
       - name: Prime index & fetch (retry)
         run: |
           set -e
@@ -412,6 +464,8 @@ jobs:
     if: github.repository_owner == 'cputer'
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -420,6 +474,8 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+      - name: Cargo metadata (smoke)
+        run: cargo metadata --format-version=1 --locked
       - name: Prime index & fetch (retry)
         run: |
           set -e


### PR DESCRIPTION
## Summary
- ensure every job exports `CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse`
- add a cargo metadata smoke check ahead of the heavier build/test steps

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d44180448322a00e78f432c67e93)