### PR TITLE
Fix no-feature builds by adding cpu-buffers fallbacks

### DIFF
--- a/src/eval/mlir_opt.rs
+++ b/src/eval/mlir_opt.rs
@@ -20,7 +20,6 @@ impl MlirOptOutput {
 
 #[cfg(feature = "mlir-subprocess")]
 use std::time::Duration;
-use std::time::Instant;
 
 #[cfg(feature = "mlir-subprocess")]
 use std::io::Write;
@@ -57,7 +56,7 @@ pub fn run_mlir_opt(
         stdin.write_all(mlir_input.as_bytes())?;
     }
 
-    let start = Instant::now();
+    let start = std::time::Instant::now();
     loop {
         if let Some(status) = child.try_wait()? {
             let (stdout, stderr) = collect_child_output(&mut child);

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -82,6 +82,14 @@ pub fn emit_mlir_to_file(
     std::fs::write(path, txt)
 }
 
+#[cfg(not(feature = "cpu-buffers"))]
+pub(crate) const MATERIALIZE_MAX: usize = 0;
+
+#[cfg(not(feature = "cpu-buffers"))]
+pub(crate) fn num_elems(_shape: &[ShapeDim]) -> Option<usize> {
+    None
+}
+
 #[cfg(feature = "cpu-buffers")]
 pub(crate) fn num_elems(shape: &[ShapeDim]) -> Option<usize> {
     let mut n: usize = 1;


### PR DESCRIPTION
## Summary
- add harmless fallbacks for `MATERIALIZE_MAX` and `num_elems` when `cpu-buffers` is disabled so tensor stdlib imports resolve
- drop the unused `Instant` import in `mlir_opt.rs` and qualify the timing call to keep the feature-gated code compiling cleanly

## Testing
- cargo fmt --all -- --check
- cargo build --no-default-features *(fails: `mind::package` is behind the `pkg` feature in the binary)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130741d4d48322a1784fe5ea5d583c)