### PR TITLE
Add comprehensive MIND whitepaper

### DIFF
--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -1,0 +1,153 @@
+# MIND: The Native Language for Intelligent Systems
+
+**CPUTER Inc. — California, USA**  \
+Contact: [info@cputer.com](mailto:info@cputer.com) | +1 (844) 394-1538 | Web: [mindlang.dev](https://mindlang.dev)
+
+## Executive Summary
+
+MIND is a next-generation programming language and compiler stack designed to build intelligent systems natively. It offers a unified, end-to-end toolchain for machine learning and AI development, integrating tensor algebra, static shape inference, automatic differentiation, and device semantics directly into its type system. By compiling through MLIR and LLVM, MIND enables developers to write high-level AI models with compile-time guarantees that eliminate runtime shape and device mismatches, delivering memory-safe, deterministic executables with reproducible builds. The language and compiler front-end are implemented in Rust, ensuring performance and safety.
+
+**Market Need.** AI software development today is fragmented across languages, frameworks, and deployment environments. Teams often prototype in Python, reimplement in C++/CUDA, and manage distinct runtimes for cloud versus edge. This fragmentation slows delivery, increases operational risk, and contributes to the industry reality that over 85% of AI/ML projects never reach production. Organizations require a cohesive platform that unifies modeling, compilation, and deployment.
+
+**Solution.** MIND provides a unified language and compiler that boosts developer productivity by eliminating glue code, reducing errors, and automating low-level optimization. Enterprises benefit from deterministic performance, reproducible builds, and easier auditability. With an open-core (MIT-licensed) foundation and enterprise extensions, MIND encourages broad adoption while offering commercial-grade support and capabilities.
+
+## Market Opportunity
+
+### Fragmentation of the AI Stack
+
+The modern AI workflow typically involves data scientists experimenting in Python, systems engineers rewriting critical components in C++/CUDA, and DevOps teams integrating models with disparate runtimes. Each framework introduces its own intermediate representation and hardware support, making optimizations non-transferable and integration error-prone. Dynamic typing hides errors until runtime, resulting in costly debugging and unreliable deployments. Fragmentation drives up operational costs, lengthens iteration cycles, and contributes to statistics such as the oft-cited 87% failure rate of AI projects reaching production.
+
+### Growing Demand for Integrated Tooling
+
+The global AI software market is projected to reach $174 billion in 2025 and grow to $467 billion by 2030. Enterprises across industries are investing in MLOps solutions to streamline AI lifecycles. Key trends amplifying the need for MIND include:
+
+- **Specialized hardware proliferation.** MLIR-based compilation delivers performance portability across GPUs, TPUs, FPGAs, NPUs, and emerging edge devices.
+- **Rising model complexity.** Built-in automatic differentiation and static shape checking simplify development of large-scale, multi-modal models.
+- **Reproducibility and governance requirements.** Deterministic compilation and static analysis support auditability and compliance.
+- **Developer productivity.** By encapsulating systems-level optimizations, MIND enables teams to achieve results comparable to top-tier AI infrastructure groups.
+
+### Addressable Market
+
+The market for AI development platforms and compilers is poised for multi-billion dollar growth. Interest in technologies such as MLIR, OpenXLA, and new languages like Mojo underscores industry appetite for unified solutions. MIND aims to be the first open-core AI-native language to capture this opportunity.
+
+## Technology Overview
+
+### Language Design
+
+- **Tensor-native type system.** Tensors are first-class citizens with compile-time shape inference, catching dimension mismatches before runtime and enabling aggressive optimizations.
+- **Embedded automatic differentiation.** Differentiable programming is integrated into the language, allowing the compiler to generate optimized gradients.
+- **Compile-time device semantics.** Device capabilities are encoded in the type system, preventing unsupported operations from reaching deployment targets.
+- **Rust-inspired safety.** MIND adopts Rust’s focus on memory safety and deterministic resource management, eliminating entire classes of runtime failures.
+
+### Compiler Architecture
+
+MIND source code is parsed by a Rust-based front-end into a dedicated MLIR dialect optimized for tensor computations. High-level optimizations such as kernel fusion occur at this stage before lowering to LLVM IR for target-specific code generation. This multi-level pipeline enables deterministic builds, portability across hardware, and compatibility with emerging accelerator backends that adopt MLIR.
+
+### Runtime and Execution
+
+- **Ahead-of-time compilation.** Generate standalone CPU binaries or libraries with minimal runtime dependencies.
+- **Just-in-time execution.** Support interactive development through a JIT mode suitable for notebooks and rapid prototyping.
+- **Modular accelerator executors.** Pluggable modules manage CUDA, Vulkan/SPIR-V, and specialized NPU targets, with enterprise variants delivering tuned kernels.
+- **Foreign function interfaces.** Seamless interop with C/C++ and Python allows incremental adoption and integration into existing ecosystems.
+- **Deterministic execution.** Rust’s safety guarantees and controlled runtime enable reproducible, bit-for-bit consistent inference where required.
+
+### Technical Differentiation
+
+Compared to Python-based frameworks, MIND eliminates the dual-language problem and offers stronger compile-time guarantees. Against other compiled ML languages, MIND’s open-core model and fully static design deliver both community accessibility and optimization headroom. Relative to hand-optimized C++/Rust, MIND achieves comparable performance with higher-level abstractions and domain-specific compiler intelligence.
+
+## Market Positioning
+
+### Competitive Landscape
+
+- **Python + AI libraries.** Dominant but fragmented; MIND complements and gradually replaces performance-critical components.
+- **Mojo (Modular).** Proprietary and Python-compatible; MIND differentiates through openness and Rust-based static guarantees.
+- **Julia.** General numerical language; MIND focuses specifically on AI, integrating autodiff and GPU support natively.
+- **DSLs and IR frameworks (TVM, ONNX).** Optimize pre-built models; MIND offers a full language plus compiler for end-to-end workflows.
+- **Traditional C++/Rust.** Require specialized expertise; MIND raises abstraction without sacrificing performance.
+
+### Competitive Advantages
+
+1. **End-to-end unification.** Single codebase from research to production.
+2. **Open-core community.** MIT-licensed core accelerates adoption and ecosystem growth.
+3. **Performance and safety.** Combines systems-level efficiency with memory-safe execution.
+4. **Hardware partnerships.** MLIR foundation enables rapid support for new accelerators.
+5. **Targeted beachheads.** Focus on edge AI, finance, and regulated sectors where MIND’s guarantees provide outsized value.
+
+## Business Model
+
+MIND follows an open-core strategy:
+
+- **Community Edition.** Free, MIT-licensed language, compiler, and base runtime.
+- **Enterprise extensions.** Optimized runtime modules, advanced compiler passes, management tooling, and integrations.
+- **Support and services.** Tiered SLAs, professional services, and training.
+- **Cloud compiler.** Subscription or usage-based access to always up-to-date compilation and benchmarking services.
+
+Revenue streams include licensing (per seat/device), enterprise support contracts, cloud services, and professional engagements. Value propositions emphasize developer efficiency, infrastructure savings, new product enablement, and risk mitigation.
+
+## Go-to-Market Strategy
+
+- **Developer evangelism.** Tutorials, documentation, community programs, and example projects to drive grassroots adoption.
+- **Public sector engagement.** Pursue grants and collaborations aligned with open, secure AI infrastructure.
+- **Enterprise sales.** Consultative proofs-of-concept showcasing performance gains and operational simplification.
+- **Cloud partnerships.** Offer MIND via major cloud marketplaces and integrate with managed ML services.
+- **Conversion tactics.** Upsell heavy community users to enterprise tiers, provide training/certification, and cultivate a partner ecosystem.
+
+## Financial Outlook
+
+Early revenue (years 1–2) is expected from pilot enterprise deals and support (~$0.5–3M). Mid-term growth (years 3–4) adds cloud services, hardware licensing, and expanding enterprise contracts, targeting $15M ARR with modest market penetration. Long-term potential exceeds $100M ARR with broader adoption across AI development teams.
+
+Key financial drivers:
+
+- Seat-based enterprise subscriptions (e.g., $1,000 per developer annually).
+- Hardware/runtime licensing (per device or deployment).
+- Cloud compiler usage fees.
+- Premium support tiers with guaranteed response times.
+
+## Roadmap
+
+### Phase 1 (2025–2026): Developer SDK & Early Adoption
+
+- Release language spec, SDK, and documentation.
+- Provide tutorials, sample projects, and IDE integrations.
+- Build community channels and gather feedback via design partners.
+
+### Phase 2 (2026): Cloud Compiler & Ecosystem Integration
+
+- Launch beta cloud compiler service and CI/CD integrations.
+- Deliver interoperability with PyTorch, TensorFlow, and ONNX.
+- Expand optimization passes and enterprise compliance features.
+
+### Phase 3 (2027): Embedded Runtime & Edge Deployment
+
+- Release lightweight runtimes for microcontrollers and edge devices.
+- Add quantization, pruning, and advanced production optimizations.
+- Ship enterprise management suite and deepen cloud partnerships.
+
+### Beyond 2027
+
+- Extend MIND across full AI pipelines and orchestrations (Naestro AI OS).
+- Support emerging hardware paradigms and foster a global ecosystem.
+
+## Team
+
+CPUTER Inc. brings together compiler veterans, AI practitioners, and business leaders with proven experience delivering systems at scale. The team blends:
+
+- **Compiler and systems experts** with backgrounds in LLVM, MLIR, and large-scale runtimes.
+- **AI domain specialists** who have led ML platform teams and understand practitioner pain points.
+- **Advisors and network** connections spanning academia, cloud providers, and enterprise buyers.
+- **Open-source stewards** committed to community governance and collaboration.
+- **Business and operations leaders** experienced in enterprise software go-to-market strategies.
+
+The broader vision encompasses Naestro, an AI operating system that leverages MIND as its programming foundation, demonstrating the team’s ambition to redefine AI infrastructure end-to-end.
+
+## Contact
+
+**CPUTER Inc.**  \
+California, USA  \
+Phone: +1 (844) 394-1538  \
+Email: [info@cputer.com](mailto:info@cputer.com)  \
+Web: [https://mindlang.dev](https://mindlang.dev) | [https://cputer.com](https://cputer.com)
+
+---
+
+*MIND – The Native Language for Intelligent Systems combines advanced compiler technology with practical AI development needs, positioning it as the foundational platform for the next generation of intelligent software.*


### PR DESCRIPTION
## Summary
- add a new whitepaper in `docs/whitepaper.md` describing the MIND platform, technology, and market strategy
- outline market opportunity, business model, roadmap, and team positioning for stakeholders

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148b5ad80883228498eba624ae987c)