### PR TITLE
fmt: apply stable rustfmt changes so CI passes

### DIFF
--- a/tests/autodiff_preview.rs
+++ b/tests/autodiff_preview.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn grad_add_is_ones() {
     let src = "let x: Tensor[f32,(2,3)] = 0; grad(tensor.sum(x + 1), wrt=[x])";

--- a/tests/conv2d_types.rs
+++ b/tests/conv2d_types.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 #[test]
 fn conv2d_channel_mismatch_errors() {
     let src = r#"
@@ -23,3 +21,4 @@ fn conv2d_same_padding_symbolic_shapes() {
     let diags = mind::type_checker::check_module_types(&module, src, &HashMap::new());
     assert!(diags.is_empty());
 }
+use std::collections::HashMap;

--- a/tests/dot_variants.rs
+++ b/tests/dot_variants.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn dot_vec_vec_scalar() {
     let src = r#" let v: Tensor[f32,(3)] = 1; let w: Tensor[f32,(3)] = 2; tensor.dot(v,w) "#;

--- a/tests/index_slice_preview.rs
+++ b/tests/index_slice_preview.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn index_drops_axis() {
     let src = r#" let x: Tensor[f32,(2,5)] = 1; tensor.index(x, axis=1, i=0) "#;

--- a/tests/linalg_grad.rs
+++ b/tests/linalg_grad.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn grad_sum_matmul_is_ones() {
     let src = r#"

--- a/tests/linalg_preview.rs
+++ b/tests/linalg_preview.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn matmul_preview_fill() {
     let src = r#"

--- a/tests/mlir_gpu.rs
+++ b/tests/mlir_gpu.rs
@@ -1,11 +1,10 @@
 #![cfg(feature = "mlir-gpu")]
 
+use std::collections::HashMap;
+
 use mind::eval;
 
 use mind::parser;
-
-use std::collections::HashMap;
-
 #[test]
 fn gpu_mode_falls_back_cleanly() {
     let src = "let x: Tensor[f32,(1,1)] = 0; x + 1";

--- a/tests/mlir_jit.rs
+++ b/tests/mlir_jit.rs
@@ -1,11 +1,10 @@
 #![cfg(feature = "mlir-jit")]
 
+use std::collections::HashMap;
+
 use mind::eval;
 
 use mind::parser;
-
-use std::collections::HashMap;
-
 #[test]
 fn jit_mode_falls_back_cleanly() {
     let src = "let x: Tensor[f32,(1,1)] = 0; x + 1";

--- a/tests/reductions_grad.rs
+++ b/tests/reductions_grad.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn grad_sum_is_ones() {
     let src = r#"

--- a/tests/reductions_preview.rs
+++ b/tests/reductions_preview.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn sum_all_axes_preview() {
     let src = r#"

--- a/tests/relu_preview.rs
+++ b/tests/relu_preview.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn relu_preview_keeps_shape() {
     let src = "let x: Tensor[f32,(2,3)] = 0; tensor.relu(x - 1)";

--- a/tests/shape_ops_preview.rs
+++ b/tests/shape_ops_preview.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn reshape_and_back_grad_shape_only() {
     let src = r#"

--- a/tests/tensor_broadcast.rs
+++ b/tests/tensor_broadcast.rs
@@ -1,11 +1,11 @@
+use std::collections::HashMap;
+
 use mind::parser;
 use mind::type_checker;
 use mind::types::DType;
 use mind::types::ShapeDim;
 use mind::types::TensorType;
 use mind::types::ValueType;
-use std::collections::HashMap;
-
 #[test]
 fn tensor_plus_tensor_same_shape() {
     let src = "a + b";

--- a/tests/tensor_eval.rs
+++ b/tests/tensor_eval.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn annotated_tensor_plus_scalar_yields_tensor_preview() {
     let src = "let x: Tensor[f32,(2,3)] = 0; x + 1";

--- a/tests/tensor_symbolic.rs
+++ b/tests/tensor_symbolic.rs
@@ -1,11 +1,11 @@
+use std::collections::HashMap;
+
 use mind::parser;
 use mind::type_checker;
 use mind::types::DType;
 use mind::types::ShapeDim;
 use mind::types::TensorType;
 use mind::types::ValueType;
-use std::collections::HashMap;
-
 #[test]
 fn broadcast_with_symbols_equal_symbols_ok() {
     let src = "a + b";

--- a/tests/transpose_preview.rs
+++ b/tests/transpose_preview.rs
@@ -1,8 +1,7 @@
-use mind::eval;
-use mind::parser;
-
 use std::collections::HashMap;
 
+use mind::eval;
+use mind::parser;
 #[test]
 fn transpose_reverse() {
     let src = r#" let x: Tensor[f32,(2,3,4)] = 0; tensor.transpose(x) "#;

--- a/tests/typecheck_binary.rs
+++ b/tests/typecheck_binary.rs
@@ -1,9 +1,8 @@
+use std::collections::HashMap;
+
 use mind::parser;
 use mind::type_checker;
 use mind::types::ValueType;
-
-use std::collections::HashMap;
-
 #[test]
 fn scalars_ok() {
     let src = "1 + 2 * 3";


### PR DESCRIPTION
## Summary
- reorder `use std::collections::HashMap;` ahead of crate imports across the test suite to match stable rustfmt output

## Testing
- cargo +stable fmt --all -- --check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131810e420832280257e2f6bce048d)