### PR TITLE
Harden IR core: canonicalization, verifier, stable printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Explore the full language tour and runtime guides in [`/docs`](docs/README.md).
 
 * [Type System](docs/type-system.md) — ranks, shapes, polymorphism, and effect tracking.
 * [Autodiff](docs/autodiff.md) — reverse-mode differentiation on the SSA IR.
+* [IR core](docs/ir.md) — deterministic IR pipeline with verifier and printer.
 * [IR & MLIR](docs/ir-mlir.md) — compiler pipeline from parser to MLIR dialects.
 
 ## Architecture

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -1,0 +1,52 @@
+# MIND IR core
+
+MIND lowers parsed programs into a lightweight SSA-style IR that is intentionally
+deterministic. The IR is used by static autodiff, the interpreter, and the MLIR
+export path. This document tracks the hardening work that keeps the IR stable
+for downstream consumers.
+
+## Canonicalization
+
+The `canonicalize_module` pass lives in `src/opt/ir_canonical.rs` and performs
+deterministic cleanups:
+
+- Orders operands for commutative arithmetic to remove incidental variance.
+- Removes dead instructions that do not contribute to outputs.
+- Performs simple constant folding on integer binary ops.
+- Resets `next_id` so SSA identifiers remain dense and reproducible.
+
+The pass is pure and idempotent—running it multiple times produces identical
+results.
+
+## Verifier
+
+The IR verifier (`src/ir/verify.rs`) enforces SSA discipline and basic operand
+sanity:
+
+- Every SSA value is defined exactly once and before it is used.
+- An `Output` instruction must be present.
+- `next_id` must be in sync with the highest defined value.
+- Numeric operands (axes, etc.) are checked for obviously invalid values.
+
+The verifier never panics on malformed IR; it returns structured
+`IrVerifyError` values for deterministic diagnostics.
+
+## Stable pretty-printer
+
+`format_ir_module` (`src/ir/print.rs`) renders IR in a stable, human-readable
+form that is suitable for snapshot tests and debugging. Functions, basic
+blocks, and instructions are emitted in deterministic order with consistent SSA
+identifiers.
+
+## Backend preparation
+
+Use `prepare_ir_for_backend` to combine verification and canonicalization before
+handing IR to downstream consumers:
+
+```rust
+let mut ir = lower_to_ir(&parsed_module);
+prepare_ir_for_backend(&mut ir)?;
+```
+
+This helper ensures the IR is valid and canonical before autodiff, MLIR
+lowering, or interpretation.

