### PR TITLE
fmt(ci): split grouped imports to satisfy rustfmt --check

### DIFF
--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -40,7 +40,7 @@ fn offset_to_loc(src: &str, offset: usize) -> Location {
 }
 
 /// Extract the single source line containing `span.start`.
-fn line_at(src: &str, span: Span) -> (String, usize /*line_start_offset*/) {
+fn line_at(src: &str, span: Span) -> (String, usize /* line_start_offset */) {
     let bytes = src.as_bytes();
     let mut b = span.start;
     while b > 0 && bytes[b - 1] != b'\n' {

--- a/src/eval/autodiff.rs
+++ b/src/eval/autodiff.rs
@@ -1,16 +1,22 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 use crate::ast;
 use crate::eval::TensorVal;
-use crate::linalg::{self, MatMulShapeInfo};
+use crate::linalg::MatMulShapeInfo;
+use crate::linalg::{self};
 
 #[derive(Clone)]
 pub struct TensorEnvEntry {
     pub value: TensorVal,
     pub expr: Option<ast::Node>,
 }
-use crate::types::{ConvPadding, DType, ShapeDim};
+use crate::types::ConvPadding;
+use crate::types::DType;
+use crate::types::ShapeDim;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NodeId(usize);

--- a/src/eval/ir_interp.rs
+++ b/src/eval/ir_interp.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
 
-use crate::eval::value::{TensorVal, Value};
-use crate::ir::{BinOp, IRModule, Instr, ValueId};
+use crate::eval::value::TensorVal;
+use crate::eval::value::Value;
+use crate::ir::BinOp;
+use crate::ir::IRModule;
+use crate::ir::Instr;
+use crate::ir::ValueId;
 use crate::types::ShapeDim;
 
 pub fn eval_ir(ir: &IRModule) -> Value {

--- a/src/eval/lower.rs
+++ b/src/eval/lower.rs
@@ -1,8 +1,16 @@
 use std::collections::HashMap;
 
-use crate::ast::{self, Literal, TypeAnn};
-use crate::ir::{BinOp, IRModule, IndexSpec, Instr, SliceSpec, ValueId};
-use crate::types::{DType, ShapeDim};
+use crate::ast::Literal;
+use crate::ast::TypeAnn;
+use crate::ast::{self};
+use crate::ir::BinOp;
+use crate::ir::IRModule;
+use crate::ir::IndexSpec;
+use crate::ir::Instr;
+use crate::ir::SliceSpec;
+use crate::ir::ValueId;
+use crate::types::DType;
+use crate::types::ShapeDim;
 
 pub fn lower_to_ir(module: &ast::Module) -> IRModule {
     let mut ir = IRModule::new();

--- a/src/eval/mlir_build.rs
+++ b/src/eval/mlir_build.rs
@@ -3,9 +3,15 @@ use std::io::Write;
 #[cfg(feature = "mlir-build")]
 use std::path::Path;
 #[cfg(feature = "mlir-build")]
-use std::process::{Child, Command, Stdio};
+use std::process::Child;
 #[cfg(feature = "mlir-build")]
-use std::time::{Duration, Instant};
+use std::process::Command;
+#[cfg(feature = "mlir-build")]
+use std::process::Stdio;
+#[cfg(feature = "mlir-build")]
+use std::time::Duration;
+#[cfg(feature = "mlir-build")]
+use std::time::Instant;
 
 #[cfg(feature = "mlir-build")]
 use tempfile::NamedTempFile;


### PR DESCRIPTION
## Summary
- split grouped imports in eval modules to align with rustfmt expectations
- normalize diagnostics line_at comment spacing per rustfmt output

## Testing
- `cargo fmt -- --check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f3f4caf48322bd7b07c69bb20920)