### PR TITLE
ci: fix cargo sparse config duplication

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,6 @@
-[source.crates-io]
-replace-with = "crates-io-sparse"
-
-[source.crates-io-sparse]
-registry = "sparse+https://index.crates.io/"
+[registries]
+crates-io = { protocol = "sparse" }
 
 [net]
+retry = 3
 git-fetch-with-cli = true
-retry = true
-retry-requests = 3


### PR DESCRIPTION
## Summary
* Remove duplicate `[source.crates-io-sparse]` entry from `.cargo/config.toml`
* Keep only `[registries.crates-io]` with `protocol = "sparse"` (Cargo 1.70+ default)
* Fix `source ... already defined by 'crates-io'` error during `cargo metadata`

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b164fe8c8322871e385db33c44e0)