### PR TITLE
Add runtime interface and evaluator runtime field

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -25,6 +25,7 @@ use crate::ast::Module;
 use crate::ast::Node;
 
 use crate::ast::TypeAnn;
+use crate::runtime_interface::{MindRuntime, NoOpRuntime};
 
 use crate::eval::autodiff::TensorEnvEntry;
 use crate::types::DType;
@@ -51,6 +52,18 @@ pub mod mlir_opt;
 #[cfg(feature = "mlir-exec")]
 pub mod mlir_run;
 pub mod value;
+
+pub struct Evaluator {
+    pub runtime: Box<dyn MindRuntime>,
+}
+
+impl Default for Evaluator {
+    fn default() -> Self {
+        Self {
+            runtime: Box::new(NoOpRuntime),
+        }
+    }
+}
 
 pub use ir_interp::eval_ir;
 pub use lower::lower_to_ir;

--- a/src/runtime_interface.rs
+++ b/src/runtime_interface.rs
@@ -1,0 +1,32 @@
+use crate::types::{DType, Shape};
+
+#[derive(Clone, Copy, Debug)]
+pub enum DeviceKind {
+    Cpu,
+    Gpu,
+    Other,
+}
+
+#[derive(Clone, Debug)]
+pub struct TensorDesc {
+    pub shape: Shape,
+    pub dtype: DType,
+}
+
+pub trait MindRuntime {
+    fn allocate(&self, desc: &TensorDesc) -> usize;
+    fn run_op(&self, op: &str, inputs: &[usize], outputs: &[usize]);
+    fn synchronize(&self) {}
+}
+
+pub struct NoOpRuntime;
+
+impl MindRuntime for NoOpRuntime {
+    fn allocate(&self, _desc: &TensorDesc) -> usize {
+        0
+    }
+
+    fn run_op(&self, _op: &str, _inputs: &[usize], _outputs: &[usize]) {
+        // no-op
+    }
+}


### PR DESCRIPTION
## Summary
- add a new runtime_interface module exposing MindRuntime with a NoOpRuntime implementation and runtime descriptors
- import the runtime interface in eval module and provide an Evaluator struct carrying a runtime handle

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368fbd11488322992610fad0e530a4)