### PR TITLE
Document open-core licensing structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,26 @@
-MIT License
+MIND Licensing Overview – Open Core (Community + Enterprise)
 
-Copyright (c) 2025 MIND Language Contributors
+This repository contains the Community Edition of the MIND language and core compiler.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+MIND uses an open-core dual licensing model:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Community Edition (this repository)
+   - Licensed under the MIT License.
+   - See `LICENSE-MIT` for the full MIT terms.
+   - You may use, modify, distribute, and embed this code under standard MIT conditions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Enterprise & SaaS Offerings (not part of this repository)
+   - MIND Enterprise Edition features (advanced optimizations, cluster/GPU management, observability, multi-tenant control plane, etc.).
+   - Hosted “MIND Cloud” or other managed SaaS offerings operated by STARGA Inc.
+   - Proprietary extensions, closed-source plugins, and integrations not included in this repository.
+   - Use of MIND trademarks, logos, and brand in ways that suggest endorsement or official partnership.
+
+These Enterprise and SaaS components are NOT licensed under MIT and require a separate commercial agreement with STARGA Inc.
+
+For commercial licensing, OEM, or large-scale deployment, please contact:
+  STARGA Inc.
+  Email: legal@star.ga or info@star.ga
+
+In summary:
+- This repository (Community Edition) → MIT (`LICENSE-MIT`)
+- Enterprise/SaaS/closed-source components → Commercial License (`LICENSE-COMMERCIAL` and separate agreements)

--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -1,0 +1,36 @@
+COMMERCIAL LICENSE NOTICE – MIND (Enterprise & SaaS)
+
+The source code in this repository is the Community Edition of the MIND language and core compiler
+and is provided under the MIT License (see `LICENSE-MIT`).
+
+The following are NOT licensed under MIT and require a separate commercial agreement
+with STARGA Inc.:
+
+1. MIND Enterprise Edition features
+   (advanced optimizations, cluster and GPU management, observability, multi-tenant control plane,
+   advanced scheduling, and similar enterprise-only capabilities).
+
+2. Hosted “MIND Cloud” / SaaS services
+   operated or branded by STARGA Inc., including managed compilation, optimization, or execution
+   services that are not fully covered by the public Community Edition code in this repository.
+
+3. Proprietary extensions, plugins, or integrations
+   that are distributed separately from this repository or explicitly marked as “Enterprise”,
+   “Commercial”, or “Proprietary”.
+
+4. Use of MIND trademarks, logos, and brand
+   in any way that suggests partnership, endorsement, or official certification by STARGA Inc.,
+   unless explicitly agreed in writing.
+
+Commercial licensing, OEM deals, and large-scale enterprise usage:
+
+Please contact STARGA Inc. at:
+  legal@star.ga
+  or
+  info@star.ga
+
+to obtain a commercial license agreement, enterprise terms, or a tailored partnership contract.
+
+This `LICENSE-COMMERCIAL` file is a notice and high-level summary.
+The actual commercial rights and obligations will be governed by a separate
+signed agreement between you and STARGA Inc.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 MIND Language Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # MIND — Native Language for Intelligent Systems
 
 [![CI](https://github.com/cputer/mind/actions/workflows/ci.yml/badge.svg)](https://github.com/cputer/mind/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE-MIT)
 
 ## Overview
 
@@ -46,7 +46,22 @@ Upcoming milestones and release planning live in [`/docs/roadmap.md`](docs/roadm
 * [Brand assets](assets/logo/mind.svg) · [Social cover](assets/social/og-cover.svg)
 * [Contributing guidelines](CONTRIBUTING.md)
 * [Security policy](SECURITY.md)
-* [License](LICENSE)
+
+## Licensing
+
+MIND follows an open-core dual licensing model maintained by STARGA Inc.
+
+- **Community Edition (this repository)**  \
+  The language, core compiler, and runtime found here are provided under the MIT License.  \
+  See [`LICENSE-MIT`](./LICENSE-MIT) for the full text.
+
+- **Enterprise & SaaS Offerings**  \
+  Enterprise-only features, hosted “MIND Cloud” services, and proprietary extensions are available under a separate commercial license from STARGA Inc. These components are not covered by the MIT License and are not necessarily present in this repository.
+
+For commercial licensing, OEM partnerships, or large-scale deployments, please contact:
+`info@star.ga` or `legal@star.ga`.
+
+* [Licensing overview](LICENSE)
 
 ---
 


### PR DESCRIPTION
## Summary
- add a licensing overview router plus commercial notice to describe the open-core model
- move MIT terms to LICENSE-MIT and update README licensing details

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69228bb35cfc832abb2700856fb12c7d)