### PR TITLE
ci: fix “env key already defined” by deduping proxy vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,10 @@ jobs:
     name: Build & Test (no default features)
     runs-on: ubuntu-latest
     env:
-      # Neutralize any runner/org proxy settings (define ONCE here)
+      # Neutralize any runner/org proxy settings (single casing only)
       http_proxy: ""
       https_proxy: ""
       no_proxy: ""
-      HTTP_PROXY: ""
-      HTTPS_PROXY: ""
-      NO_PROXY: ""
       # Force sparse index for crates.io
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
* Remove duplicate `HTTP_PROXY/HTTPS_PROXY/NO_PROXY` entries in job `env`.
* Keep a single (lowercase) set of proxy overrides to satisfy GitHub’s YAML duplicate-key check.
* Retain sparse registry + color settings. This unblocks the workflow syntax error so runs can be triggered again.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912adc215b483229f39896a463797b0)