--- a/src/ir/print.rs
+++ b/src/ir/print.rs
@@ -1,0 +1,221 @@
+// Copyright 2025 STARGA Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Part of the MIND project (Machine Intelligence Native Design).
+
+use std::fmt::Write;
+
+use crate::ir::{BinOp, IRModule, Instr, ValueId};
+use crate::types::{DType, ShapeDim};
+
+/// Format an [`IRModule`] into a stable, human-readable string.
+pub fn format_ir_module(module: &IRModule) -> String {
+    let mut out = String::new();
+    writeln!(&mut out, "module {{").expect("write to string cannot fail");
+    for instr in &module.instrs {
+        format_instr(instr, &mut out);
+    }
+    writeln!(&mut out, "}}  // next_id = {}", module.next_id).expect("write to string cannot fail");
+    out
+}
+
+fn format_instr(instr: &Instr, out: &mut String) {
+    match instr {
+        Instr::ConstI64(id, value) => {
+            writeln!(out, "  {} = const.i64 {}", value_name(*id), value).unwrap();
+        }
+        Instr::ConstTensor(id, dtype, shape, fill) => {
+            writeln!(
+                out,
+                "  {} = const.tensor {} {:?} fill={:?}",
+                value_name(*id),
+                format_dtype(dtype),
+                format_shape(shape),
+                fill
+            )
+            .unwrap();
+        }
+        Instr::BinOp { dst, op, lhs, rhs } => {
+            writeln!(
+                out,
+                "  {} = {} {}, {}",
+                value_name(*dst),
+                format_binop(*op),
+                value_name(*lhs),
+                value_name(*rhs)
+            )
+            .unwrap();
+        }
+        Instr::Sum {
+            dst,
+            src,
+            axes,
+            keepdims,
+        } => {
+            writeln!(
+                out,
+                "  {} = sum {} axes={:?} keepdims={}",
+                value_name(*dst),
+                value_name(*src),
+                axes,
+                keepdims
+            )
+            .unwrap();
+        }
+        Instr::Mean {
+            dst,
+            src,
+            axes,
+            keepdims,
+        } => {
+            writeln!(
+                out,
+                "  {} = mean {} axes={:?} keepdims={}",
+                value_name(*dst),
+                value_name(*src),
+                axes,
+                keepdims
+            )
+            .unwrap();
+        }
+        Instr::Reshape {
+            dst,
+            src,
+            new_shape,
+        } => {
+            writeln!(
+                out,
+                "  {} = reshape {} {:?}",
+                value_name(*dst),
+                value_name(*src),
+                format_shape(new_shape)
+            )
+            .unwrap();
+        }
+        Instr::ExpandDims { dst, src, axis } => {
+            writeln!(
+                out,
+                "  {} = expand_dims {} axis={}",
+                value_name(*dst),
+                value_name(*src),
+                axis
+            )
+            .unwrap();
+        }
+        Instr::Squeeze { dst, src, axes } => {
+            writeln!(
+                out,
+                "  {} = squeeze {} axes={:?}",
+                value_name(*dst),
+                value_name(*src),
+                axes
+            )
+            .unwrap();
+        }
+        Instr::Transpose { dst, src, perm } => {
+            writeln!(
+                out,
+                "  {} = transpose {} perm={:?}",
+                value_name(*dst),
+                value_name(*src),
+                perm
+            )
+            .unwrap();
+        }
+        Instr::Dot { dst, a, b } => {
+            writeln!(
+                out,
+                "  {} = dot {}, {}",
+                value_name(*dst),
+                value_name(*a),
+                value_name(*b)
+            )
+            .unwrap();
+        }
+        Instr::MatMul { dst, a, b } => {
+            writeln!(
+                out,
+                "  {} = matmul {}, {}",
+                value_name(*dst),
+                value_name(*a),
+                value_name(*b)
+            )
+            .unwrap();
+        }
+        Instr::Index { dst, src, indices } => {
+            writeln!(
+                out,
+                "  {} = index {} {:?}",
+                value_name(*dst),
+                value_name(*src),
+                indices
+            )
+            .unwrap();
+        }
+        Instr::Slice { dst, src, dims } => {
+            writeln!(
+                out,
+                "  {} = slice {} {:?}",
+                value_name(*dst),
+                value_name(*src),
+                dims
+            )
+            .unwrap();
+        }
+        Instr::Gather {
+            dst,
+            src,
+            indices,
+            axis,
+        } => {
+            writeln!(
+                out,
+                "  {} = gather {} indices={} axis={}",
+                value_name(*dst),
+                value_name(*src),
+                value_name(*indices),
+                axis
+            )
+            .unwrap();
+        }
+        Instr::Output(id) => {
+            writeln!(out, "  output {}", value_name(*id)).unwrap();
+        }
+    }
+}
+
+fn value_name(id: ValueId) -> String {
+    format!("%{}", id.0)
+}
+
+fn format_binop(op: BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "add",
+        BinOp::Sub => "sub",
+        BinOp::Mul => "mul",
+        BinOp::Div => "div",
+    }
+}
+
+fn format_dtype(dtype: &DType) -> String {
+    format!("{:?}", dtype)
+}
+
+fn format_shape(shape: &[ShapeDim]) -> Vec<String> {
+    shape
+        .iter()
+        .map(|dim| match dim {
+            ShapeDim::Known(n) => n.to_string(),
+            ShapeDim::Sym(sym) => sym.to_string(),
+        })
+        .collect()
+}

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -1,0 +1,156 @@
+// Copyright 2025 STARGA Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Part of the MIND project (Machine Intelligence Native Design).
+
+use std::collections::BTreeSet;
+
+use crate::ir::{IRModule, Instr, ValueId};
+
+/// Structured errors returned by the IR verifier.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum IrVerifyError {
+    /// Multiple instructions attempted to define the same SSA value.
+    #[error("duplicate definition for value %{0}")]
+    DuplicateDefinition(ValueId),
+    /// A value was referenced before it had been defined.
+    #[error("use of undefined value %{value} at instruction {instr_index}")]
+    UseBeforeDefinition { value: ValueId, instr_index: usize },
+    /// The module contains no `Output` instruction.
+    #[error("module is missing an Output instruction")]
+    MissingOutput,
+    /// The module's `next_id` counter does not match the SSA IDs in use.
+    #[error("next_id {found} is smaller than required {expected}")]
+    NextIdOutOfSync { found: usize, expected: usize },
+    /// Operand validation failed (e.g., a negative axis or stride).
+    #[error("invalid operand in instruction {instr_index}: {message}")]
+    InvalidOperand { instr_index: usize, message: String },
+}
+
+/// Verify that an [`IRModule`] is well-formed and deterministic.
+///
+/// The verifier enforces SSA discipline (unique definitions, no use-before-def),
+/// basic operand sanity, and synchronization of the module's `next_id` counter.
+/// It returns structured errors instead of panicking on invalid input.
+pub fn verify_module(module: &IRModule) -> Result<(), IrVerifyError> {
+    let mut defined: BTreeSet<ValueId> = BTreeSet::new();
+    let mut saw_output = false;
+    let mut max_seen = 0usize;
+
+    for (idx, instr) in module.instrs.iter().enumerate() {
+        validate_operands(idx, instr, &defined)?;
+
+        if let Some(dst) = instruction_dst(instr) {
+            if !defined.insert(dst) {
+                return Err(IrVerifyError::DuplicateDefinition(dst));
+            }
+            max_seen = max_seen.max(dst.0 + 1);
+        }
+
+        if matches!(instr, Instr::Output(_)) {
+            saw_output = true;
+        }
+    }
+
+    if !saw_output {
+        return Err(IrVerifyError::MissingOutput);
+    }
+
+    if module.next_id < max_seen {
+        return Err(IrVerifyError::NextIdOutOfSync {
+            found: module.next_id,
+            expected: max_seen,
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_operands(
+    instr_index: usize,
+    instr: &Instr,
+    defined: &BTreeSet<ValueId>,
+) -> Result<(), IrVerifyError> {
+    let check_defined = |value: ValueId| {
+        if !defined.contains(&value) {
+            Err(IrVerifyError::UseBeforeDefinition { value, instr_index })
+        } else {
+            Ok(())
+        }
+    };
+
+    match instr {
+        Instr::ConstI64(_, _) | Instr::ConstTensor(_, _, _, _) => {}
+        Instr::BinOp { lhs, rhs, .. } => {
+            check_defined(*lhs)?;
+            check_defined(*rhs)?;
+        }
+        Instr::Sum { src, axes, .. } | Instr::Mean { src, axes, .. } => {
+            check_defined(*src)?;
+            if axes.iter().any(|axis| *axis < 0) {
+                return Err(IrVerifyError::InvalidOperand {
+                    instr_index,
+                    message: "axes must be non-negative".to_string(),
+                });
+            }
+        }
+        Instr::Reshape { src, .. }
+        | Instr::ExpandDims { src, .. }
+        | Instr::Squeeze { src, .. }
+        | Instr::Transpose { src, .. }
+        | Instr::Index { src, .. }
+        | Instr::Slice { src, .. } => {
+            check_defined(*src)?;
+        }
+        Instr::Dot { a, b, .. } | Instr::MatMul { a, b, .. } => {
+            check_defined(*a)?;
+            check_defined(*b)?;
+        }
+        Instr::Gather {
+            src, indices, axis, ..
+        } => {
+            check_defined(*src)?;
+            check_defined(*indices)?;
+            if *axis < 0 {
+                return Err(IrVerifyError::InvalidOperand {
+                    instr_index,
+                    message: "axis must be non-negative".to_string(),
+                });
+            }
+        }
+        Instr::Output(id) => {
+            check_defined(*id)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn instruction_dst(instr: &Instr) -> Option<ValueId> {
+    match instr {
+        Instr::ConstI64(dst, ..)
+        | Instr::ConstTensor(dst, ..)
+        | Instr::BinOp { dst, .. }
+        | Instr::Sum { dst, .. }
+        | Instr::Mean { dst, .. }
+        | Instr::Reshape { dst, .. }
+        | Instr::ExpandDims { dst, .. }
+        | Instr::Squeeze { dst, .. }
+        | Instr::Transpose { dst, .. }
+        | Instr::Dot { dst, .. }
+        | Instr::MatMul { dst, .. }
+        | Instr::Index { dst, .. }
+        | Instr::Slice { dst, .. }
+        | Instr::Gather { dst, .. } => Some(*dst),
+        Instr::Output(_) => None,
+    }
+}

--- a/src/opt/ir_canonical.rs
+++ b/src/opt/ir_canonical.rs
@@ -1,0 +1,165 @@
+// Copyright 2025 STARGA Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Part of the MIND project (Machine Intelligence Native Design).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ir::{BinOp, IRModule, Instr, ValueId};
+
+/// Canonicalize the public MIND IR in-place.
+///
+/// The pass is intentionally conservative: it keeps the existing SSA IDs,
+/// performs deterministic cleanups (operand ordering, trivial constant folding),
+/// and prunes provably dead instructions. Running the pass repeatedly is
+/// idempotent.
+pub fn canonicalize_module(module: &mut IRModule) {
+    let mut instrs = prune_dead(&module.instrs);
+    reorder_commutative_ops(&mut instrs);
+    constant_fold(&mut instrs);
+    instrs = prune_dead(&instrs);
+
+    module.instrs = instrs;
+    module.next_id = next_sequential_id(module);
+}
+
+fn prune_dead(instrs: &[Instr]) -> Vec<Instr> {
+    let mut used: BTreeSet<ValueId> = BTreeSet::new();
+    for instr in instrs.iter().rev() {
+        match instr {
+            Instr::Output(id) => {
+                used.insert(*id);
+            }
+            other => {
+                let dst = instruction_dst(other);
+                if dst.map_or(true, |id| used.contains(&id)) {
+                    for operand in instruction_operands(other) {
+                        used.insert(operand);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut pruned = Vec::with_capacity(instrs.len());
+    for instr in instrs {
+        if let Some(dst) = instruction_dst(instr) {
+            if !used.contains(&dst) {
+                continue;
+            }
+        }
+        pruned.push(instr.clone());
+    }
+    pruned
+}
+
+fn reorder_commutative_ops(instrs: &mut [Instr]) {
+    for instr in instrs.iter_mut() {
+        if let Instr::BinOp { op, lhs, rhs, .. } = instr {
+            if matches!(op, BinOp::Add | BinOp::Mul) && rhs < lhs {
+                std::mem::swap(lhs, rhs);
+            }
+        }
+    }
+}
+
+fn constant_fold(instrs: &mut Vec<Instr>) {
+    let mut constants: BTreeMap<ValueId, i64> = BTreeMap::new();
+    for instr in instrs.iter_mut() {
+        match instr {
+            Instr::ConstI64(id, value) => {
+                constants.insert(*id, *value);
+            }
+            Instr::BinOp { dst, op, lhs, rhs } => {
+                let dst_id = *dst;
+                let lhs_id = *lhs;
+                let rhs_id = *rhs;
+                let op_kind = *op;
+
+                if let (Some(l), Some(r)) = (
+                    constants.get(&lhs_id).copied(),
+                    constants.get(&rhs_id).copied(),
+                ) {
+                    let folded = match op_kind {
+                        BinOp::Add => l.saturating_add(r),
+                        BinOp::Sub => l.saturating_sub(r),
+                        BinOp::Mul => l.saturating_mul(r),
+                        BinOp::Div => {
+                            if r == 0 {
+                                continue;
+                            }
+                            l / r
+                        }
+                    };
+                    *instr = Instr::ConstI64(dst_id, folded);
+                    constants.insert(dst_id, folded);
+                    continue;
+                }
+
+                constants.remove(&dst_id);
+            }
+            _ => {
+                if let Some(dst) = instruction_dst(instr) {
+                    constants.remove(&dst);
+                }
+            }
+        }
+    }
+}
+
+fn next_sequential_id(module: &IRModule) -> usize {
+    module
+        .instrs
+        .iter()
+        .filter_map(instruction_dst)
+        .map(|id| id.0 + 1)
+        .max()
+        .unwrap_or(0)
+}
+
+fn instruction_dst(instr: &Instr) -> Option<ValueId> {
+    match instr {
+        Instr::ConstI64(dst, ..)
+        | Instr::ConstTensor(dst, ..)
+        | Instr::BinOp { dst, .. }
+        | Instr::Sum { dst, .. }
+        | Instr::Mean { dst, .. }
+        | Instr::Reshape { dst, .. }
+        | Instr::ExpandDims { dst, .. }
+        | Instr::Squeeze { dst, .. }
+        | Instr::Transpose { dst, .. }
+        | Instr::Dot { dst, .. }
+        | Instr::MatMul { dst, .. }
+        | Instr::Index { dst, .. }
+        | Instr::Slice { dst, .. }
+        | Instr::Gather { dst, .. } => Some(*dst),
+        Instr::Output(_) => None,
+    }
+}
+
+fn instruction_operands(instr: &Instr) -> Vec<ValueId> {
+    match instr {
+        Instr::ConstI64(_, _) | Instr::ConstTensor(_, _, _, _) => Vec::new(),
+        Instr::BinOp { lhs, rhs, .. } => vec![*lhs, *rhs],
+        Instr::Sum { src, .. }
+        | Instr::Mean { src, .. }
+        | Instr::Reshape { src, .. }
+        | Instr::ExpandDims { src, .. }
+        | Instr::Squeeze { src, .. }
+        | Instr::Transpose { src, .. }
+        | Instr::Index { src, .. }
+        | Instr::Slice { src, .. } => vec![*src],
+        Instr::Dot { a, b, .. } | Instr::MatMul { a, b, .. } => vec![*a, *b],
+        Instr::Gather { src, indices, .. } => vec![*src, *indices],
+        Instr::Output(id) => vec![*id],
+    }
+}

--- a/src/opt/mod.rs
+++ b/src/opt/mod.rs
@@ -13,3 +13,4 @@
 // Part of the MIND project (Machine Intelligence Native Design).
 
 pub mod fold;
+pub mod ir_canonical;

--- a/tests/ir_core.rs
+++ b/tests/ir_core.rs
@@ -1,0 +1,119 @@
+use mind::ir::{
+    canonicalize_module, format_ir_module, prepare_ir_for_backend, verify_module, BinOp, IRModule,
+    Instr, IrVerifyError, ValueId,
+};
+
+fn scalar_const(ir: &mut IRModule, value: i64) -> ValueId {
+    let id = ir.fresh();
+    ir.instrs.push(Instr::ConstI64(id, value));
+    id
+}
+
+#[test]
+fn canonicalization_is_deterministic_and_idempotent() {
+    let mut module = IRModule::new();
+    let unused = scalar_const(&mut module, 7);
+    let a = scalar_const(&mut module, 1);
+    let b = scalar_const(&mut module, 2);
+    let add = module.fresh();
+    module.instrs.push(Instr::BinOp {
+        dst: add,
+        op: BinOp::Add,
+        lhs: b,
+        rhs: a,
+    });
+    module.instrs.push(Instr::Output(add));
+    // Ensure the unused const is kept alive in the SSA namespace but removed from code.
+    module.next_id = unused.0.max(module.next_id);
+
+    let mut second = module.clone();
+
+    canonicalize_module(&mut module);
+    canonicalize_module(&mut second);
+
+    assert_eq!(format_ir_module(&module), format_ir_module(&second));
+
+    let snapshot = format_ir_module(&module);
+    canonicalize_module(&mut module);
+    assert_eq!(snapshot, format_ir_module(&module));
+}
+
+#[test]
+fn canonicalization_constant_folds_simple_ints() {
+    let mut module = IRModule::new();
+    let a = scalar_const(&mut module, 4);
+    let b = scalar_const(&mut module, 6);
+    let dst = module.fresh();
+    module.instrs.push(Instr::BinOp {
+        dst,
+        op: BinOp::Mul,
+        lhs: a,
+        rhs: b,
+    });
+    module.instrs.push(Instr::Output(dst));
+
+    canonicalize_module(&mut module);
+    let printed = format_ir_module(&module);
+    assert!(
+        printed.contains("const.i64 24"),
+        "expected constant folding: {}",
+        printed
+    );
+    assert!(
+        !printed.contains("const.i64 4\n  %1 = const.i64 6"),
+        "dead inputs were not removed after folding: {}",
+        printed
+    );
+}
+
+#[test]
+fn verifier_catches_missing_output() {
+    let module = IRModule::new();
+    let err = verify_module(&module).unwrap_err();
+    assert!(matches!(err, IrVerifyError::MissingOutput));
+}
+
+#[test]
+fn verifier_rejects_use_before_definition() {
+    let mut module = IRModule::new();
+    let phantom = ValueId(99);
+    module.instrs.push(Instr::Output(phantom));
+
+    let err = verify_module(&module).unwrap_err();
+    assert!(matches!(err, IrVerifyError::UseBeforeDefinition { .. }));
+}
+
+#[test]
+fn verifier_checks_next_id_sync() {
+    let mut module = IRModule::new();
+    let id = module.fresh();
+    module.instrs.push(Instr::ConstI64(id, 1));
+    module.instrs.push(Instr::Output(id));
+    module.next_id = 0; // deliberately stale
+
+    let err = verify_module(&module).unwrap_err();
+    assert!(matches!(err, IrVerifyError::NextIdOutOfSync { .. }));
+}
+
+#[test]
+fn prepare_pipeline_runs_verifier_and_canonicalizer() {
+    let mut module = IRModule::new();
+    let a = scalar_const(&mut module, 2);
+    let b = scalar_const(&mut module, 3);
+    let dst = module.fresh();
+    module.instrs.push(Instr::BinOp {
+        dst,
+        op: BinOp::Add,
+        lhs: b,
+        rhs: a,
+    });
+    module.instrs.push(Instr::Output(dst));
+
+    prepare_ir_for_backend(&mut module).expect("backend prep");
+    let printed = format_ir_module(&module);
+    assert!(
+        printed.contains("const.i64 5"),
+        "expected folded sum: {}",
+        printed
+    );
+}


### PR DESCRIPTION
## Summary
- add an IR canonicalization pass with deterministic operand ordering, dead-code pruning, and simple constant folding
- introduce an explicit IR verifier, stable pretty-printer, and backend prep helper
- document the IR core and add snapshot-style tests for determinism and validation

## Testing
- cargo test -- --nocapture


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693711bb7860832289c95a452bc6f790)