### PR TITLE
Clean up runtime_interface export and module wiring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ pub mod runtime_interface;
 pub mod stdlib;
 pub mod type_checker;
 pub mod types;
-
 pub mod ir;
 
 #[cfg(feature = "autodiff")]


### PR DESCRIPTION
## Summary
- remove the extra blank line in `src/lib.rs` so the module list stays contiguous around the `runtime_interface` export

## Testing
- cargo check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693702373cdc8322b90d7db521ad5ca1)