### PR TITLE
Ensure CI uses pinned stable toolchain with rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.81.0
+        with:
+          components: rustfmt, clippy
 
       - name: Remove git proxies (belt-and-suspenders)
         run: |


### PR DESCRIPTION
## Summary
- pin the CI workflow to Rust 1.81.0 with rustfmt and clippy components preinstalled to avoid channel downloads
- keep the formatting check on the preinstalled toolchain by running plain `cargo fmt -- --check`

## Testing
- not run (CI only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d9deca08832297aa980602cb416f)