### PR TITLE
fmt: make rustfmt --check pass; unblock Clippy

### DIFF
--- a/src/eval/autodiff.rs
+++ b/src/eval/autodiff.rs
@@ -6,8 +6,8 @@ use std::sync::atomic::Ordering;
 
 use crate::ast;
 use crate::eval::TensorVal;
+use crate::linalg;
 use crate::linalg::MatMulShapeInfo;
-use crate::linalg::{self};
 
 #[derive(Clone)]
 pub struct TensorEnvEntry {

--- a/src/eval/lower.rs
+++ b/src/eval/lower.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
+use crate::ast;
 use crate::ast::Literal;
 use crate::ast::TypeAnn;
-use crate::ast::{self};
+
 use crate::ir::BinOp;
 use crate::ir::IRModule;
 use crate::ir::IndexSpec;

--- a/src/eval/mlir_export.rs
+++ b/src/eval/mlir_export.rs
@@ -1,8 +1,20 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use crate::ir::{BinOp, IRModule, IndexSpec, Instr, SliceSpec, ValueId};
-use crate::types::{DType, ShapeDim};
+use crate::ir::BinOp;
+
+use crate::ir::IRModule;
+
+use crate::ir::IndexSpec;
+
+use crate::ir::Instr;
+
+use crate::ir::SliceSpec;
+
+use crate::ir::ValueId;
+
+use crate::types::DType;
+use crate::types::ShapeDim;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MlirEmitMode {

--- a/src/eval/mlir_opt.rs
+++ b/src/eval/mlir_opt.rs
@@ -19,13 +19,19 @@ impl MlirOptOutput {
 }
 
 #[cfg(feature = "mlir-subprocess")]
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
+
 #[cfg(feature = "mlir-subprocess")]
-use std::{
-    io::Write,
-    process::{Child, Command, Stdio},
-    thread,
-};
+use std::io::Write;
+#[cfg(feature = "mlir-subprocess")]
+use std::process::Child;
+#[cfg(feature = "mlir-subprocess")]
+use std::process::Command;
+#[cfg(feature = "mlir-subprocess")]
+use std::process::Stdio;
+#[cfg(feature = "mlir-subprocess")]
+use std::thread;
 
 #[cfg(feature = "mlir-subprocess")]
 pub fn run_mlir_opt(

--- a/src/eval/mlir_run.rs
+++ b/src/eval/mlir_run.rs
@@ -2,7 +2,8 @@
 use std::path::PathBuf;
 
 #[cfg(feature = "mlir-exec")]
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 #[cfg(feature = "mlir-exec")]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -29,7 +30,9 @@ impl Default for MlirExecConfig {
 pub fn exec_mlir_text(mlir: &str, cfg: &MlirExecConfig) -> Result<String, String> {
     use std::env;
     use std::io::Write;
-    use std::process::{Child, Command, Stdio};
+    use std::process::Child;
+    use std::process::Command;
+    use std::process::Stdio;
 
     use tempfile::NamedTempFile;
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,8 +1,21 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
 
-use crate::ast::{BinOp, Literal, Module, Node, TypeAnn};
+use crate::ast::BinOp;
+
+use crate::ast::Literal;
+
+use crate::ast::Module;
+
+use crate::ast::Node;
+
+use crate::ast::TypeAnn;
+
 use crate::eval::autodiff::TensorEnvEntry;
-use crate::types::{DType, ShapeDim, ValueType};
+use crate::types::DType;
+use crate::types::ShapeDim;
+use crate::types::ValueType;
 
 #[cfg(feature = "cpu-exec")]
 use crate::exec;
@@ -28,17 +41,28 @@ pub mod value;
 pub use ir_interp::eval_ir;
 pub use lower::lower_to_ir;
 #[cfg(feature = "mlir-build")]
-pub use mlir_build::{
-    build_all as build_mlir_artifacts, resolve_tools as resolve_mlir_build_tools,
-    BuildError as MlirBuildError, BuildOptions as MlirBuildOptions,
-    BuildProducts as MlirBuildProducts, BuildTools as MlirBuildTools,
-};
-pub use mlir_export::{
-    emit_mlir_with_opts, to_mlir, MlirEmitMode, MlirEmitOptions, MlirLowerPreset,
-};
+pub use mlir_build::build_all as build_mlir_artifacts;
+#[cfg(feature = "mlir-build")]
+pub use mlir_build::resolve_tools as resolve_mlir_build_tools;
+#[cfg(feature = "mlir-build")]
+pub use mlir_build::BuildError as MlirBuildError;
+#[cfg(feature = "mlir-build")]
+pub use mlir_build::BuildOptions as MlirBuildOptions;
+#[cfg(feature = "mlir-build")]
+pub use mlir_build::BuildProducts as MlirBuildProducts;
+#[cfg(feature = "mlir-build")]
+pub use mlir_build::BuildTools as MlirBuildTools;
+pub use mlir_export::emit_mlir_with_opts;
+pub use mlir_export::to_mlir;
+pub use mlir_export::MlirEmitMode;
+pub use mlir_export::MlirEmitOptions;
+pub use mlir_export::MlirLowerPreset;
 #[cfg(feature = "mlir-exec")]
 pub use mlir_run::MlirExecConfig;
-pub use value::{format_value_human, TensorVal, Value, VarId};
+pub use value::format_value_human;
+pub use value::TensorVal;
+pub use value::Value;
+pub use value::VarId;
 
 pub fn emit_mlir_string(ir: &crate::ir::IRModule, preset: mlir_export::MlirLowerPreset) -> String {
     let opts = mlir_export::MlirEmitOptions {

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -1,15 +1,32 @@
-use std::collections::{BTreeSet, HashMap};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::BTreeSet;
+use std::collections::HashMap;
 
-use crate::ast::{Literal, Node};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use crate::ast::Literal;
+
+use crate::ast::Node;
+
 use crate::eval::autodiff::TensorEnvEntry;
-use crate::eval::{
-    eval_value_expr_mode, format_value_human, EvalError, ExecMode, TensorVal, Value,
-};
+use crate::eval::eval_value_expr_mode;
+use crate::eval::format_value_human;
+use crate::eval::EvalError;
+use crate::eval::ExecMode;
+use crate::eval::TensorVal;
+use crate::eval::Value;
+
 #[cfg(feature = "cpu-buffers")]
-use crate::eval::{materialize_filled, num_elems, MATERIALIZE_MAX};
-use crate::linalg::{self, MatMulShapeInfo};
-use crate::types::{ConvPadding, DType, ShapeDim};
+use crate::eval::materialize_filled;
+use crate::eval::num_elems;
+use crate::eval::MATERIALIZE_MAX;
+
+use crate::linalg;
+use crate::linalg::MatMulShapeInfo;
+
+use crate::types::ConvPadding;
+use crate::types::DType;
+use crate::types::ShapeDim;
 
 #[cfg(feature = "cpu-buffers")]
 use crate::eval::value::Buffer;

--- a/src/eval/value.rs
+++ b/src/eval/value.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeMap;
 
-use crate::types::{DType, ShapeDim, TensorType};
+use crate::types::DType;
+
+use crate::types::ShapeDim;
+
+use crate::types::TensorType;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct VarId(pub String);
@@ -202,7 +206,8 @@ fn format_buffer_sample(buf: &Buffer, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{DType, ShapeDim};
+    use crate::types::DType;
+    use crate::types::ShapeDim;
 
     #[test]
     fn format_tensor_fill_trim() {

--- a/src/exec/conv.rs
+++ b/src/exec/conv.rs
@@ -1,5 +1,6 @@
 use crate::eval::value::TensorVal;
-use crate::types::{ConvPadding, ShapeDim};
+use crate::types::ConvPadding;
+use crate::types::ShapeDim;
 
 use super::cpu::ExecError;
 

--- a/src/exec/cpu.rs
+++ b/src/exec/cpu.rs
@@ -2,7 +2,8 @@
 
 use crate::eval::value::TensorVal;
 use crate::exec::simd_chunks_mut;
-use crate::types::{DType, ShapeDim};
+use crate::types::DType;
+use crate::types::ShapeDim;
 
 #[derive(Debug)]
 pub enum ExecError {

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -4,7 +4,10 @@
 pub mod capi {
     use std::cell::RefCell;
     use std::ffi::CString;
-    use std::os::raw::{c_char, c_int, c_void};
+    use std::os::raw::c_char;
+    use std::os::raw::c_int;
+    use std::os::raw::c_void;
+
     use std::ptr;
 
     #[repr(C)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,4 +1,6 @@
-use crate::types::{DType, ShapeDim};
+use crate::types::DType;
+use crate::types::ShapeDim;
+
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,21 +5,36 @@
 //!   mind repl
 
 #[cfg(feature = "pkg")]
-use anyhow::{anyhow, Context, Result};
-use clap::{Args, Parser, Subcommand};
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+
+use clap::Args;
+use clap::Parser;
+use clap::Subcommand;
+
 #[cfg(feature = "pkg")]
-use mind::package::{
-    build_package, default_install_dir, inspect_package, install_package, MindManifest,
-};
-use mind::{diagnostics, eval, parser};
+use mind::package::build_package;
+use mind::package::default_install_dir;
+use mind::package::inspect_package;
+use mind::package::install_package;
+use mind::package::MindManifest;
+
+use mind::diagnostics;
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
-use std::io::{self, Write};
+use std::io;
+use std::io::Write;
+
+#[cfg(feature = "pkg")]
+use std::fs;
+use std::path::Path;
 #[cfg(any(feature = "mlir-build", feature = "pkg"))]
 use std::path::PathBuf;
 #[cfg(feature = "mlir-exec")]
 use std::time::Duration;
-#[cfg(feature = "pkg")]
-use std::{fs, path::Path};
 
 struct EmitOpts {
     emit_mlir_stdout: bool,

--- a/src/opt/fold.rs
+++ b/src/opt/fold.rs
@@ -1,4 +1,6 @@
-use crate::ast::{BinOp, Literal, Node};
+use crate::ast::BinOp;
+use crate::ast::Literal;
+use crate::ast::Node;
 
 /// Fold constant integer subtrees bottom-up. Pure function; no env.
 pub fn fold(node: &Node) -> Node {

--- a/src/package/manifest.rs
+++ b/src/package/manifest.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct MindManifest {

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -3,16 +3,31 @@ mod manifest;
 pub use manifest::MindManifest;
 
 use std::collections::BTreeMap;
-use std::fs::{self, File};
-use std::io::{Cursor, Read};
-use std::path::{Component, Path, PathBuf};
+use std::fs;
+use std::fs::File;
 
-use anyhow::{anyhow, Context, Result};
+use std::io::Cursor;
+use std::io::Read;
+
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::anyhow;
+
+use anyhow::Context;
+
+use anyhow::Result;
+
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use sha2::{Digest, Sha256};
-use tar::{Archive, Builder, Header};
+use sha2::Digest;
+use sha2::Sha256;
+
+use tar::Archive;
+use tar::Builder;
+use tar::Header;
 
 pub fn build_package(out_path: &str, files: &[&str], manifest: &MindManifest) -> Result<()> {
     if manifest.files.len() != files.len() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,7 +7,18 @@
 
 use chumsky::prelude::*;
 
-use crate::ast::{BinOp, Literal, Module, Node, Span, TypeAnn};
+use crate::ast::BinOp;
+
+use crate::ast::Literal;
+
+use crate::ast::Module;
+
+use crate::ast::Node;
+
+use crate::ast::Span;
+
+use crate::ast::TypeAnn;
+
 use crate::diagnostics::Diagnostic as PrettyDiagnostic;
 use crate::types::ConvPadding;
 

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -1,10 +1,28 @@
-use std::collections::{BTreeSet, HashMap};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::BTreeSet;
+use std::collections::HashMap;
 
-use crate::ast::{BinOp, Literal, Module, Node, Span as AstSpan};
-use crate::diagnostics::{Diagnostic as Pretty, Location};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use crate::ast::BinOp;
+
+use crate::ast::Literal;
+
+use crate::ast::Module;
+
+use crate::ast::Node;
+
+use crate::ast::Span as AstSpan;
+
+use crate::diagnostics::Diagnostic as Pretty;
+use crate::diagnostics::Location;
+
 use crate::linalg;
-use crate::types::{ConvPadding, DType, ShapeDim, TensorType, ValueType};
+use crate::types::ConvPadding;
+use crate::types::DType;
+use crate::types::ShapeDim;
+use crate::types::TensorType;
+use crate::types::ValueType;
 
 #[derive(Debug)]
 pub struct TypeErrSpan {

--- a/src/types/infer.rs
+++ b/src/types/infer.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code, unused_variables, unused_imports)]
-use super::{ShapeDim, TensorType};
+use super::ShapeDim;
+use super::TensorType;
 
 /// Left-biased, minimal unifier for Phase 1.
 /// - Known==Known => Known

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -105,7 +105,9 @@ impl TensorType {
 
 #[cfg(test)]
 mod tests {
-    use super::{DType, ShapeDim, TensorType};
+    use super::DType;
+    use super::ShapeDim;
+    use super::TensorType;
 
     #[test]
     fn tensor_type_new_covers_constructor() {

--- a/tests/autodiff_preview.rs
+++ b/tests/autodiff_preview.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/const_folding.rs
+++ b/tests/const_folding.rs
@@ -1,4 +1,6 @@
-use mind::{ast::Node, opt::fold, parser};
+use mind::ast::Node;
+use mind::opt::fold;
+use mind::parser;
 
 #[test]
 fn folds_simple_arith() {

--- a/tests/dot_variants.rs
+++ b/tests/dot_variants.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/exec_basic.rs
+++ b/tests/exec_basic.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "cpu-exec")]
 mod cpu {
-    use mind::{eval, parser};
+    use mind::eval;
+    use mind::parser;
+
     use std::collections::HashMap;
 
     #[test]

--- a/tests/expr_parser.rs
+++ b/tests/expr_parser.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn precedence_and_parens() {

--- a/tests/index_slice_preview.rs
+++ b/tests/index_slice_preview.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/ir_lower.rs
+++ b/tests/ir_lower.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn lower_and_eval_add_ints() {

--- a/tests/linalg_grad.rs
+++ b/tests/linalg_grad.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/linalg_preview.rs
+++ b/tests/linalg_preview.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/mlir_build.rs
+++ b/tests/mlir_build.rs
@@ -3,7 +3,10 @@
 use std::fs;
 use std::time::Duration;
 
-use mind::{eval, parser};
+use mind::eval;
+
+use mind::parser;
+
 use tempfile::tempdir;
 
 fn parse_and_lower(src: &str) -> (String, eval::MlirLowerPreset) {

--- a/tests/mlir_export.rs
+++ b/tests/mlir_export.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn mlir_export_basic() {

--- a/tests/mlir_export_indexing.rs
+++ b/tests/mlir_export_indexing.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn mlir_export_handles_index_slice_and_gather() {

--- a/tests/mlir_export_linalg.rs
+++ b/tests/mlir_export_linalg.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn mlir_export_emits_linalg_dot_and_matmul() {

--- a/tests/mlir_export_reductions.rs
+++ b/tests/mlir_export_reductions.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn mlir_export_reductions_cover_sum_and_mean() {

--- a/tests/mlir_export_shape.rs
+++ b/tests/mlir_export_shape.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn mlir_export_covers_shape_ops() {

--- a/tests/mlir_file_and_lower.rs
+++ b/tests/mlir_file_and_lower.rs
@@ -1,4 +1,5 @@
-use std::{fs, process::Command};
+use std::fs;
+use std::process::Command;
 
 use tempfile::tempdir;
 

--- a/tests/mlir_gpu.rs
+++ b/tests/mlir_gpu.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "mlir-gpu")]
 
-use mind::{eval, parser};
+use mind::eval;
+
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/mlir_jit.rs
+++ b/tests/mlir_jit.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "mlir-jit")]
 
-use mind::{eval, parser};
+use mind::eval;
+
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/mlir_opt.rs
+++ b/tests/mlir_opt.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "mlir-subprocess")]
 
-use mind::{eval, parser};
+use mind::eval;
+
+use mind::parser;
 
 #[test]
 fn mlir_opt_runs_when_available() {

--- a/tests/package_basic.rs
+++ b/tests/package_basic.rs
@@ -2,7 +2,12 @@
 
 use std::fs;
 
-use mind::package::{build_package, inspect_package, MindManifest};
+use mind::package::build_package;
+
+use mind::package::inspect_package;
+
+use mind::package::MindManifest;
+
 use tempfile::tempdir;
 
 #[test]

--- a/tests/reductions_grad.rs
+++ b/tests/reductions_grad.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/reductions_preview.rs
+++ b/tests/reductions_preview.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/relu_preview.rs
+++ b/tests/relu_preview.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/repl_basic.rs
+++ b/tests/repl_basic.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
+use std::process::Stdio;
 
 #[cfg(not(debug_assertions))]
 #[ignore]

--- a/tests/shape_ops_preview.rs
+++ b/tests/shape_ops_preview.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,4 +1,7 @@
-use mind::{lexer, parser, type_checker, types::ValueType};
+use mind::lexer;
+use mind::parser;
+use mind::type_checker;
+use mind::types::ValueType;
 
 #[test]
 fn lex_parse_check_minimal() {

--- a/tests/tensor_broadcast.rs
+++ b/tests/tensor_broadcast.rs
@@ -1,7 +1,9 @@
-use mind::{
-    parser, type_checker,
-    types::{DType, ShapeDim, TensorType, ValueType},
-};
+use mind::parser;
+use mind::type_checker;
+use mind::types::DType;
+use mind::types::ShapeDim;
+use mind::types::TensorType;
+use mind::types::ValueType;
 use std::collections::HashMap;
 
 #[test]

--- a/tests/tensor_eval.rs
+++ b/tests/tensor_eval.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/tensor_stdlib.rs
+++ b/tests/tensor_stdlib.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use mind::{eval, parser};
+use mind::eval;
+
+use mind::parser;
 
 fn eval_source(src: &str) -> eval::Value {
     let module = parser::parse(src).unwrap();

--- a/tests/tensor_symbolic.rs
+++ b/tests/tensor_symbolic.rs
@@ -1,7 +1,9 @@
-use mind::{
-    parser, type_checker,
-    types::{DType, ShapeDim, TensorType, ValueType},
-};
+use mind::parser;
+use mind::type_checker;
+use mind::types::DType;
+use mind::types::ShapeDim;
+use mind::types::TensorType;
+use mind::types::ValueType;
 use std::collections::HashMap;
 
 #[test]

--- a/tests/transpose_preview.rs
+++ b/tests/transpose_preview.rs
@@ -1,4 +1,6 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/type_ann_check.rs
+++ b/tests/type_ann_check.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn scalar_annotation_matches() {

--- a/tests/type_error_spans.rs
+++ b/tests/type_error_spans.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use mind::{diagnostics, parser, type_checker};
+use mind::diagnostics;
+
+use mind::parser;
+
+use mind::type_checker;
 
 #[test]
 fn unknown_ident_points_to_name() {

--- a/tests/type_infer.rs
+++ b/tests/type_infer.rs
@@ -1,5 +1,7 @@
 use mind::types::infer::unify;
-use mind::types::{DType, ShapeDim, TensorType};
+use mind::types::DType;
+use mind::types::ShapeDim;
+use mind::types::TensorType;
 
 #[test]
 fn unify_known_and_sym() {

--- a/tests/typecheck_binary.rs
+++ b/tests/typecheck_binary.rs
@@ -1,4 +1,7 @@
-use mind::{parser, type_checker, types::ValueType};
+use mind::parser;
+use mind::type_checker;
+use mind::types::ValueType;
+
 use std::collections::HashMap;
 
 #[test]

--- a/tests/typecheck_env.rs
+++ b/tests/typecheck_env.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn env_prevents_unknown() {

--- a/tests/vars_assign.rs
+++ b/tests/vars_assign.rs
@@ -1,4 +1,5 @@
-use mind::{eval, parser};
+use mind::eval;
+use mind::parser;
 
 #[test]
 fn let_and_use_variable() {


### PR DESCRIPTION
## Summary
* split grouped imports into single-use statements to match stable formatting
* ran cargo fmt so that `cargo fmt -- --check` passes

## Testing
* `cargo fmt --all -- --check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f7a2444c832284f51cde7ea01857)