### PR TITLE
Strip runtime implementation from public repo and keep only stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 MIND is a Rust-first language and runtime for building intelligent systems with auditable foundations. It blends declarative tensor algebra, static shape inference, automatic differentiation, and MLIR/LLVM lowering in a compact toolchain that scales from research prototypes to production.
 
+## Open-core vs proprietary runtime
+
+This repository contains the open-core stack: the MIND language, type system, compiler front-end, IR, and MLIR lowering passes. Production-grade runtime backends for CPU, GPU, and accelerators live in the private [`mind-runtime`](https://github.com/cputer/mind-runtime) repository. Functions in `src/exec/*` marked with `todo!()` or `unimplemented!()` are runtime hooks that the proprietary backend fulfills.
+
 ## Quick Start
 
 ```bash

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -65,6 +65,16 @@ impl Default for Evaluator {
     }
 }
 
+impl Evaluator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_runtime(runtime: Box<dyn MindRuntime>) -> Self {
+        Self { runtime }
+    }
+}
+
 pub use ir_interp::eval_ir;
 pub use lower::lower_to_ir;
 #[cfg(feature = "mlir-build")]
@@ -586,6 +596,8 @@ pub(crate) fn eval_value_expr_mode(
                             materialize_filled(&mut tr_exec);
                             #[cfg(feature = "cpu-exec")]
                             {
+                                // TODO(runtime): dispatch through `Evaluator::runtime` once the
+                                // runtime plumbing is threaded into evaluation.
                                 if tl_exec.dtype == DType::F32 && tr_exec.dtype == DType::F32 {
                                     let exec_res = exec::cpu::exec_dot(&tl_exec, &tr_exec);
                                     match exec_res {
@@ -621,6 +633,8 @@ pub(crate) fn eval_value_expr_mode(
                             materialize_filled(&mut tr_exec);
                             #[cfg(feature = "cpu-exec")]
                             {
+                                // TODO(runtime): dispatch through `Evaluator::runtime` once the
+                                // runtime plumbing is threaded into evaluation.
                                 if tl_exec.dtype == DType::F32 && tr_exec.dtype == DType::F32 {
                                     let exec_res = exec::cpu::exec_matmul(&tl_exec, &tr_exec);
                                     match exec_res {
@@ -784,6 +798,8 @@ fn apply_tensor_scalar(
             materialize_filled(&mut tensor_exec);
             #[cfg(feature = "cpu-exec")]
             {
+                // TODO(runtime): dispatch through `Evaluator::runtime` once the runtime plumbing is
+                // threaded into evaluation.
                 if tensor_exec.dtype == DType::F32 {
                     let exec_res = match op {
                         BinOp::Add => exec::cpu::exec_add_scalar(&tensor_exec, scalar as f32),

--- a/src/exec/conv.rs
+++ b/src/exec/conv.rs
@@ -18,141 +18,22 @@ use crate::types::ShapeDim;
 
 use super::cpu::ExecError;
 
-fn shape_as_usize(shape: &[ShapeDim]) -> Result<Vec<usize>, ExecError> {
-    let mut out = Vec::with_capacity(shape.len());
-    for dim in shape {
-        match dim {
-            ShapeDim::Known(v) => out.push(*v),
-            ShapeDim::Sym(_) => return Err(ExecError::Shape("symbolic dims".into())),
-        }
-    }
-    Ok(out)
+fn _shape_as_usize(_shape: &[ShapeDim]) -> Result<Vec<usize>, ExecError> {
+    // TODO(runtime): shape handling is implemented in the proprietary runtime backend.
+    Err(ExecError::Unsupported(
+        "Convolution shape materialization is provided by the proprietary MIND runtime".into(),
+    ))
 }
 
 pub fn exec_conv2d(
-    input: &TensorVal,
-    weights: &TensorVal,
-    stride_h: usize,
-    stride_w: usize,
-    padding: ConvPadding,
+    _input: &TensorVal,
+    _weights: &TensorVal,
+    _stride_h: usize,
+    _stride_w: usize,
+    _padding: ConvPadding,
 ) -> Result<TensorVal, ExecError> {
-    if stride_h == 0 || stride_w == 0 {
-        return Err(ExecError::Shape("strides must be positive".into()));
-    }
-    if input.dtype != crate::types::DType::F32 || weights.dtype != crate::types::DType::F32 {
-        return Err(ExecError::Type(
-            "only f32 tensors supported in cpu-exec".into(),
-        ));
-    }
-
-    let in_shape = shape_as_usize(&input.shape)?;
-    let wt_shape = shape_as_usize(&weights.shape)?;
-    if in_shape.len() != 4 || wt_shape.len() != 4 {
-        return Err(ExecError::Shape(
-            "`tensor.conv2d` expects NHWC x HWIO tensors".into(),
-        ));
-    }
-
-    let n = in_shape[0];
-    let in_h = in_shape[1];
-    let in_w = in_shape[2];
-    let in_c = in_shape[3];
-
-    let kernel_h = wt_shape[0];
-    let kernel_w = wt_shape[1];
-    let kernel_c = wt_shape[2];
-    let out_c = wt_shape[3];
-
-    if kernel_h == 0 || kernel_w == 0 {
-        return Err(ExecError::Shape(
-            "kernel dimensions must be positive".into(),
-        ));
-    }
-
-    if in_c != kernel_c {
-        return Err(ExecError::Shape("input/output channel mismatch".into()));
-    }
-
-    let (pad_top, pad_left, out_h, out_w) = match padding {
-        ConvPadding::Valid => {
-            if in_h < kernel_h || in_w < kernel_w {
-                return Err(ExecError::Shape("kernel larger than input".into()));
-            }
-            let out_h = (in_h - kernel_h) / stride_h + 1;
-            let out_w = (in_w - kernel_w) / stride_w + 1;
-            (0, 0, out_h, out_w)
-        }
-        ConvPadding::Same => {
-            let out_h = (in_h + stride_h - 1) / stride_h;
-            let out_w = (in_w + stride_w - 1) / stride_w;
-            let pad_h = out_h
-                .saturating_sub(1)
-                .saturating_mul(stride_h)
-                .saturating_add(kernel_h)
-                .saturating_sub(in_h);
-            let pad_w = out_w
-                .saturating_sub(1)
-                .saturating_mul(stride_w)
-                .saturating_add(kernel_w)
-                .saturating_sub(in_w);
-            let pad_top = pad_h / 2;
-            let pad_left = pad_w / 2;
-            (pad_top, pad_left, out_h, out_w)
-        }
-    };
-
-    let input_buf = input
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("input tensor not materialized".into()))?;
-    let weight_buf = weights
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("weight tensor not materialized".into()))?;
-
-    let mut output = vec![0.0f32; n * out_h * out_w * out_c];
-
-    let pad_top_i = pad_top as isize;
-    let pad_left_i = pad_left as isize;
-
-    for batch in 0..n {
-        for oh in 0..out_h {
-            for ow in 0..out_w {
-                let out_index = ((batch * out_h + oh) * out_w + ow) * out_c;
-                let out_slice = &mut output[out_index..out_index + out_c];
-                for val in out_slice.iter_mut() {
-                    *val = 0.0;
-                }
-
-                for kh in 0..kernel_h {
-                    let ih = oh * stride_h + kh;
-                    let ih_padded = ih as isize - pad_top_i;
-                    if ih_padded < 0 || ih_padded >= in_h as isize {
-                        continue;
-                    }
-                    for kw in 0..kernel_w {
-                        let iw = ow * stride_w + kw;
-                        let iw_padded = iw as isize - pad_left_i;
-                        if iw_padded < 0 || iw_padded >= in_w as isize {
-                            continue;
-                        }
-                        let input_offset = (((batch * in_h + ih_padded as usize) * in_w
-                            + iw_padded as usize)
-                            * in_c) as usize;
-                        let weight_offset_base = ((kh * kernel_w + kw) * in_c) * out_c;
-                        for ic in 0..in_c {
-                            let input_val = input_buf[input_offset + ic];
-                            let weight_offset = weight_offset_base + ic * out_c;
-                            for oc in 0..out_c {
-                                out_slice[oc] += input_val * weight_buf[weight_offset + oc];
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(TensorVal::from_materialized_f32(
-        vec![n, out_h, out_w, out_c],
-        output,
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    Err(ExecError::Unsupported(
+        "Conv2d execution is provided by the proprietary MIND runtime backend".into(),
     ))
 }

--- a/src/exec/cpu.rs
+++ b/src/exec/cpu.rs
@@ -12,11 +12,9 @@
 
 // Part of the MIND project (Machine Intelligence Native Design).
 
-//! Minimal CPU executor for TensorVal with materialized buffers (f32 only for v1).
+//! CPU execution stubs. Real implementations live in the proprietary `mind-runtime` backend.
 
 use crate::eval::value::TensorVal;
-use crate::exec::simd_chunks_mut;
-use crate::types::DType;
 use crate::types::ShapeDim;
 
 #[derive(Debug)]
@@ -29,351 +27,88 @@ pub enum ExecError {
 
 type R<T> = Result<T, ExecError>;
 
-#[inline]
-fn numel(shape: &[usize]) -> usize {
-    shape.iter().product()
+fn runtime_stub<T>() -> R<T> {
+    Err(ExecError::Unsupported(
+        "CPU execution is provided by the proprietary MIND runtime backend".into(),
+    ))
 }
 
-fn shape_usize(shape: &[ShapeDim]) -> Option<Vec<usize>> {
-    let mut out = Vec::with_capacity(shape.len());
-    for dim in shape {
-        match dim {
-            ShapeDim::Known(n) => out.push(*n),
-            ShapeDim::Sym(_) => return None,
-        }
-    }
-    Some(out)
+fn _shape_usize(_shape: &[ShapeDim]) -> Option<Vec<usize>> {
+    // TODO(runtime): implement shape materialization in the proprietary backend.
+    None
 }
 
-fn ensure_f32(t: &TensorVal) -> R<()> {
-    match t.dtype {
-        DType::F32 => Ok(()),
-        _ => Err(ExecError::Type(
-            "only f32 tensors supported in cpu-exec".into(),
-        )),
-    }
+pub fn exec_add(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-fn broadcast_shapes(a: &[usize], b: &[usize]) -> R<Vec<usize>> {
-    let mut out = Vec::new();
-    let mut i = a.len() as isize - 1;
-    let mut j = b.len() as isize - 1;
-    while i >= 0 || j >= 0 {
-        let da = if i >= 0 { a[i as usize] } else { 1 };
-        let db = if j >= 0 { b[j as usize] } else { 1 };
-        let dim = if da == db || da == 1 {
-            db
-        } else if db == 1 {
-            da
-        } else {
-            return Err(ExecError::Shape(format!(
-                "cannot broadcast shapes {:?} and {:?}",
-                a, b
-            )));
-        };
-        out.push(dim);
-        i -= 1;
-        j -= 1;
-    }
-    out.reverse();
-    Ok(out)
+pub fn exec_sub(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-fn stride_for(shape: &[usize]) -> Vec<usize> {
-    let mut stride = vec![0; shape.len()];
-    let mut acc = 1;
-    for i in (0..shape.len()).rev() {
-        stride[i] = acc;
-        acc *= shape[i];
-    }
-    stride
+pub fn exec_mul(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-fn index_broadcast(idx: &[usize], shape: &[usize], stride: &[usize]) -> usize {
-    let offset_base = idx.len().saturating_sub(shape.len());
-    let mut offset = 0usize;
-    for i in 0..shape.len() {
-        let dim = shape[i];
-        let take = if dim == 1 { 0 } else { idx[offset_base + i] };
-        offset += take * stride[i];
-    }
-    offset
+pub fn exec_div(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-fn elementwise_binop_f32(
-    op: fn(f32, f32) -> f32,
-    lhs: (&[f32], &[usize]),
-    rhs: (&[f32], &[usize]),
-) -> R<(Vec<f32>, Vec<usize>)> {
-    let (ldata, lshape) = lhs;
-    let (rdata, rshape) = rhs;
-    let out_shape = broadcast_shapes(lshape, rshape)?;
-    let out_numel = numel(&out_shape);
-    let lstride = stride_for(lshape);
-    let rstride = stride_for(rshape);
-    let mut out = vec![0f32; out_numel];
-    if out_shape.is_empty() {
-        let li = index_broadcast(&[], lshape, &lstride);
-        let ri = index_broadcast(&[], rshape, &rstride);
-        out[0] = op(ldata[li], rdata[ri]);
-        return Ok((out, out_shape));
-    }
-    let mut idx = vec![0usize; out_shape.len()];
-    for linear in 0..out_numel {
-        let mut t = linear;
-        for ax in (0..out_shape.len()).rev() {
-            let dim = out_shape[ax];
-            idx[ax] = t % dim;
-            t /= dim;
-        }
-        let li = index_broadcast(&idx, lshape, &lstride);
-        let ri = index_broadcast(&idx, rshape, &rstride);
-        out[linear] = op(ldata[li], rdata[ri]);
-    }
-    Ok((out, out_shape))
+pub fn exec_add_scalar(_t: &TensorVal, _scalar: f32) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-fn elementwise_unary_f32<F>(op: F, data: &[f32]) -> Vec<f32>
-where
-    F: Fn(f32) -> f32,
-{
-    let mut out = data.to_vec();
-    for chunk in simd_chunks_mut(&mut out) {
-        for v in chunk {
-            *v = op(*v);
-        }
-    }
-    out
+pub fn exec_sub_scalar(_t: &TensorVal, _scalar: f32) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-fn reduce_sum(data: &[f32]) -> f32 {
-    data.iter().copied().sum()
+pub fn exec_scalar_sub(_scalar: f32, _t: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-pub fn exec_add(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
-    ensure_f32(lhs)?;
-    ensure_f32(rhs)?;
-    let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata = lhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata = rhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
-    let (out, shape) = elementwise_binop_f32(|a, b| a + b, (ldata, &lshape), (rdata, &rshape))?;
-    Ok(TensorVal::from_materialized_f32(shape, out))
+pub fn exec_mul_scalar(_t: &TensorVal, _scalar: f32) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-pub fn exec_sub(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
-    ensure_f32(lhs)?;
-    ensure_f32(rhs)?;
-    let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata = lhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata = rhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
-    let (out, shape) = elementwise_binop_f32(|a, b| a - b, (ldata, &lshape), (rdata, &rshape))?;
-    Ok(TensorVal::from_materialized_f32(shape, out))
+pub fn exec_div_scalar(_t: &TensorVal, _scalar: f32, _tensor_on_left: bool) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-pub fn exec_mul(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
-    ensure_f32(lhs)?;
-    ensure_f32(rhs)?;
-    let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata = lhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata = rhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
-    let (out, shape) = elementwise_binop_f32(|a, b| a * b, (ldata, &lshape), (rdata, &rshape))?;
-    Ok(TensorVal::from_materialized_f32(shape, out))
+pub fn exec_sum_all(_t: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-pub fn exec_div(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
-    ensure_f32(lhs)?;
-    ensure_f32(rhs)?;
-    let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let ldata = lhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata = rhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
-    if rdata.iter().any(|&v| v == 0.0) {
-        return Err(ExecError::Math("division by zero".into()));
-    }
-    let (out, shape) = elementwise_binop_f32(|a, b| a / b, (ldata, &lshape), (rdata, &rshape))?;
-    Ok(TensorVal::from_materialized_f32(shape, out))
+pub fn exec_mean_all(_t: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-pub fn exec_add_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
-    ensure_f32(t)?;
-    let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let out = elementwise_unary_f32(|v| v + scalar, data);
-    Ok(TensorVal::from_materialized_f32(shape, out))
+pub fn relu_inplace(_buf: &mut [f32]) {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    unimplemented!("In-place ReLU is provided by the proprietary MIND runtime backend");
 }
 
-pub fn exec_sub_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
-    ensure_f32(t)?;
-    let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let out = elementwise_unary_f32(|v| v - scalar, data);
-    Ok(TensorVal::from_materialized_f32(shape, out))
+pub fn exec_relu(_t: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-pub fn exec_scalar_sub(scalar: f32, t: &TensorVal) -> R<TensorVal> {
-    ensure_f32(t)?;
-    let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let out = elementwise_unary_f32(|v| scalar - v, data);
-    Ok(TensorVal::from_materialized_f32(shape, out))
+pub fn exec_matmul(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }
 
-pub fn exec_mul_scalar(t: &TensorVal, scalar: f32) -> R<TensorVal> {
-    ensure_f32(t)?;
-    let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let out = elementwise_unary_f32(|v| v * scalar, data);
-    Ok(TensorVal::from_materialized_f32(shape, out))
-}
-
-pub fn exec_div_scalar(t: &TensorVal, scalar: f32, tensor_on_left: bool) -> R<TensorVal> {
-    ensure_f32(t)?;
-    if !tensor_on_left && data_has_zero(t)? {
-        return Err(ExecError::Math("division by zero".into()));
-    }
-    let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let out = if tensor_on_left {
-        elementwise_unary_f32(|v| v / scalar, data)
-    } else {
-        elementwise_unary_f32(|v| scalar / v, data)
-    };
-    Ok(TensorVal::from_materialized_f32(shape, out))
-}
-
-fn data_has_zero(t: &TensorVal) -> R<bool> {
-    ensure_f32(t)?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    Ok(data.iter().any(|&v| v == 0.0))
-}
-
-pub fn exec_sum_all(t: &TensorVal) -> R<TensorVal> {
-    ensure_f32(t)?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let sum = reduce_sum(data);
-    Ok(TensorVal::from_materialized_f32(vec![], vec![sum]))
-}
-
-pub fn exec_mean_all(t: &TensorVal) -> R<TensorVal> {
-    ensure_f32(t)?;
-    let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    if shape.iter().any(|&d| d == 0) {
-        return Err(ExecError::Math("mean over zero elements".into()));
-    }
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let sum = reduce_sum(data);
-    let count = numel(&shape) as f32;
-    Ok(TensorVal::from_materialized_f32(vec![], vec![sum / count]))
-}
-
-pub fn relu_inplace(buf: &mut [f32]) {
-    for chunk in simd_chunks_mut(buf) {
-        for v in chunk {
-            if *v < 0.0 {
-                *v = 0.0;
-            }
-        }
-    }
-}
-
-pub fn exec_relu(t: &TensorVal) -> R<TensorVal> {
-    ensure_f32(t)?;
-    let shape = shape_usize(&t.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let data = t
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("tensor not materialized".into()))?;
-    let mut out = data.to_vec();
-    relu_inplace(&mut out);
-    Ok(TensorVal::from_materialized_f32(shape, out))
-}
-
-pub fn exec_matmul(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
-    ensure_f32(lhs)?;
-    ensure_f32(rhs)?;
-    let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    if lshape.len() != 2 || rshape.len() != 2 {
-        return Err(ExecError::Shape("matmul expects 2D tensors".into()));
-    }
-    let (m, k1) = (lshape[0], lshape[1]);
-    let (k2, n) = (rshape[0], rshape[1]);
-    if k1 != k2 {
-        return Err(ExecError::Shape("inner dims mismatch".into()));
-    }
-    let ldata = lhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-    let rdata = rhs
-        .as_f32()
-        .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
-    let mut out = vec![0f32; m * n];
-    for i in 0..m {
-        for j in 0..n {
-            let mut acc = 0f32;
-            for k in 0..k1 {
-                acc += ldata[i * k1 + k] * rdata[k * n + j];
-            }
-            out[i * n + j] = acc;
-        }
-    }
-    Ok(TensorVal::from_materialized_f32(vec![m, n], out))
-}
-
-pub fn exec_dot(lhs: &TensorVal, rhs: &TensorVal) -> R<TensorVal> {
-    ensure_f32(lhs)?;
-    ensure_f32(rhs)?;
-    let lshape = shape_usize(&lhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    let rshape = shape_usize(&rhs.shape).ok_or_else(|| ExecError::Shape("symbolic dims".into()))?;
-    match (lshape.len(), rshape.len()) {
-        (1, 1) => {
-            if lshape[0] != rshape[0] {
-                return Err(ExecError::Shape("dot expects equal length vectors".into()));
-            }
-            let ldata = lhs
-                .as_f32()
-                .ok_or_else(|| ExecError::Unsupported("lhs not materialized".into()))?;
-            let rdata = rhs
-                .as_f32()
-                .ok_or_else(|| ExecError::Unsupported("rhs not materialized".into()))?;
-            let sum = ldata.iter().zip(rdata.iter()).map(|(a, b)| a * b).sum();
-            Ok(TensorVal::from_materialized_f32(vec![], vec![sum]))
-        }
-        (2, 2) => exec_matmul(lhs, rhs),
-        _ => Err(ExecError::Shape("dot expects 1D or 2D tensors".into())),
-    }
+pub fn exec_dot(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
+    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    runtime_stub()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod parser;
 pub mod stdlib;
 pub mod type_checker;
 pub mod types;
+pub mod runtime_interface;
 
 pub mod ir;
 

--- a/src/runtime_interface.rs
+++ b/src/runtime_interface.rs
@@ -1,4 +1,4 @@
-use crate::types::{DType, Shape};
+use crate::types::{DType, ShapeDim};
 
 #[derive(Clone, Copy, Debug)]
 pub enum DeviceKind {
@@ -9,7 +9,7 @@ pub enum DeviceKind {
 
 #[derive(Clone, Debug)]
 pub struct TensorDesc {
-    pub shape: Shape,
+    pub shape: Vec<ShapeDim>,
     pub dtype: DType,
 }
 


### PR DESCRIPTION
## Summary
- replace CPU and convolution execution modules with stubs that point to the proprietary runtime backend
- add convenient evaluator constructors and note where runtime dispatch should be threaded
- document the open-core/runtime split and update runtime FFI docs to match the public interface

## Testing
- cargo check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fe7178988322a814171eeadf6317)