### PR TITLE
fix(fmt): use stable rustfmt config and apply formatting

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,9 @@
 fn main() {
     if std::env::var("CARGO_FEATURE_FFI_EXAMPLES").is_ok() {
         println!("cargo:rerun-if-changed=examples/c/min.c");
-        cc::Build::new().file("examples/c/min.c").warnings(false).compile("mind_ffi_examples");
+        cc::Build::new()
+            .file("examples/c/min.c")
+            .warnings(false)
+            .compile("mind_ffi_examples");
     }
 }

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -81,6 +81,11 @@ impl Diagnostic {
         let start = offset_to_loc(src, span.start);
         let end = offset_to_loc(src, span.end);
         let message = e.to_string();
-        Diagnostic { message, span, start, end }
+        Diagnostic {
+            message,
+            span,
+            start,
+            end,
+        }
     }
 }

--- a/src/eval/ir_interp.rs
+++ b/src/eval/ir_interp.rs
@@ -44,7 +44,11 @@ pub fn eval_ir(ir: &IRModule) -> Value {
                 vals.insert(*dst, out.clone());
                 last = out;
             }
-            Instr::Reshape { dst, src, new_shape } => {
+            Instr::Reshape {
+                dst,
+                src,
+                new_shape,
+            } => {
                 let value = vals.get(src).cloned().unwrap_or(Value::Int(0));
                 let reshaped = match value {
                     Value::Tensor(t) => {

--- a/src/eval/mlir_build.rs
+++ b/src/eval/mlir_build.rs
@@ -111,7 +111,10 @@ pub fn build_all(
         run_clang_codegen(&llvm_ir, tools, opts.target_triple, path, true)?;
     }
 
-    Ok(BuildProducts { optimized_mlir, llvm_ir })
+    Ok(BuildProducts {
+        optimized_mlir,
+        llvm_ir,
+    })
 }
 
 #[cfg(feature = "mlir-build")]
@@ -146,8 +149,13 @@ fn preset_default_pipeline(preset: &str) -> Option<&'static str> {
 #[cfg(feature = "mlir-build")]
 fn run_mlir_opt(input: &str, pipeline: &str, tools: &BuildTools) -> Result<String, BuildError> {
     let args = vec![format!("--pass-pipeline={pipeline}")];
-    let output =
-        run_command(&tools.mlir_opt, &args, Some(input.as_bytes()), tools.timeout, "mlir-opt")?;
+    let output = run_command(
+        &tools.mlir_opt,
+        &args,
+        Some(input.as_bytes()),
+        tools.timeout,
+        "mlir-opt",
+    )?;
     if !output.status.success() {
         return Err(BuildError::Subprocess {
             tool: "mlir-opt",
@@ -302,7 +310,11 @@ fn collect_child_output(mut child: Child) -> Result<CommandOutput, BuildError> {
 
     let status = child.wait()?;
 
-    Ok(CommandOutput { stdout, stderr, status })
+    Ok(CommandOutput {
+        stdout,
+        stderr,
+        status,
+    })
 }
 
 #[cfg(feature = "mlir-build")]

--- a/src/eval/mlir_opt.rs
+++ b/src/eval/mlir_opt.rs
@@ -10,7 +10,11 @@ pub struct MlirOptOutput {
 
 impl MlirOptOutput {
     pub fn from_error<E: fmt::Display>(err: E) -> Self {
-        Self { stdout: String::new(), stderr: err.to_string(), status_ok: false }
+        Self {
+            stdout: String::new(),
+            stderr: err.to_string(),
+            status_ok: false,
+        }
     }
 }
 
@@ -37,8 +41,11 @@ pub fn run_mlir_opt(
         cmd.arg(format!("--pass-pipeline={pipeline}"));
     }
 
-    let mut child =
-        cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
 
     if let Some(mut stdin) = child.stdin.take() {
         stdin.write_all(mlir_input.as_bytes())?;
@@ -48,7 +55,11 @@ pub fn run_mlir_opt(
     loop {
         if let Some(status) = child.try_wait()? {
             let (stdout, stderr) = collect_child_output(&mut child);
-            return Ok(MlirOptOutput { stdout, stderr, status_ok: status.success() });
+            return Ok(MlirOptOutput {
+                stdout,
+                stderr,
+                status_ok: status.success(),
+            });
         }
 
         if start.elapsed() > Duration::from_millis(timeout_ms) {
@@ -94,5 +105,7 @@ pub fn run_mlir_opt(
     _passes: &[String],
     _timeout_ms: u64,
 ) -> std::io::Result<MlirOptOutput> {
-    Ok(MlirOptOutput::from_error("mlir-subprocess feature is disabled"))
+    Ok(MlirOptOutput::from_error(
+        "mlir-subprocess feature is disabled",
+    ))
 }

--- a/src/eval/mlir_run.rs
+++ b/src/eval/mlir_run.rs
@@ -89,7 +89,9 @@ pub fn exec_mlir_text(mlir: &str, cfg: &MlirExecConfig) -> Result<String, String
         }
     }
     opt_cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let opt_output = opt_cmd.output().map_err(|e| format!("mlir-opt failed to spawn: {e}"))?;
+    let opt_output = opt_cmd
+        .output()
+        .map_err(|e| format!("mlir-opt failed to spawn: {e}"))?;
     if !opt_output.status.success() {
         return Err(format!(
             "mlir-opt failed: {}\n{}",
@@ -109,15 +111,27 @@ pub fn exec_mlir_text(mlir: &str, cfg: &MlirExecConfig) -> Result<String, String
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let mut child =
-        runner_cmd.spawn().map_err(|e| format!("mlir-cpu-runner failed to spawn: {e}"))?;
+    let mut child = runner_cmd
+        .spawn()
+        .map_err(|e| format!("mlir-cpu-runner failed to spawn: {e}"))?;
     {
-        let stdin = child.stdin.as_mut().ok_or("Failed to open stdin for mlir-cpu-runner")?;
-        stdin.write_all(optimized_mlir.as_bytes()).map_err(|e| e.to_string())?;
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or("Failed to open stdin for mlir-cpu-runner")?;
+        stdin
+            .write_all(optimized_mlir.as_bytes())
+            .map_err(|e| e.to_string())?;
     }
 
-    let mut child_stdout = child.stdout.take().ok_or("Failed to capture mlir-cpu-runner stdout")?;
-    let mut child_stderr = child.stderr.take().ok_or("Failed to capture mlir-cpu-runner stderr")?;
+    let mut child_stdout = child
+        .stdout
+        .take()
+        .ok_or("Failed to capture mlir-cpu-runner stdout")?;
+    let mut child_stderr = child
+        .stderr
+        .take()
+        .ok_or("Failed to capture mlir-cpu-runner stderr")?;
 
     use std::io::Read;
 

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -537,7 +537,11 @@ fn slice_len_with_step(len: Option<usize>, start: i32, end: i32, step: i32) -> O
 
 fn normalize_expand_axis(axis: i32, rank: usize) -> Result<usize, EvalError> {
     let extended = rank + 1;
-    let idx = if axis < 0 { (extended as i32) + axis } else { axis };
+    let idx = if axis < 0 {
+        (extended as i32) + axis
+    } else {
+        axis
+    };
     if idx < 0 || idx > extended as i32 - 1 {
         Err(EvalError::Unsupported)
     } else {
@@ -715,12 +719,7 @@ pub(crate) fn conv2d_tensor_preview(
     let out_h = conv_output_dim_eval(&x.shape[1], Some(&w.shape[0]), stride_h, padding)?;
     let out_w = conv_output_dim_eval(&x.shape[2], Some(&w.shape[1]), stride_w, padding)?;
 
-    let out_shape = vec![
-        x.shape[0].clone(),
-        out_h,
-        out_w,
-        w.shape[3].clone(),
-    ];
+    let out_shape = vec![x.shape[0].clone(), out_h, out_w, w.shape[3].clone()];
 
     Ok(TensorVal::new(dtype, out_shape, None))
 }
@@ -868,7 +867,10 @@ pub(crate) fn transpose_tensor_preview(
         linalg::default_transpose(rank)
     };
     let shape = linalg::permute_shape(&tensor.shape, &perm);
-    Ok((TensorVal::new(tensor.dtype.clone(), shape, tensor.fill), perm))
+    Ok((
+        TensorVal::new(tensor.dtype.clone(), shape, tensor.fill),
+        perm,
+    ))
 }
 
 pub(crate) fn index_tensor_preview(
@@ -945,7 +947,11 @@ pub(crate) fn slice_stride_tensor_preview(
         }
     };
     shape[axis] = new_dim;
-    let fill = if tensor.fill.is_some() { tensor.fill } else { None };
+    let fill = if tensor.fill.is_some() {
+        tensor.fill
+    } else {
+        None
+    };
     Ok(TensorVal::new(tensor.dtype.clone(), shape, fill))
 }
 

--- a/src/eval/value.rs
+++ b/src/eval/value.rs
@@ -213,7 +213,11 @@ mod tests {
 
     #[test]
     fn format_tensor_shape_symbols() {
-        let t = TensorVal::new(DType::I32, vec![ShapeDim::Sym("B"), ShapeDim::Known(4)], None);
+        let t = TensorVal::new(
+            DType::I32,
+            vec![ShapeDim::Sym("B"), ShapeDim::Known(4)],
+            None,
+        );
         let s = format_value_human(&Value::Tensor(t));
         assert!(s.contains("(B,4)"));
     }

--- a/src/exec/conv.rs
+++ b/src/exec/conv.rs
@@ -25,13 +25,17 @@ pub fn exec_conv2d(
         return Err(ExecError::Shape("strides must be positive".into()));
     }
     if input.dtype != crate::types::DType::F32 || weights.dtype != crate::types::DType::F32 {
-        return Err(ExecError::Type("only f32 tensors supported in cpu-exec".into()));
+        return Err(ExecError::Type(
+            "only f32 tensors supported in cpu-exec".into(),
+        ));
     }
 
     let in_shape = shape_as_usize(&input.shape)?;
     let wt_shape = shape_as_usize(&weights.shape)?;
     if in_shape.len() != 4 || wt_shape.len() != 4 {
-        return Err(ExecError::Shape("`tensor.conv2d` expects NHWC x HWIO tensors".into()));
+        return Err(ExecError::Shape(
+            "`tensor.conv2d` expects NHWC x HWIO tensors".into(),
+        ));
     }
 
     let n = in_shape[0];
@@ -45,7 +49,9 @@ pub fn exec_conv2d(
     let out_c = wt_shape[3];
 
     if kernel_h == 0 || kernel_w == 0 {
-        return Err(ExecError::Shape("kernel dimensions must be positive".into()));
+        return Err(ExecError::Shape(
+            "kernel dimensions must be positive".into(),
+        ));
     }
 
     if in_c != kernel_c {
@@ -130,5 +136,8 @@ pub fn exec_conv2d(
         }
     }
 
-    Ok(TensorVal::from_materialized_f32(vec![n, out_h, out_w, out_c], output))
+    Ok(TensorVal::from_materialized_f32(
+        vec![n, out_h, out_w, out_c],
+        output,
+    ))
 }

--- a/src/exec/cpu.rs
+++ b/src/exec/cpu.rs
@@ -33,7 +33,9 @@ fn shape_usize(shape: &[ShapeDim]) -> Option<Vec<usize>> {
 fn ensure_f32(t: &TensorVal) -> R<()> {
     match t.dtype {
         DType::F32 => Ok(()),
-        _ => Err(ExecError::Type("only f32 tensors supported in cpu-exec".into())),
+        _ => Err(ExecError::Type(
+            "only f32 tensors supported in cpu-exec".into(),
+        )),
     }
 }
 
@@ -49,7 +51,10 @@ fn broadcast_shapes(a: &[usize], b: &[usize]) -> R<Vec<usize>> {
         } else if db == 1 {
             da
         } else {
-            return Err(ExecError::Shape(format!("cannot broadcast shapes {:?} and {:?}", a, b)));
+            return Err(ExecError::Shape(format!(
+                "cannot broadcast shapes {:?} and {:?}",
+                a, b
+            )));
         };
         out.push(dim);
         i -= 1;
@@ -135,10 +140,12 @@ pub fn exec_add(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
     ensure_f32(rhs)?;
     let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
     let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata =
-        lhs.as_f32().ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata =
-        rhs.as_f32().ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
+    let ldata = lhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
+    let rdata = rhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
     let (out, shape) = elementwise_binop_f32(|a, b| a + b, (ldata, &lshape), (rdata, &rshape))?;
     Ok(TensorVal::from_materialized_f32(shape, out))
 }
@@ -148,10 +155,12 @@ pub fn exec_sub(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
     ensure_f32(rhs)?;
     let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
     let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata =
-        lhs.as_f32().ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata =
-        rhs.as_f32().ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
+    let ldata = lhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
+    let rdata = rhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
     let (out, shape) = elementwise_binop_f32(|a, b| a - b, (ldata, &lshape), (rdata, &rshape))?;
     Ok(TensorVal::from_materialized_f32(shape, out))
 }
@@ -161,10 +170,12 @@ pub fn exec_mul(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
     ensure_f32(rhs)?;
     let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
     let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata =
-        lhs.as_f32().ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata =
-        rhs.as_f32().ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
+    let ldata = lhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
+    let rdata = rhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
     let (out, shape) = elementwise_binop_f32(|a, b| a * b, (ldata, &lshape), (rdata, &rshape))?;
     Ok(TensorVal::from_materialized_f32(shape, out))
 }
@@ -174,10 +185,12 @@ pub fn exec_div(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
     ensure_f32(rhs)?;
     let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
     let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata =
-        lhs.as_f32().ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata =
-        rhs.as_f32().ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
+    let ldata = lhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
+    let rdata = rhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
     if rdata.iter().any(|&v| v == 0.0) {
         return Err(ExecError::Math("division by zero".into()));
     }
@@ -188,8 +201,9 @@ pub fn exec_div(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
 pub fn exec_add_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
     ensure_f32(t)?;
     let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let out = elementwise_unary_f32(|v| v + scalar, data);
     Ok(TensorVal::from_materialized_f32(shape, out))
 }
@@ -197,8 +211,9 @@ pub fn exec_add_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
 pub fn exec_sub_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
     ensure_f32(t)?;
     let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let out = elementwise_unary_f32(|v| v - scalar, data);
     Ok(TensorVal::from_materialized_f32(shape, out))
 }
@@ -206,8 +221,9 @@ pub fn exec_sub_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
 pub fn exec_scalar_sub(scalar: f32, t: &TensorVal) -> R<TensorVal> {
     ensure_f32(t)?;
     let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let out = elementwise_unary_f32(|v| scalar - v, data);
     Ok(TensorVal::from_materialized_f32(shape, out))
 }
@@ -215,8 +231,9 @@ pub fn exec_scalar_sub(scalar: f32, t: &TensorVal) -> R<TensorVal> {
 pub fn exec_mul_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
     ensure_f32(t)?;
     let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let out = elementwise_unary_f32(|v| v * scalar, data);
     Ok(TensorVal::from_materialized_f32(shape, out))
 }
@@ -227,8 +244,9 @@ pub fn exec_div_scalar(t: &TensorVal, scalar: f32, tensor_on_left: bool) -> R<Te
         return Err(ExecError::Math("division by zero".into()));
     }
     let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let out = if tensor_on_left {
         elementwise_unary_f32(|v| v / scalar, data)
     } else {
@@ -239,15 +257,17 @@ pub fn exec_div_scalar(t: &TensorVal, scalar: f32, tensor_on_left: bool) -> R<Te
 
 fn data_has_zero(t: &TensorVal) -> R<bool> {
     ensure_f32(t)?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     Ok(data.iter().any(|&v| v == 0.0))
 }
 
 pub fn exec_sum_all(t: &TensorVal) -> R<TensorVal> {
     ensure_f32(t)?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let sum = reduce_sum(data);
     Ok(TensorVal::from_materialized_f32(vec![], vec![sum]))
 }
@@ -258,8 +278,9 @@ pub fn exec_mean_all(t: &TensorVal) -> R<TensorVal> {
     if shape.iter().any(|&d| d == 0) {
         return Err(ExecError::Math("mean over zero elements".into()));
     }
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let sum = reduce_sum(data);
     let count = numel(&shape) as f32;
     Ok(TensorVal::from_materialized_f32(vec![], vec![sum / count]))
@@ -278,8 +299,9 @@ pub fn relu_inplace(buf: &mut [f32]) {
 pub fn exec_relu(t: &TensorVal) -> R<TensorVal> {
     ensure_f32(t)?;
     let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data =
-        t.as_f32().ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
+    let data = t
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
     let mut out = data.to_vec();
     relu_inplace(&mut out);
     Ok(TensorVal::from_materialized_f32(shape, out))
@@ -298,10 +320,12 @@ pub fn exec_matmul(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
     if k1 != k2 {
         return Err(ExecError::Shape("inner dims mismatch".into()));
     }
-    let ldata =
-        lhs.as_f32().ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata =
-        rhs.as_f32().ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
+    let ldata = lhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
+    let rdata = rhs
+        .as_f32()
+        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
     let mut out = vec![0f32; m * n];
     for i in 0..m {
         for j in 0..n {

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -136,19 +136,21 @@ pub mod capi {
 
     #[no_mangle]
     pub extern "C" fn mind_last_error() -> *const c_char {
-        LAST_ERROR.with(
-            |slot| {
-                if let Some(s) = slot.borrow().as_ref() {
-                    s.as_ptr()
-                } else {
-                    ptr::null()
-                }
-            },
-        )
+        LAST_ERROR.with(|slot| {
+            if let Some(s) = slot.borrow().as_ref() {
+                s.as_ptr()
+            } else {
+                ptr::null()
+            }
+        })
     }
 
     pub fn last_error_as_str() -> Option<String> {
-        LAST_ERROR.with(|slot| slot.borrow().as_ref().map(|s| s.to_string_lossy().into_owned()))
+        LAST_ERROR.with(|slot| {
+            slot.borrow()
+                .as_ref()
+                .map(|s| s.to_string_lossy().into_owned())
+        })
     }
 
     #[allow(dead_code)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -22,18 +22,70 @@ pub struct IndexSpec {
 pub enum Instr {
     ConstI64(ValueId, i64),
     ConstTensor(ValueId, DType, Vec<ShapeDim>, Option<f64>),
-    BinOp { dst: ValueId, op: BinOp, lhs: ValueId, rhs: ValueId },
-    Sum { dst: ValueId, src: ValueId, axes: Vec<i64>, keepdims: bool },
-    Mean { dst: ValueId, src: ValueId, axes: Vec<i64>, keepdims: bool },
-    Reshape { dst: ValueId, src: ValueId, new_shape: Vec<ShapeDim> },
-    ExpandDims { dst: ValueId, src: ValueId, axis: i64 },
-    Squeeze { dst: ValueId, src: ValueId, axes: Vec<i64> },
-    Transpose { dst: ValueId, src: ValueId, perm: Vec<i64> },
-    Dot { dst: ValueId, a: ValueId, b: ValueId },
-    MatMul { dst: ValueId, a: ValueId, b: ValueId },
-    Index { dst: ValueId, src: ValueId, indices: Vec<IndexSpec> },
-    Slice { dst: ValueId, src: ValueId, dims: Vec<SliceSpec> },
-    Gather { dst: ValueId, src: ValueId, indices: ValueId, axis: i64 },
+    BinOp {
+        dst: ValueId,
+        op: BinOp,
+        lhs: ValueId,
+        rhs: ValueId,
+    },
+    Sum {
+        dst: ValueId,
+        src: ValueId,
+        axes: Vec<i64>,
+        keepdims: bool,
+    },
+    Mean {
+        dst: ValueId,
+        src: ValueId,
+        axes: Vec<i64>,
+        keepdims: bool,
+    },
+    Reshape {
+        dst: ValueId,
+        src: ValueId,
+        new_shape: Vec<ShapeDim>,
+    },
+    ExpandDims {
+        dst: ValueId,
+        src: ValueId,
+        axis: i64,
+    },
+    Squeeze {
+        dst: ValueId,
+        src: ValueId,
+        axes: Vec<i64>,
+    },
+    Transpose {
+        dst: ValueId,
+        src: ValueId,
+        perm: Vec<i64>,
+    },
+    Dot {
+        dst: ValueId,
+        a: ValueId,
+        b: ValueId,
+    },
+    MatMul {
+        dst: ValueId,
+        a: ValueId,
+        b: ValueId,
+    },
+    Index {
+        dst: ValueId,
+        src: ValueId,
+        indices: Vec<IndexSpec>,
+    },
+    Slice {
+        dst: ValueId,
+        src: ValueId,
+        dims: Vec<SliceSpec>,
+    },
+    Gather {
+        dst: ValueId,
+        src: ValueId,
+        indices: ValueId,
+        axis: i64,
+    },
     Output(ValueId),
 }
 
@@ -53,7 +105,10 @@ pub struct IRModule {
 
 impl IRModule {
     pub fn new() -> Self {
-        Self { instrs: Vec::new(), next_id: 0 }
+        Self {
+            instrs: Vec::new(),
+            next_id: 0,
+        }
     }
 
     pub fn fresh(&mut self) -> ValueId {

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -45,7 +45,9 @@ fn merge_dims(a: ShapeDim, b: ShapeDim) -> Result<ShapeDim, String> {
             if sa == sb {
                 Ok(ShapeDim::Sym(sa))
             } else {
-                Err(format!("cannot broadcast symbolic dimensions {sa} and {sb}"))
+                Err(format!(
+                    "cannot broadcast symbolic dimensions {sa} and {sb}"
+                ))
             }
         }
         (ShapeDim::Sym(sym), ShapeDim::Known(1)) | (ShapeDim::Known(1), ShapeDim::Sym(sym)) => {
@@ -56,7 +58,10 @@ fn merge_dims(a: ShapeDim, b: ShapeDim) -> Result<ShapeDim, String> {
             if other == 1 {
                 Ok(ShapeDim::Sym(sym))
             } else {
-                Err(format!("cannot broadcast dimension {} with symbolic {}", other, sym))
+                Err(format!(
+                    "cannot broadcast dimension {} with symbolic {}",
+                    other, sym
+                ))
             }
         }
     }
@@ -67,8 +72,16 @@ pub fn broadcast_leading(lhs: &[ShapeDim], rhs: &[ShapeDim]) -> Result<Vec<Shape
     let mut i = lhs.len() as isize - 1;
     let mut j = rhs.len() as isize - 1;
     while i >= 0 || j >= 0 {
-        let ld = if i >= 0 { lhs[i as usize].clone() } else { ShapeDim::Known(1) };
-        let rd = if j >= 0 { rhs[j as usize].clone() } else { ShapeDim::Known(1) };
+        let ld = if i >= 0 {
+            lhs[i as usize].clone()
+        } else {
+            ShapeDim::Known(1)
+        };
+        let rd = if j >= 0 {
+            rhs[j as usize].clone()
+        } else {
+            ShapeDim::Known(1)
+        };
         let dim = merge_dims(ld, rd)?;
         result.push(dim);
         i -= 1;
@@ -90,7 +103,11 @@ pub fn normalize_axis(axis: i32, rank: usize) -> Result<usize, String> {
 
 pub fn normalize_permutation(axes: &[i32], rank: usize) -> Result<Vec<usize>, String> {
     if axes.len() != rank {
-        return Err(format!("permutation length {} does not match rank {}", axes.len(), rank));
+        return Err(format!(
+            "permutation length {} does not match rank {}",
+            axes.len(),
+            rank
+        ));
     }
     let mut seen = vec![false; rank];
     let mut perm = Vec::with_capacity(rank);

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,7 @@ impl EmitOpts {
             ..Default::default()
         };
         if let Some(lower) = &args.mlir_lower {
-            out.mlir_lower =
-                lower.parse().unwrap_or(eval::MlirLowerPreset::None);
+            out.mlir_lower = lower.parse().unwrap_or(eval::MlirLowerPreset::None);
         }
         if let Some(pipeline) = &args.mlir_passes {
             if !pipeline.trim().is_empty() {
@@ -284,7 +283,11 @@ fn run_eval_command(args: EvalArgs) {
             };
             let blocks = parse_triplet(&args.gpu_blocks, "gpu-blocks");
             let threads = parse_triplet(&args.gpu_threads, "gpu-threads");
-            eval::ExecMode::MlirGpu { backend, blocks, threads }
+            eval::ExecMode::MlirGpu {
+                backend,
+                blocks,
+                threads,
+            }
         }
         #[cfg(not(feature = "mlir-gpu"))]
         {
@@ -466,8 +469,9 @@ fn run_eval_once(src: &str, emit_opts: EmitOpts, exec_mode: eval::ExecMode) {
                         if let Some(path) = emit_opts.emit_mlir_file.as_ref() {
                             if !(emit_opts.wants_aot_artifacts() && mlir_written_by_builder) {
                                 let path_ref = std::path::Path::new(path);
-                                let parent =
-                                    path_ref.parent().unwrap_or_else(|| std::path::Path::new("."));
+                                let parent = path_ref
+                                    .parent()
+                                    .unwrap_or_else(|| std::path::Path::new("."));
                                 if let Err(e) = std::fs::create_dir_all(parent) {
                                     eprintln!("Failed to create directories for {}: {e}", path);
                                 } else if let Err(e) = std::fs::write(path_ref, &mlir_text) {
@@ -590,13 +594,24 @@ fn package_install(path: &str, target: Option<&str>) -> Result<()> {
     };
 
     install_package(path, target_str)?;
-    println!("Installed {} {} to {}", manifest.name, manifest.version, target_path.display());
+    println!(
+        "Installed {} {} to {}",
+        manifest.name,
+        manifest.version,
+        target_path.display()
+    );
     Ok(())
 }
 
 #[cfg(feature = "pkg")]
 fn discover_default_artifacts() -> Result<Vec<String>> {
-    let candidates = ["model.mlir", "model.so", "mind.h", "metadata.json", "README.md"];
+    let candidates = [
+        "model.mlir",
+        "model.so",
+        "mind.h",
+        "metadata.json",
+        "README.md",
+    ];
     let mut found = Vec::new();
     for candidate in candidates {
         if Path::new(candidate).exists() {
@@ -618,7 +633,10 @@ fn validate_files(files: &[String]) -> Result<Vec<String>> {
     for file in files {
         let path = Path::new(file);
         if path.is_absolute() {
-            return Err(anyhow!("listed artifact '{}' must be a relative path", file));
+            return Err(anyhow!(
+                "listed artifact '{}' must be a relative path",
+                file
+            ));
         }
         if path.components().count() != 1 {
             return Err(anyhow!(

--- a/src/opt/fold.rs
+++ b/src/opt/fold.rs
@@ -3,7 +3,12 @@ use crate::ast::{BinOp, Literal, Node};
 /// Fold constant integer subtrees bottom-up. Pure function; no env.
 pub fn fold(node: &Node) -> Node {
     match node {
-        Node::Binary { op, left, right, span } => {
+        Node::Binary {
+            op,
+            left,
+            right,
+            span,
+        } => {
             let l = fold(left);
             let r = fold(right);
             if let (Node::Lit(Literal::Int(a), _), Node::Lit(Literal::Int(b), _)) = (&l, &r) {
@@ -26,7 +31,12 @@ pub fn fold(node: &Node) -> Node {
                 };
                 Node::Lit(Literal::Int(v), *span)
             } else {
-                Node::Binary { op: *op, left: Box::new(l), right: Box::new(r), span: *span }
+                Node::Binary {
+                    op: *op,
+                    left: Box::new(l),
+                    right: Box::new(r),
+                    span: *span,
+                }
             }
         }
         Node::Paren(inner, span) => {

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -106,7 +106,10 @@ pub fn install_package(path: &str, target_dir: &str) -> Result<()> {
     for entry in archive.entries()? {
         let mut entry = entry?;
         let entry_path = entry.path()?.into_owned();
-        if entry_path.components().any(|c| matches!(c, Component::ParentDir)) {
+        if entry_path
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
+        {
             return Err(anyhow!("package contains invalid path traversal entries"));
         }
         if entry_path.as_ref() == Path::new("package.toml") {
@@ -129,5 +132,8 @@ pub fn install_package(path: &str, target_dir: &str) -> Result<()> {
 
 pub fn default_install_dir(manifest: &MindManifest) -> Result<PathBuf> {
     let home = dirs::home_dir().ok_or_else(|| anyhow!("unable to determine home directory"))?;
-    Ok(home.join(".mind").join("packages").join(format!("{}-{}", manifest.name, manifest.version)))
+    Ok(home
+        .join(".mind")
+        .join("packages")
+        .join(format!("{}-{}", manifest.name, manifest.version)))
 }

--- a/src/stdlib/tensor.rs
+++ b/src/stdlib/tensor.rs
@@ -10,13 +10,22 @@ pub struct Tensor<T> {
 
 impl<T> Tensor<T> {
     pub fn zeros(shape: &[usize]) -> Self {
-        Self { shape: shape.to_vec(), _t: PhantomData }
+        Self {
+            shape: shape.to_vec(),
+            _t: PhantomData,
+        }
     }
     pub fn ones(shape: &[usize]) -> Self {
-        Self { shape: shape.to_vec(), _t: PhantomData }
+        Self {
+            shape: shape.to_vec(),
+            _t: PhantomData,
+        }
     }
     pub fn reshape(&self, new_shape: &[usize]) -> Self {
-        Self { shape: new_shape.to_vec(), _t: PhantomData }
+        Self {
+            shape: new_shape.to_vec(),
+            _t: PhantomData,
+        }
     }
     pub fn shape(&self) -> &[usize] {
         &self.shape

--- a/src/types/infer.rs
+++ b/src/types/infer.rs
@@ -21,5 +21,8 @@ pub fn unify(a: &TensorType, b: &TensorType) -> TensorType {
         };
         out.push(r);
     }
-    TensorType { dtype: a.dtype.clone(), shape: out }
+    TensorType {
+        dtype: a.dtype.clone(),
+        shape: out,
+    }
 }

--- a/tests/cli_build.rs
+++ b/tests/cli_build.rs
@@ -7,10 +7,12 @@ use mind::eval;
 use tempfile::tempdir;
 
 fn ensure_toolchain() -> bool {
-    eval::resolve_mlir_build_tools().map(|_| true).unwrap_or_else(|err| {
-        eprintln!("Skipping CLI build test: {err}");
-        false
-    })
+    eval::resolve_mlir_build_tools()
+        .map(|_| true)
+        .unwrap_or_else(|err| {
+            eprintln!("Skipping CLI build test: {err}");
+            false
+        })
 }
 
 #[test]

--- a/tests/cli_eval.rs
+++ b/tests/cli_eval.rs
@@ -8,7 +8,14 @@ fn _ignore_in_release_mode() {}
 #[test]
 fn mind_eval_basic_expr() {
     let output = Command::new("cargo")
-        .args(["run", "--quiet", "--no-default-features", "--", "eval", "2 + 3 * 4"])
+        .args([
+            "run",
+            "--quiet",
+            "--no-default-features",
+            "--",
+            "eval",
+            "2 + 3 * 4",
+        ])
         .output()
         .expect("run");
 

--- a/tests/conv2d_exec.rs
+++ b/tests/conv2d_exec.rs
@@ -10,7 +10,16 @@ fn conv2d_valid_runs() {
     "#;
 
     let output = Command::new("cargo")
-        .args(["run", "--quiet", "--features", "cpu-exec cpu-conv", "--", "eval", "--exec", src])
+        .args([
+            "run",
+            "--quiet",
+            "--features",
+            "cpu-exec cpu-conv",
+            "--",
+            "eval",
+            "--exec",
+            src,
+        ])
         .output()
         .unwrap();
     assert!(output.status.success());

--- a/tests/diagnostics_parse.rs
+++ b/tests/diagnostics_parse.rs
@@ -6,8 +6,11 @@ fn shows_pretty_error_for_unexpected_paren() {
     let Err(diags) = parser::parse_with_diagnostics(src) else {
         panic!("expected error");
     };
-    let joined =
-        diags.iter().map(|d| mind::diagnostics::render(src, d)).collect::<Vec<_>>().join("\n");
+    let joined = diags
+        .iter()
+        .map(|d| mind::diagnostics::render(src, d))
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(joined.contains("error"));
     assert!(joined.contains("line 1"));
     assert!(joined.contains("^")); // caret present

--- a/tests/mlir_build.rs
+++ b/tests/mlir_build.rs
@@ -25,7 +25,9 @@ fn resolve_or_skip() -> Option<eval::MlirBuildTools> {
 
 #[test]
 fn build_emits_mlir_and_llvm() {
-    let Some(tools) = resolve_or_skip() else { return };
+    let Some(tools) = resolve_or_skip() else {
+        return;
+    };
     let (mlir_src, preset) = parse_and_lower("let x = 1; x + 2");
     let dir = tempdir().expect("tempdir");
     let mlir_path = dir.path().join("out.mlir");
@@ -59,7 +61,9 @@ fn build_emits_mlir_and_llvm() {
 
 #[test]
 fn build_emits_object_file() {
-    let Some(tools) = resolve_or_skip() else { return };
+    let Some(tools) = resolve_or_skip() else {
+        return;
+    };
     let (mlir_src, preset) = parse_and_lower("let x = 1; x * 3");
     let dir = tempdir().expect("tempdir");
     let obj_path = dir.path().join("out.o");
@@ -81,7 +85,9 @@ fn build_emits_object_file() {
 
 #[test]
 fn build_emits_shared_library() {
-    let Some(tools) = resolve_or_skip() else { return };
+    let Some(tools) = resolve_or_skip() else {
+        return;
+    };
     let (mlir_src, preset) = parse_and_lower("let x = 1; x");
     let dir = tempdir().expect("tempdir");
     let lib_name = format!("test_artifact{}", std::env::consts::DLL_SUFFIX);

--- a/tests/mlir_exec.rs
+++ b/tests/mlir_exec.rs
@@ -20,7 +20,11 @@ fn mlir_exec_scalar_add() {
         ])
         .output()
         .expect("run mlir exec");
-    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("3"), "stdout: {}", stdout);
 }
@@ -35,17 +39,43 @@ fn parity_cpu_vs_mlir_exec_simple() {
     let src = "let x: Tensor[f32,(2,2)] = 1; tensor.sum(x + 2)";
 
     let cpu = std::process::Command::new("cargo")
-        .args(["run", "--quiet", "--features", "cpu-exec", "--", "eval", "--exec", src])
+        .args([
+            "run",
+            "--quiet",
+            "--features",
+            "cpu-exec",
+            "--",
+            "eval",
+            "--exec",
+            src,
+        ])
         .output()
         .expect("run cpu exec");
-    assert!(cpu.status.success(), "cpu stderr: {}", String::from_utf8_lossy(&cpu.stderr));
+    assert!(
+        cpu.status.success(),
+        "cpu stderr: {}",
+        String::from_utf8_lossy(&cpu.stderr)
+    );
     let cpu_stdout = String::from_utf8_lossy(&cpu.stdout).trim().to_string();
 
     let mlir = std::process::Command::new("cargo")
-        .args(["run", "--quiet", "--features", "mlir-exec", "--", "eval", "--mlir-exec", src])
+        .args([
+            "run",
+            "--quiet",
+            "--features",
+            "mlir-exec",
+            "--",
+            "eval",
+            "--mlir-exec",
+            src,
+        ])
         .output()
         .expect("run mlir exec");
-    assert!(mlir.status.success(), "mlir stderr: {}", String::from_utf8_lossy(&mlir.stderr));
+    assert!(
+        mlir.status.success(),
+        "mlir stderr: {}",
+        String::from_utf8_lossy(&mlir.stderr)
+    );
     let mlir_stdout = String::from_utf8_lossy(&mlir.stdout).trim().to_string();
 
     assert!(

--- a/tests/mlir_export_indexing.rs
+++ b/tests/mlir_export_indexing.rs
@@ -14,8 +14,17 @@ fn mlir_export_handles_index_slice_and_gather() {
     let ir = eval::lower_to_ir(&module);
     let mlir = eval::to_mlir(&ir, "main");
 
-    assert!(mlir.contains("tensor.extract"), "expected tensor.extract in {mlir}");
-    assert!(mlir.contains("tensor.extract_slice"), "expected tensor.extract_slice in {mlir}");
-    assert!(mlir.contains("tensor.insert"), "expected tensor.insert in {mlir}");
+    assert!(
+        mlir.contains("tensor.extract"),
+        "expected tensor.extract in {mlir}"
+    );
+    assert!(
+        mlir.contains("tensor.extract_slice"),
+        "expected tensor.extract_slice in {mlir}"
+    );
+    assert!(
+        mlir.contains("tensor.insert"),
+        "expected tensor.insert in {mlir}"
+    );
     assert!(mlir.contains("scf.for"), "expected scf.for in {mlir}");
 }

--- a/tests/mlir_export_linalg.rs
+++ b/tests/mlir_export_linalg.rs
@@ -16,5 +16,8 @@ fn mlir_export_emits_linalg_dot_and_matmul() {
     let mlir = eval::to_mlir(&ir, "main");
 
     assert!(mlir.contains("linalg.dot"), "expected linalg.dot in {mlir}");
-    assert!(mlir.contains("linalg.matmul"), "expected linalg.matmul in {mlir}");
+    assert!(
+        mlir.contains("linalg.matmul"),
+        "expected linalg.matmul in {mlir}"
+    );
 }

--- a/tests/mlir_export_reductions.rs
+++ b/tests/mlir_export_reductions.rs
@@ -11,7 +11,10 @@ fn mlir_export_reductions_cover_sum_and_mean() {
     let ir = eval::lower_to_ir(&module);
     let mlir = eval::to_mlir(&ir, "main");
 
-    assert!(mlir.contains("tensor.reduce"), "expected tensor.reduce in {mlir}");
+    assert!(
+        mlir.contains("tensor.reduce"),
+        "expected tensor.reduce in {mlir}"
+    );
     assert!(mlir.contains("arith.addf"), "expected arith.addf in {mlir}");
     assert!(mlir.contains("arith.divf"), "expected arith.divf in {mlir}");
 }

--- a/tests/mlir_export_shape.rs
+++ b/tests/mlir_export_shape.rs
@@ -13,6 +13,12 @@ fn mlir_export_covers_shape_ops() {
     let ir = eval::lower_to_ir(&module);
     let mlir = eval::to_mlir(&ir, "main");
 
-    assert!(mlir.contains("tensor.reshape"), "expected tensor.reshape in {mlir}");
-    assert!(mlir.contains("linalg.transpose"), "expected linalg.transpose in {mlir}");
+    assert!(
+        mlir.contains("tensor.reshape"),
+        "expected tensor.reshape in {mlir}"
+    );
+    assert!(
+        mlir.contains("linalg.transpose"),
+        "expected linalg.transpose in {mlir}"
+    );
 }

--- a/tests/package_basic.rs
+++ b/tests/package_basic.rs
@@ -24,11 +24,19 @@ fn build_and_inspect_roundtrip() {
 
     let package_path = dir.path().join("demo.mindpkg");
     let artifact = model_path.to_string_lossy().into_owned();
-    build_package(package_path.to_str().expect("package path"), &[artifact.as_str()], &manifest)
-        .expect("package build");
+    build_package(
+        package_path.to_str().expect("package path"),
+        &[artifact.as_str()],
+        &manifest,
+    )
+    .expect("package build");
 
     let parsed =
         inspect_package(package_path.to_str().expect("package path")).expect("inspect package");
     assert_eq!(parsed.name, "demo");
-    assert!(parsed.checksums.as_ref().expect("checksums present").contains_key("model.mlir"));
+    assert!(parsed
+        .checksums
+        .as_ref()
+        .expect("checksums present")
+        .contains_key("model.mlir"));
 }

--- a/tests/relu_exec.rs
+++ b/tests/relu_exec.rs
@@ -5,7 +5,16 @@ fn relu_exec_non_negative() {
 
     let program = "let x: Tensor[f32,(1,4)] = 0; x = x - 3; tensor.relu(x + 1)";
     let output = Command::new("cargo")
-        .args(["run", "--quiet", "--features", "cpu-exec", "--", "eval", "--exec", program])
+        .args([
+            "run",
+            "--quiet",
+            "--features",
+            "cpu-exec",
+            "--",
+            "eval",
+            "--exec",
+            program,
+        ])
         .output()
         .unwrap();
     assert!(output.status.success());

--- a/tests/type_error_spans.rs
+++ b/tests/type_error_spans.rs
@@ -9,10 +9,16 @@ fn unknown_ident_points_to_name() {
     let diags = type_checker::check_module_types(&module, src, &HashMap::new());
     assert!(!diags.is_empty(), "expected type error diagnostic");
     let rendered = diagnostics::render(src, &diags[0]);
-    assert!(rendered.contains("x + 1"), "diagnostic missing offending line: {rendered}");
+    assert!(
+        rendered.contains("x + 1"),
+        "diagnostic missing offending line: {rendered}"
+    );
     let line = "let n: i32 = x + 1";
     let x_idx = line.find('x').unwrap();
     let caret_line = rendered.lines().last().unwrap_or("");
     let caret_pos = caret_line.find('^').unwrap_or(usize::MAX);
-    assert!(caret_pos >= x_idx.saturating_sub(2), "caret not near identifier: {rendered}");
+    assert!(
+        caret_pos >= x_idx.saturating_sub(2),
+        "caret not near identifier: {rendered}"
+    );
 }


### PR DESCRIPTION
## Summary
- remove nightly-only rustfmt keys so stable rustfmt can run without warnings
- apply `cargo fmt` with the stable configuration across the codebase

## Testing
- cargo fmt --all

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d6d4774c8322b38cbbb507cb0c9c)