### PR TITLE
fix(ci): use flate2 rust backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ which = { version = "6", optional = true }
 tempfile = { version = "3", optional = true }
 toml = { version = "0.8", optional = true }
 tar = { version = "0.4", optional = true }
-flate2 = { version = "1.0", features = ["gzip"], optional = true }
+flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
 sha2 = { version = "0.10", optional = true }
 dirs = { version = "5", optional = true }
 


### PR DESCRIPTION
## Summary
- replace the flate2 dependency feature selection to disable default features
- enable the rust_backend feature for flate2 so gzip support remains available

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b5056d188322afee619855c1fd51)