### PR TITLE
Fix MLIR lowering destination style and validation

### DIFF
--- a/tests/mlir_lowering.rs
+++ b/tests/mlir_lowering.rs
@@ -52,6 +52,8 @@ fn lowers_basic_arithmetic() {
     let text_b =
         compile_ir_to_mlir_text(&mut cloned).expect("lowering should succeed deterministically");
 
+    assert!(text_a.contains("func.func @main() -> (tensor<2x2xf32>)"));
+    assert!(text_a.contains("linalg.fill ins(%fill"));
     assert!(text_a.contains("arith.addf"));
     assert_eq!(text_a, text_b, "lowering must be deterministic");
 }
@@ -80,8 +82,10 @@ fn lowers_matmul() {
     module.instrs.push(Instr::Output(dst));
 
     let text = compile_ir_to_mlir_text(&mut module).expect("matmul lowering");
-    assert!(text.contains("linalg.matmul"));
-    assert!(text.contains("tensor<2x4xf32>"));
+    assert!(text.contains("func.func @main() -> (tensor<2x4xf32>)"));
+    assert!(text.contains("tensor.empty"));
+    assert!(text.contains("linalg.matmul ins(%"));
+    assert!(text.contains("outs(%tmp"));
 }
 
 #[test]
@@ -121,8 +125,10 @@ fn lowers_conv2d() {
     module.instrs.push(Instr::Output(dst));
 
     let text = compile_ir_to_mlir_text(&mut module).expect("conv2d lowering");
+    assert!(text.contains("func.func @main() -> (tensor<1x8x8x4xf32>)"));
+    assert!(text.contains("tensor.empty"));
     assert!(text.contains("linalg.conv_2d_nhwc_hwcf"));
-    assert!(text.contains("tensor<1x8x8x4xf32>"));
+    assert!(text.contains("outs(%tmp"));
 }
 
 #[test]
@@ -158,6 +164,47 @@ fn lowers_multiple_outputs() {
     module.instrs.push(Instr::Output(a));
 
     let text = compile_ir_to_mlir_text(&mut module).expect("lowering should work");
+    assert!(text.contains("func.func @main() -> (i64, i64)"));
     assert!(text.contains("return %"));
     assert!(text.contains("i64"));
+}
+
+#[test]
+fn conv2d_mismatched_channels() {
+    let mut module = IRModule::new();
+    let input = tensor_const(
+        &mut module,
+        DType::F32,
+        vec![
+            ShapeDim::Known(1),
+            ShapeDim::Known(4),
+            ShapeDim::Known(4),
+            ShapeDim::Known(3),
+        ],
+        Some(0.0),
+    );
+    let filter = tensor_const(
+        &mut module,
+        DType::F32,
+        vec![
+            ShapeDim::Known(3),
+            ShapeDim::Known(3),
+            ShapeDim::Known(4),
+            ShapeDim::Known(8),
+        ],
+        Some(0.0),
+    );
+    let dst = module.fresh();
+    module.instrs.push(Instr::Conv2d {
+        dst,
+        input,
+        filter,
+        stride_h: 1,
+        stride_w: 1,
+        padding: ConvPadding::Same,
+    });
+    module.instrs.push(Instr::Output(dst));
+
+    let err = compile_ir_to_mlir_text(&mut module).expect_err("channel mismatch should error");
+    assert!(matches!(err, mind::MlirLowerError::ShapeError(msg) if msg.contains("input channels")));
 }


### PR DESCRIPTION
## Summary
- emit linalg.matmul/conv_2d ops using destination-passing with empty tensors
- separate fill constants from linalg.fill and align MLIR function signatures with outputs
- add conv2d channel compatibility checks and refresh MLIR lowering tests

## Testing
- cargo check --features "mlir-lowering"
- cargo test --features "mlir-lowering"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371b7552488322bb7e5d830d333cee)