### PR TITLE
Add STARGA copyright headers to Rust sources

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 fn main() {
     if std::env::var("CARGO_FEATURE_FFI_EXAMPLES").is_ok() {
         println!("cargo:rerun-if-changed=examples/c/min.c");

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use crate::types::ConvPadding;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/autodiff/mod.rs
+++ b/src/autodiff/mod.rs
@@ -1,4 +1,8 @@
 #![allow(dead_code, unused_variables, unused_imports)]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 //! Minimal autodiff prototype (Phase 1).
 //!
 //! `grad(f)` returns a closure that runs `f()` and also returns a placeholder

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 //! Pretty diagnostics: spans, line/col, caret-highlights.
 
 use std::ops::Range;

--- a/src/eval/autodiff.rs
+++ b/src/eval/autodiff.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;

--- a/src/eval/ir_interp.rs
+++ b/src/eval/ir_interp.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use crate::eval::value::TensorVal;

--- a/src/eval/lower.rs
+++ b/src/eval/lower.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use crate::ast;

--- a/src/eval/mlir_build.rs
+++ b/src/eval/mlir_build.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "mlir-build")]
 use std::io::Write;
 #[cfg(feature = "mlir-build")]

--- a/src/eval/mlir_export.rs
+++ b/src/eval/mlir_export.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 use std::fmt::Write;
 

--- a/src/eval/mlir_gpu.rs
+++ b/src/eval/mlir_gpu.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use crate::eval::EvalError;
 
 use super::GpuBackend;

--- a/src/eval/mlir_jit.rs
+++ b/src/eval/mlir_jit.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::path::PathBuf;
 
 use libloading::Library;

--- a/src/eval/mlir_opt.rs
+++ b/src/eval/mlir_opt.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::fmt;
 
 /// Result of running mlir-opt.

--- a/src/eval/mlir_run.rs
+++ b/src/eval/mlir_run.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "mlir-exec")]
 use std::path::PathBuf;
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;

--- a/src/eval/stdlib/mod.rs
+++ b/src/eval/stdlib/mod.rs
@@ -1,1 +1,5 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 pub mod tensor;

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 

--- a/src/eval/value.rs
+++ b/src/eval/value.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::BTreeMap;
 
 use crate::types::DType;

--- a/src/exec/conv.rs
+++ b/src/exec/conv.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use crate::eval::value::TensorVal;
 use crate::types::ConvPadding;
 use crate::types::ShapeDim;

--- a/src/exec/cpu.rs
+++ b/src/exec/cpu.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 //! Minimal CPU executor for TensorVal with materialized buffers (f32 only for v1).
 
 use crate::eval::value::TensorVal;

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "cpu-exec")]
 pub mod cpu;
 

--- a/src/ffi/header.rs
+++ b/src/ffi/header.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "ffi-c")]
 pub fn generate_header() -> String {
     let header = r#"#ifndef MIND_H

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 #[cfg(feature = "ffi-c")]
 pub mod capi {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use crate::types::DType;
 use crate::types::ShapeDim;
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use logos::Logos;
 
 #[derive(Logos, Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 //! MIND core library (Phase 1 scaffold)
 pub mod ast;
 pub mod diagnostics;

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use crate::types::ShapeDim;
 
 #[derive(Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 //! Command-line entry point for MIND.
 //!
 //! Usage:

--- a/src/opt/fold.rs
+++ b/src/opt/fold.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use crate::ast::BinOp;
 use crate::ast::Literal;
 use crate::ast::Node;

--- a/src/opt/mod.rs
+++ b/src/opt/mod.rs
@@ -1,1 +1,5 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 pub mod fold;

--- a/src/package/manifest.rs
+++ b/src/package/manifest.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::BTreeMap;
 
 use anyhow::Result;

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 mod manifest;
 
 pub use manifest::MindManifest;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 //! # Example
 //! ```
 //! use mind::{parser, eval};

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,1 +1,5 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 pub mod tensor;

--- a/src/stdlib/tensor.rs
+++ b/src/stdlib/tensor.rs
@@ -1,4 +1,8 @@
 #![allow(dead_code, unused_variables, unused_imports)]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::marker::PhantomData;
 
 /// Minimal placeholder tensor for Phase 1 (no data buffer).

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 

--- a/src/types/infer.rs
+++ b/src/types/infer.rs
@@ -1,4 +1,8 @@
 #![allow(dead_code, unused_variables, unused_imports)]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use super::ShapeDim;
 use super::TensorType;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 //! Basic tensor type definitions.
 //!
 //! # Example

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use super::TensorType;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/autodiff.rs
+++ b/tests/autodiff.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "autodiff")]
 #[test]
 fn grad_placeholder_runs() {

--- a/tests/autodiff_preview.rs
+++ b/tests/autodiff_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/cli_buffers.rs
+++ b/tests/cli_buffers.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "cpu-buffers")]
 #[test]
 fn cli_shows_materialized_note() {

--- a/tests/cli_build.rs
+++ b/tests/cli_build.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "mlir-build")]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 use std::fs;
 use std::process::Command;

