### PR TITLE
Update CI to use Rust 1.83 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@1.81.0
+      - name: Install Rust (stable, edition-2024 ready)
+        uses: dtolnay/rust-toolchain@1.83.0
         with:
           components: rustfmt, clippy
 


### PR DESCRIPTION
## Summary
- update the CI workflow to install Rust 1.83.0 with edition-2024 support

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912dd4079588322b280196318260bc8)