### PR TITLE
Ensure headers follow crate-level attributes

### DIFF
--- a/src/autodiff/mod.rs
+++ b/src/autodiff/mod.rs
@@ -1,7 +1,8 @@
-#![allow(dead_code, unused_variables, unused_imports)]
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).
+
+#![allow(dead_code, unused_variables, unused_imports)]
 
 //! Minimal autodiff prototype (Phase 1).
 //!

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/src/stdlib/tensor.rs
+++ b/src/stdlib/tensor.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, unused_variables, unused_imports)]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/src/types/infer.rs
+++ b/src/types/infer.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, unused_variables, unused_imports)]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/tests/cli_build.rs
+++ b/tests/cli_build.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "mlir-build")]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/tests/ffi_header.rs
+++ b/tests/ffi_header.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "ffi-c")]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/tests/mlir_build.rs
+++ b/tests/mlir_build.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "mlir-build")]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/tests/mlir_gpu.rs
+++ b/tests/mlir_gpu.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "mlir-gpu")]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/tests/mlir_jit.rs
+++ b/tests/mlir_jit.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "mlir-jit")]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/tests/mlir_opt.rs
+++ b/tests/mlir_opt.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "mlir-subprocess")]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).

--- a/tests/package_basic.rs
+++ b/tests/package_basic.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "pkg")]
+
 // Copyright (c) 2025 STARGA Inc. and MIND Language Contributors
 // SPDX-License-Identifier: MIT
 // Part of the MIND project (Machine Intelligence Native Design).


### PR DESCRIPTION
## Summary
- update header insertion script to keep shebangs and crate-level attributes ahead of the project header
- fix existing Rust files to place header comments after crate-level attributes or adjust module attributes for consistency

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692288ab97f4832a83d67005a04369ca)