--- a/tests/cli_eval.rs
+++ b/tests/cli_eval.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::process::Command;
 
 #[cfg(not(debug_assertions))]

--- a/tests/cli_exec.rs
+++ b/tests/cli_exec.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "cpu-exec")]
 #[test]
 fn cli_runs_exec() {

--- a/tests/cli_tensor.rs
+++ b/tests/cli_tensor.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::process::Command;
 
 #[test]

--- a/tests/const_folding.rs
+++ b/tests/const_folding.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::ast::Node;
 use mind::opt::fold;
 use mind::parser;

--- a/tests/conv2d_exec.rs
+++ b/tests/conv2d_exec.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(all(feature = "cpu-exec", feature = "cpu-conv"))]
 #[test]
 fn conv2d_valid_runs() {

--- a/tests/conv2d_types.rs
+++ b/tests/conv2d_types.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[test]
 fn conv2d_channel_mismatch_errors() {
     let src = r#"

--- a/tests/diagnostics_parse.rs
+++ b/tests/diagnostics_parse.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::parser;
 
 #[test]

--- a/tests/dot_variants.rs
+++ b/tests/dot_variants.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/exec_basic.rs
+++ b/tests/exec_basic.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "cpu-exec")]
 mod cpu {
     use mind::eval;

--- a/tests/expr_parser.rs
+++ b/tests/expr_parser.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/ffi_header.rs
+++ b/tests/ffi_header.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "ffi-c")]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 #[test]
 fn header_contains_expected_symbols() {

--- a/tests/gather_preview.rs
+++ b/tests/gather_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[test]
 fn gather_inserts_idx_shape() {
     let src = r#"

--- a/tests/index_slice_grad.rs
+++ b/tests/index_slice_grad.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[test]
 fn grad_through_slice_shapes_ok() {
     let src = r#"

--- a/tests/index_slice_preview.rs
+++ b/tests/index_slice_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/index_slice_types.rs
+++ b/tests/index_slice_types.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[test]
 fn index_axis_bounds_checked() {
     let src = r#" let x: Tensor[f32,(2,5)] = 0; tensor.index(x, axis=2, i=0) "#;

--- a/tests/ir_lower.rs
+++ b/tests/ir_lower.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/ir_stub.rs
+++ b/tests/ir_stub.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "mlir")]
 #[test]
 fn lower_placeholder_contains_mlir_module() {

--- a/tests/linalg_grad.rs
+++ b/tests/linalg_grad.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/linalg_preview.rs
+++ b/tests/linalg_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/mlir_build.rs
+++ b/tests/mlir_build.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "mlir-build")]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 use std::fs;
 use std::time::Duration;

--- a/tests/mlir_exec.rs
+++ b/tests/mlir_exec.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "mlir-exec")]
 #[test]
 fn mlir_exec_scalar_add() {

--- a/tests/mlir_export.rs
+++ b/tests/mlir_export.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/mlir_export_indexing.rs
+++ b/tests/mlir_export_indexing.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/mlir_export_linalg.rs
+++ b/tests/mlir_export_linalg.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/mlir_export_reductions.rs
+++ b/tests/mlir_export_reductions.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/mlir_export_shape.rs
+++ b/tests/mlir_export_shape.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/mlir_file_and_lower.rs
+++ b/tests/mlir_file_and_lower.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::fs;
 use std::process::Command;
 

--- a/tests/mlir_gpu.rs
+++ b/tests/mlir_gpu.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "mlir-gpu")]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 use std::collections::HashMap;
 

--- a/tests/mlir_jit.rs
+++ b/tests/mlir_jit.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "mlir-jit")]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 use std::collections::HashMap;
 

--- a/tests/mlir_opt.rs
+++ b/tests/mlir_opt.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "mlir-subprocess")]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 use mind::eval;
 

