### PR TITLE
Fix clippy warnings for no-feature builds

### DIFF
--- a/src/eval/mlir_export.rs
+++ b/src/eval/mlir_export.rs
@@ -123,8 +123,9 @@ impl MlirEmitter {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MlirLowerPreset {
+    #[default]
     None,
     Core,
     ArithLinalg,
@@ -155,12 +156,6 @@ impl MlirLowerPreset {
             Self::JitCpu => "jit-cpu",
             Self::GpuDefault => "gpu-default",
         }
-    }
-}
-
-impl Default for MlirLowerPreset {
-    fn default() -> Self {
-        Self::None
     }
 }
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -82,14 +82,6 @@ pub fn emit_mlir_to_file(
     std::fs::write(path, txt)
 }
 
-#[cfg(not(feature = "cpu-buffers"))]
-pub(crate) const MATERIALIZE_MAX: usize = 0;
-
-#[cfg(not(feature = "cpu-buffers"))]
-pub(crate) fn num_elems(_shape: &[ShapeDim]) -> Option<usize> {
-    None
-}
-
 #[cfg(feature = "cpu-buffers")]
 pub(crate) fn num_elems(shape: &[ShapeDim]) -> Option<usize> {
     let mut n: usize = 1;

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -18,7 +18,9 @@ use crate::eval::Value;
 
 #[cfg(feature = "cpu-buffers")]
 use crate::eval::materialize_filled;
+#[cfg(feature = "cpu-buffers")]
 use crate::eval::num_elems;
+#[cfg(feature = "cpu-buffers")]
 use crate::eval::MATERIALIZE_MAX;
 
 use crate::linalg;


### PR DESCRIPTION
## Summary
- gate tensor stdlib imports behind the `cpu-buffers` feature
- remove unused `cpu-buffers` fallbacks and derive `Default` for `MlirLowerPreset`

## Testing
- cargo check --no-default-features
- cargo clippy --no-default-features -- -D warnings

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131c656ff083229a89fd691e43ae9f)