### PR TITLE
Add feature compile matrix and fix pkg manifest parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,19 @@ jobs:
             cargo check --no-default-features
           fi
 
+      - name: Feature compile matrix
+        shell: bash
+        run: |
+          if [ -f Cargo.lock ]; then
+            cargo check --no-default-features --locked
+            cargo check --no-default-features --features cpu-exec --locked
+            cargo check --no-default-features --features pkg --locked
+          else
+            cargo check --no-default-features
+            cargo check --no-default-features --features cpu-exec
+            cargo check --no-default-features --features pkg
+          fi
+
       - name: Build
         shell: bash
         run: |

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -101,7 +101,8 @@ pub fn inspect_package(path: &str) -> Result<MindManifest> {
         return Err(anyhow!("package.toml not found in package"));
     }
 
-    let manifest: MindManifest = toml::from_slice(&manifest_data)?;
+    let manifest_toml = String::from_utf8(manifest_data)?;
+    let manifest: MindManifest = toml::from_str(&manifest_toml)?;
     Ok(manifest)
 }
 
@@ -127,7 +128,7 @@ pub fn install_package(path: &str, target_dir: &str) -> Result<()> {
         {
             return Err(anyhow!("package contains invalid path traversal entries"));
         }
-        if entry_path.as_ref() == Path::new("package.toml") {
+        if entry_path.as_path() == Path::new("package.toml") {
             // manifest handled separately
             let mut buf = Vec::new();
             entry.read_to_end(&mut buf)?;


### PR DESCRIPTION
## Summary
- add a feature compile matrix to the CI workflow ahead of the build/test/clippy stages
- fix package inspection to parse manifest data via UTF-8 strings and avoid ambiguous PathBuf comparisons

## Testing
- `cargo check --no-default-features`
- `cargo check --no-default-features --features cpu-exec`
- `cargo check --no-default-features --features pkg`
- `cargo fmt -- --check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691310593d188322954e5c9b8892cf6d)