### PR TITLE
Polish runtime docs and stubs

### DIFF
--- a/docs/ffi-runtime.md
+++ b/docs/ffi-runtime.md
@@ -7,7 +7,7 @@ The open-core repository exposes the surface needed to embed compiled MIND modul
 The `runtime_interface` module defines the traits used by evaluators and FFI shims:
 
 - `MindRuntime` – a backend-agnostic trait for allocating tensors, launching operations, and synchronizing devices.
-- `TensorDesc` – a simple descriptor that pairs `Shape` metadata with a `DType`.
+- `TensorDesc` – a simple descriptor that pairs shape dimensions (`Vec<ShapeDim>`) with a `DType`.
 - `DeviceKind` – identifies a broad execution target (CPU, GPU, or other accelerators).
 
 Backends implement `MindRuntime` to provide real allocators and kernel dispatch. The default `NoOpRuntime` included here is a stub suitable for compiler smoke tests.
@@ -19,10 +19,15 @@ Backends implement `MindRuntime` to provide real allocators and kernel dispatch.
 3. Use the runtime to allocate inputs, run operations, and collect outputs through the backend-specific API.
 
 ```rust
-use mind::runtime_interface::{MindRuntime, NoOpRuntime, TensorDesc};
+use mind::runtime_interface::{DeviceKind, MindRuntime, NoOpRuntime, TensorDesc};
+use mind::types::ShapeDim;
 
 fn run_demo(runtime: &dyn MindRuntime) {
-    let buffer = runtime.allocate(&TensorDesc { shape: vec![2, 3].into(), dtype: mind::types::DType::F32 });
+    let buffer = runtime.allocate(&TensorDesc {
+        shape: vec![ShapeDim::Known(2), ShapeDim::Known(3)],
+        dtype: mind::types::DType::F32,
+        device: Some(DeviceKind::Cpu),
+    });
     runtime.run_op("demo_op", &[buffer], &[]);
     runtime.synchronize();
 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -90,12 +90,12 @@ mod tests {
 
     #[test]
     fn evaluator_uses_default_runtime() {
-        let mut eval = Evaluator::new();
+        let eval = Evaluator::new();
 
         let desc = TensorDesc {
             shape: Vec::new(),
             dtype: DType::F32,
-            device: DeviceKind::Cpu,
+            device: Some(DeviceKind::Cpu),
         };
 
         let handle = eval.runtime.allocate(&desc);

--- a/src/exec/conv.rs
+++ b/src/exec/conv.rs
@@ -19,7 +19,7 @@ use crate::types::ShapeDim;
 use super::cpu::ExecError;
 
 fn _shape_as_usize(_shape: &[ShapeDim]) -> Result<Vec<usize>, ExecError> {
-    // TODO(runtime): shape handling is implemented in the proprietary runtime backend.
+    // TODO(runtime): implement shape handling in the proprietary runtime backend.
     Err(ExecError::Unsupported(
         "Convolution shape materialization is provided by the proprietary MIND runtime".into(),
     ))
@@ -32,7 +32,7 @@ pub fn exec_conv2d(
     _stride_w: usize,
     _padding: ConvPadding,
 ) -> Result<TensorVal, ExecError> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     Err(ExecError::Unsupported(
         "Conv2d execution is provided by the proprietary MIND runtime backend".into(),
     ))

--- a/src/exec/cpu.rs
+++ b/src/exec/cpu.rs
@@ -39,76 +39,76 @@ fn _shape_usize(_shape: &[ShapeDim]) -> Option<Vec<usize>> {
 }
 
 pub fn exec_add(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_sub(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_mul(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_div(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_add_scalar(_t: &TensorVal, _scalar: f32) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_sub_scalar(_t: &TensorVal, _scalar: f32) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_scalar_sub(_scalar: f32, _t: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_mul_scalar(_t: &TensorVal, _scalar: f32) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_div_scalar(_t: &TensorVal, _scalar: f32, _tensor_on_left: bool) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_sum_all(_t: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_mean_all(_t: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn relu_inplace(_buf: &mut [f32]) {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     unimplemented!("In-place ReLU is provided by the proprietary MIND runtime backend");
 }
 
 pub fn exec_relu(_t: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_matmul(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }
 
 pub fn exec_dot(_lhs: &TensorVal, _rhs: &TensorVal) -> R<TensorVal> {
-    // TODO(runtime): implemented in proprietary `mind-runtime` backend.
+    // TODO(runtime): implement in proprietary `mind-runtime` backend.
     runtime_stub()
 }

--- a/src/runtime_interface.rs
+++ b/src/runtime_interface.rs
@@ -20,7 +20,7 @@ pub struct TensorDesc {
     pub shape: Vec<ShapeDim>,
     pub dtype: DType,
     /// Optional execution device for this tensor.
-    pub device: DeviceKind,
+    pub device: Option<DeviceKind>,
 }
 
 /// Core interface for the MIND runtime.


### PR DESCRIPTION
## Summary
- update FFI runtime documentation to reflect the current TensorDesc shape and device fields
- normalize runtime stub TODO comments and make TensorDesc device optional in the interface and tests
- clean evaluator test naming and defaults

## Testing
- cargo check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693704412490832294067ffaef6c713d)