### PR TITLE
Fix no-feature build by gating pkg CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,15 @@ jobs:
             cargo metadata --format-version=1
           fi
 
+      - name: Check compiles (no features)
+        shell: bash
+        run: |
+          if [ -f Cargo.lock ]; then
+            cargo check --no-default-features --locked
+          else
+            cargo check --no-default-features
+          fi
+
       - name: Build
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- gate the package CLI types and helpers behind the `pkg` feature so the binary builds without it
- add a CI check that runs `cargo check --no-default-features`

## Testing
- cargo fmt
- cargo check --no-default-features

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913099bbed08322bd728cb3c72ddebe)