--- a/tests/package_basic.rs
+++ b/tests/package_basic.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "pkg")]
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
 
 use std::fs;
 

--- a/tests/reductions_grad.rs
+++ b/tests/reductions_grad.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/reductions_preview.rs
+++ b/tests/reductions_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/relu_exec.rs
+++ b/tests/relu_exec.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "cpu-exec")]
 #[test]
 fn relu_exec_non_negative() {

--- a/tests/relu_preview.rs
+++ b/tests/relu_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/repl_basic.rs
+++ b/tests/repl_basic.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::io::Write;
 use std::process::Command;
 use std::process::Stdio;

--- a/tests/shape_ops_preview.rs
+++ b/tests/shape_ops_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::lexer;
 use mind::parser;
 use mind::type_checker;

--- a/tests/stdlib_tensor.rs
+++ b/tests/stdlib_tensor.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::stdlib::tensor::Tensor;
 
 #[test]

--- a/tests/stride_gather_grad.rs
+++ b/tests/stride_gather_grad.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[test]
 fn grad_through_stride_and_gather_shapes() {
     let src = r#"

--- a/tests/stride_preview.rs
+++ b/tests/stride_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[test]
 fn stride_pos_step_len() {
     let src = r#" let x: Tensor[f32,(2,10)] = 7; tensor.slice_stride(x, axis=1, start=0, end=10, step=2) "#;

--- a/tests/stride_types.rs
+++ b/tests/stride_types.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[test]
 fn zero_step_is_error() {
     let src = r#" let x: Tensor[f32,(2,10)] = 0; tensor.slice_stride(x, axis=1, start=0, end=10, step=0) "#;

--- a/tests/tensor_broadcast.rs
+++ b/tests/tensor_broadcast.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::parser;

--- a/tests/tensor_buffers.rs
+++ b/tests/tensor_buffers.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 #[cfg(feature = "cpu-buffers")]
 #[test]
 fn materializes_small_filled_tensor() {

--- a/tests/tensor_eval.rs
+++ b/tests/tensor_eval.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/tensor_stdlib.rs
+++ b/tests/tensor_stdlib.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/tensor_symbolic.rs
+++ b/tests/tensor_symbolic.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::parser;

--- a/tests/transpose_preview.rs
+++ b/tests/transpose_preview.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::eval;

--- a/tests/type_ann_check.rs
+++ b/tests/type_ann_check.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/type_ann_parse.rs
+++ b/tests/type_ann_parse.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::parser;
 
 #[test]

--- a/tests/type_error_spans.rs
+++ b/tests/type_error_spans.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::diagnostics;

--- a/tests/type_infer.rs
+++ b/tests/type_infer.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::types::infer::unify;
 use mind::types::DType;
 use mind::types::ShapeDim;

--- a/tests/typecheck_binary.rs
+++ b/tests/typecheck_binary.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use std::collections::HashMap;
 
 use mind::parser;

--- a/tests/typecheck_env.rs
+++ b/tests/typecheck_env.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tests/vars_assign.rs
+++ b/tests/vars_assign.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
 use mind::eval;
 use mind::parser;
 

--- a/tools/add_copyright_headers.py
+++ b/tools/add_copyright_headers.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+HEADER = """// Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
+// SPDX-License-Identifier: MIT
+// Part of the MIND project (Machine Intelligence Native Design).
+
+"""
+
+def should_skip(path: Path) -> bool:
+    parts = set(path.parts)
+    if "target" in parts or ".git" in parts:
+        return True
+    return False
+
+def add_header_to_file(path: Path):
+    text = path.read_text(encoding="utf-8")
+    if "STARGA Inc. and MIND Language Contributors" in text:
+        return
+
+    if text.startswith("#!"):
+        lines = text.splitlines(keepends=True)
+        first = lines[0]
+        rest = "".join(lines[1:])
+        new_text = first + HEADER + rest
+    else:
+        new_text = HEADER + text
+
+    path.write_text(new_text, encoding="utf-8")
+    print(f"Updated: {path}")
+
+def main():
+    for root, dirs, files in os.walk(REPO_ROOT):
+        root_path = Path(root)
+        if should_skip(root_path):
+            continue
+        for name in files:
+            if name.endswith(".rs"):
+                add_header_to_file(root_path / name)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to apply the standardized STARGA/MIND corporate header to Rust sources
- insert the new corporate header into all Rust files across src, tests, and build scripts

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69228050ec90832a8bd1c5b2c374c9b5)