### PR TITLE
ci: run rustfmt check on stable toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,13 @@ jobs:
             cargo test --verbose --no-default-features
           fi
 
-      - name: Check formatting
-        run: cargo fmt -- --check
+      - name: Install stable (fmt only)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting (stable)
+        run: cargo +stable fmt --all -- --check
 
       - name: Clippy
         shell: bash

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,5 @@
 max_width = 100
 use_small_heuristics = "Default"
-imports_granularity = "Item"
-group_imports = "StdExternalCrate"
 wrap_comments = true
+newline_style = "Unix"
 edition = "2021"


### PR DESCRIPTION
## Summary
- install a dedicated stable toolchain with rustfmt during CI formatting checks
- run cargo fmt using the stable toolchain to avoid nightly-only configuration requirements
- update rustfmt.toml to use only stable-compatible options

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131596c610832289941a5377a606c5)