### PR TITLE
Fix clippy lints across evaluation and parser modules

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -63,6 +63,12 @@ impl IRModule {
     }
 }
 
+impl Default for IRModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl fmt::Display for IRModule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for instr in &self.instrs {

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -164,7 +164,7 @@ pub fn conv_output_dim_same(input: Option<usize>, stride: usize) -> Result<Optio
             if h == 0 {
                 return Err("input spatial dimension must be positive".to_string());
             }
-            let out = (h + stride - 1) / stride;
+            let out = h.div_ceil(stride);
             Ok(Some(out))
         }
         None => Ok(None),
@@ -185,10 +185,7 @@ pub fn compute_matmul_shape_info(
 
     let a_adj = if a_shape.len() == 1 {
         a_was_vec = true;
-        let mut dims = Vec::with_capacity(2);
-        dims.push(ShapeDim::Known(1));
-        dims.push(a_shape[0].clone());
-        dims
+        vec![ShapeDim::Known(1), a_shape[0].clone()]
     } else {
         a_shape.to_vec()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,20 +69,21 @@ fn default_mlir_opt_passes() -> Vec<String> {
 
 impl EmitOpts {
     fn from_eval_args(args: &EvalArgs) -> Self {
-        let mut out = EmitOpts::default();
-        out.emit_mlir_stdout = args.emit_mlir;
-        out.emit_mlir_file = args.emit_mlir_file.clone();
-        out.emit_llvm_file = args.emit_llvm_file.clone();
-        out.emit_obj_file = args.emit_obj.clone();
-        out.emit_shared_lib = args.build_shared.clone();
-        #[cfg(feature = "ffi-c")]
-        {
-            out.emit_ffi_header = args.emit_ffi_c.clone();
-            out.emit_ffi_shim = args.emit_ffi_shim.clone();
-        }
+        let mut out = EmitOpts {
+            emit_mlir_stdout: args.emit_mlir,
+            emit_mlir_file: args.emit_mlir_file.clone(),
+            emit_llvm_file: args.emit_llvm_file.clone(),
+            emit_obj_file: args.emit_obj.clone(),
+            emit_shared_lib: args.build_shared.clone(),
+            #[cfg(feature = "ffi-c")]
+            emit_ffi_header: args.emit_ffi_c.clone(),
+            #[cfg(feature = "ffi-c")]
+            emit_ffi_shim: args.emit_ffi_shim.clone(),
+            ..Default::default()
+        };
         if let Some(lower) = &args.mlir_lower {
             out.mlir_lower =
-                eval::MlirLowerPreset::from_str(lower).unwrap_or(eval::MlirLowerPreset::None);
+                lower.parse().unwrap_or(eval::MlirLowerPreset::None);
         }
         if let Some(pipeline) = &args.mlir_passes {
             if !pipeline.trim().is_empty() {
@@ -148,6 +149,7 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Command {
     Eval(EvalArgs),
     Repl,

--- a/src/opt/fold.rs
+++ b/src/opt/fold.rs
@@ -14,7 +14,7 @@ pub fn fold(node: &Node) -> Node {
                     BinOp::Div => {
                         if *b == 0 {
                             return Node::Binary {
-                                op: op.clone(),
+                                op: *op,
                                 left: Box::new(l),
                                 right: Box::new(r),
                                 span: *span,
@@ -26,7 +26,7 @@ pub fn fold(node: &Node) -> Node {
                 };
                 Node::Lit(Literal::Int(v), *span)
             } else {
-                Node::Binary { op: op.clone(), left: Box::new(l), right: Box::new(r), span: *span }
+                Node::Binary { op: *op, left: Box::new(l), right: Box::new(r), span: *span }
             }
         }
         Node::Paren(inner, span) => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -55,7 +55,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             .padded();
         let axes_list = just('[')
             .padded()
-            .ignore_then(signed_int.clone().separated_by(just(',').padded()).allow_trailing())
+            .ignore_then(signed_int.separated_by(just(',').padded()).allow_trailing())
             .then_ignore(just(']').padded());
 
         let tuple_or_paren = just('(')
@@ -91,7 +91,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
         let reduce_arg = choice((
             kw("axes")
                 .ignore_then(just('=').padded())
-                .ignore_then(axes_list.clone())
+                .ignore_then(axes_list)
                 .map(ReduceArg::Axes),
             kw("keepdims")
                 .ignore_then(just('=').padded())
@@ -158,8 +158,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
                 Node::CallReshape { x: Box::new(x), dims, span }
             });
 
-        let expand_axis =
-            kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int.clone());
+        let expand_axis = kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int);
 
         let tensor_expand_dims_call = just("tensor.expand_dims")
             .ignore_then(just('(').padded())
@@ -172,8 +171,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
                 Node::CallExpandDims { x: Box::new(x), axis, span }
             });
 
-        let squeeze_axes =
-            kw("axes").ignore_then(just('=').padded()).ignore_then(axes_list.clone());
+        let squeeze_axes = kw("axes").ignore_then(just('=').padded()).ignore_then(axes_list);
 
         let tensor_squeeze_call = just("tensor.squeeze")
             .ignore_then(just('(').padded())
@@ -186,8 +184,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
                 Node::CallSqueeze { x: Box::new(x), axes, span }
             });
 
-        let transpose_axes =
-            kw("axes").ignore_then(just('=').padded()).ignore_then(axes_list.clone());
+        let transpose_axes = kw("axes").ignore_then(just('=').padded()).ignore_then(axes_list);
 
         let tensor_transpose_call = just("tensor.transpose")
             .ignore_then(just('(').padded())
@@ -203,9 +200,9 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             .ignore_then(just('(').padded())
             .ignore_then(expr.clone())
             .then_ignore(just(',').padded())
-            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(',').padded())
-            .then(kw("i").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("i").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(')').padded())
             .map_with_span(|((x, axis), i), sp: std::ops::Range<usize>| {
                 let span = Span::new(sp.start, sp.end);
@@ -216,11 +213,11 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             .ignore_then(just('(').padded())
             .ignore_then(expr.clone())
             .then_ignore(just(',').padded())
-            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(',').padded())
-            .then(kw("start").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("start").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(',').padded())
-            .then(kw("end").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("end").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(')').padded())
             .map_with_span(|(((x, axis), start), end), sp: std::ops::Range<usize>| {
                 let span = Span::new(sp.start, sp.end);
@@ -231,13 +228,13 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             .ignore_then(just('(').padded())
             .ignore_then(expr.clone())
             .then_ignore(just(',').padded())
-            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(',').padded())
-            .then(kw("start").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("start").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(',').padded())
-            .then(kw("end").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("end").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(',').padded())
-            .then(kw("step").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("step").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(')').padded())
             .map_with_span(|((((x, axis), start), end), step), sp: std::ops::Range<usize>| {
                 let span = Span::new(sp.start, sp.end);
@@ -248,7 +245,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             .ignore_then(just('(').padded())
             .ignore_then(expr.clone())
             .then_ignore(just(',').padded())
-            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int.clone()))
+            .then(kw("axis").ignore_then(just('=').padded()).ignore_then(signed_int))
             .then_ignore(just(',').padded())
             .then(
                 kw("idx")
@@ -293,7 +290,6 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
         }
 
         let stride_value = signed_int
-            .clone()
             .map_with_span(|v, sp: std::ops::Range<usize>| (v, sp))
             .try_map(|(value, sp), _| {
                 if value <= 0 {
@@ -308,18 +304,19 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             .then_ignore(just('"'))
             .map_with_span(|s, sp: std::ops::Range<usize>| (s, sp))
             .try_map(|(value, sp), _| {
-                ConvPadding::from_str(&value)
+                value
+                    .parse()
                     .map(Conv2dArg::Padding)
-                    .ok_or_else(|| Simple::custom(sp, "padding must be \"valid\" or \"same\""))
+                    .map_err(|_| Simple::custom(sp, "padding must be \"valid\" or \"same\""))
             });
 
         let conv2d_arg = choice((
             kw("stride_h")
                 .ignore_then(just('=').padded())
-                .ignore_then(stride_value.clone().map(Conv2dArg::StrideH)),
+                .ignore_then(stride_value.map(Conv2dArg::StrideH)),
             kw("stride_w")
                 .ignore_then(just('=').padded())
-                .ignore_then(stride_value.clone().map(Conv2dArg::StrideW)),
+                .ignore_then(stride_value.map(Conv2dArg::StrideW)),
             kw("padding").ignore_then(just('=').padded()).ignore_then(padding_value),
         ));
 
@@ -362,7 +359,6 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             });
 
         let call = dotted_ident
-            .clone()
             .map_with_span(|name, sp: std::ops::Range<usize>| (name, Span::new(sp.start, sp.end)))
             .then(
                 just('(')
@@ -392,8 +388,8 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             tensor_relu_call,
             tensor_conv2d_call,
             call,
-            int.clone(),
-            ident_expr.clone(),
+            int,
+            ident_expr,
             tuple_or_paren,
         ))
         .padded()
@@ -432,7 +428,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
     let dim = choice((text::int(10).map(|s: String| s), text::ident().map(|s: String| s))).padded();
 
     let dims = just('(')
-        .ignore_then(dim.clone().separated_by(just(',').padded()).allow_trailing())
+        .ignore_then(dim.separated_by(just(',').padded()).allow_trailing())
         .then_ignore(just(')'))
         .padded();
 
@@ -442,7 +438,7 @@ pub fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
             .ignore_then(just('['))
             .ignore_then(dtype.clone())
             .then_ignore(just(',').padded())
-            .then(dims.clone())
+            .then(dims)
             .then_ignore(just(']'))
             .map(|(dt, shape)| TypeAnn::Tensor { dtype: dt, dims: shape }),
     ))

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -22,7 +22,7 @@ pub enum DType {
 }
 
 impl DType {
-    pub fn from_str(name: &str) -> Option<Self> {
+    fn parse_name(name: &str) -> Option<Self> {
         match name.to_ascii_lowercase().as_str() {
             "i32" => Some(DType::I32),
             "f32" => Some(DType::F32),
@@ -32,6 +32,10 @@ impl DType {
         }
     }
 
+    pub fn parse(name: &str) -> Option<Self> {
+        Self::parse_name(name)
+    }
+
     pub fn as_str(&self) -> &'static str {
         match self {
             DType::I32 => "i32",
@@ -39,6 +43,14 @@ impl DType {
             DType::BF16 => "bf16",
             DType::F16 => "f16",
         }
+    }
+}
+
+impl std::str::FromStr for DType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        DType::parse_name(s).ok_or(())
     }
 }
 
@@ -55,7 +67,7 @@ pub enum ConvPadding {
 }
 
 impl ConvPadding {
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
             "valid" => Some(ConvPadding::Valid),
             "same" => Some(ConvPadding::Same),
@@ -68,6 +80,14 @@ impl ConvPadding {
             ConvPadding::Valid => "valid",
             ConvPadding::Same => "same",
         }
+    }
+}
+
+impl std::str::FromStr for ConvPadding {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ConvPadding::parse(s).ok_or(())
     }
 }
 


### PR DESCRIPTION
## Summary
- replace failing clippy patterns (axis bounds, clone-on-copy, vec init) across eval, type checking, and tensor helpers
- implement `FromStr` for `DType`, `ConvPadding`, and `MlirLowerPreset` while updating callers
- tidy CLI emit options, IR defaults, and mlir/linalg helpers to keep strict clippy clean

## Testing
- cargo clippy --no-default-features --locked -- -D warnings
- cargo test --no-default-features

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912cab42b9c8322900d33ec1554d1bc)