### PR TITLE
Bump CI Rust toolchain to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@1.81.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Remove git proxies (belt-and-suspenders)
         run: |


### PR DESCRIPTION
## Summary
- update the CI workflow to install the stable Rust toolchain instead of the pinned 1.81.0 release so edition2024 crates resolve correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c28a6b388322b6eb21b004d96fe3)