### PR TITLE
Use nightly toolchain in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust (stable, edition-2024 ready)
-        uses: dtolnay/rust-toolchain@1.83.0
+      - name: Install Rust (nightly; supports edition2024)
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rustfmt, clippy
+          toolchain: nightly
+          components: clippy,rustfmt
 
       - name: Remove git proxies (belt-and-suspenders)
         run: |


### PR DESCRIPTION
## Summary
- switch the CI workflow to install the nightly Rust toolchain so edition2024 crates resolve with the existing lockfile

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e9d599408322937818b62b365d79)