### PR TITLE
Pin home crate to 0.5.11 for stable builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
         shell: bash
         run: |
           set -e
-          # If the locked metadata fails because the lockfile is stale, refresh it.
-          if ! cargo metadata --format-version=1 --locked >/dev/null 2>&1; then
-            echo "Cargo.lock is stale; refreshing in CI workspace"
-            cargo generate-lockfile
+          echo "Patching transitive 'home' crate to 0.5.11 (avoid edition2024)."
+          if ! grep -q 'name = "home"' Cargo.lock >/dev/null 2>&1 || ! grep -q 'version = "0.5.11"' Cargo.lock; then
+            cargo update -p home --precise 0.5.11
           fi
+          test -f Cargo.lock || cargo generate-lockfile
 
       - name: Cargo metadata (smoke)
         run: cargo metadata --format-version=1 --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,6 @@ registry = []
 
 [build-dependencies]
 cc = "1"
+
+[patch.crates-io]
+home = "=0.5.11"


### PR DESCRIPTION
## Summary
- add a crates.io patch to force `home` 0.5.11 so builds avoid the edition-2024 requirement
- refresh the CI lockfile preparation step to update the pinned crate before locked runs

## Testing
- not run (network-restricted environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e41fd7a883228ef93e606c918196)