### PR TITLE
Standardize MLIR lowering temporary names

### DIFF
--- a/src/mlir/lowering.rs
+++ b/src/mlir/lowering.rs
@@ -165,11 +165,11 @@ impl LoweringContext {
                 let (out_shape, m_ty, n_ty, result_ty) =
                     matmul_shapes(&a_info.shape, &b_info.shape, a_info.dtype.as_str())?;
                 self.emit_line(&format!(
-                    "    %tmp{}_init = tensor.empty() : {}",
+                    "    %tmp{} = tensor.empty() : {}",
                     dst.0, result_ty
                 ));
                 self.emit_line(&format!(
-                    "    %{} = linalg.matmul ins(%{} : {} , %{} : {}) outs(%tmp{}_init : {}) -> {}",
+                    "    %{} = linalg.matmul ins(%{} : {} , %{} : {}) outs(%tmp{} : {}) -> {}",
                     dst.0, a.0, m_ty, b.0, n_ty, dst.0, result_ty, result_ty
                 ));
                 self.values.insert(
@@ -193,11 +193,11 @@ impl LoweringContext {
                 let (out_shape, input_ty, filter_ty, result_ty) =
                     conv2d_shapes(&input_info, &filter_info, *stride_h, *stride_w, *padding)?;
                 self.emit_line(&format!(
-                    "    %tmp{}_init = tensor.empty() : {}",
+                    "    %tmp{} = tensor.empty() : {}",
                     dst.0, result_ty
                 ));
                 self.emit_line(&format!(
-                    "    %{} = linalg.conv_2d_nhwc_hwcf ins(%{} : {}, %{} : {}) outs(%tmp{}_init : {}) -> {}",
+                    "    %{} = linalg.conv_2d_nhwc_hwcf ins(%{} : {}, %{} : {}) outs(%tmp{} : {}) -> {}",
                     dst.0, input.0, input_ty, filter.0, filter_ty, dst.0, result_ty, result_ty
                 ));
                 self.values.insert(

--- a/tests/mlir_lowering.rs
+++ b/tests/mlir_lowering.rs
@@ -83,9 +83,10 @@ fn lowers_matmul() {
 
     let text = compile_ir_to_mlir_text(&mut module).expect("matmul lowering");
     assert!(text.contains("func.func @main() -> (tensor<2x4xf32>)"));
-    assert!(text.contains("tensor.empty"));
-    assert!(text.contains("linalg.matmul ins(%"));
-    assert!(text.contains("outs(%tmp"));
+    assert!(text.contains("%tmp2 = tensor.empty() : tensor<2x4xf32>"));
+    assert!(text.contains(
+        "linalg.matmul ins(%0 : tensor<2x3xf32> , %1 : tensor<3x4xf32>) outs(%tmp2 : tensor<2x4xf32>) -> tensor<2x4xf32>"
+    ));
 }
 
 #[test]
@@ -126,9 +127,10 @@ fn lowers_conv2d() {
 
     let text = compile_ir_to_mlir_text(&mut module).expect("conv2d lowering");
     assert!(text.contains("func.func @main() -> (tensor<1x8x8x4xf32>)"));
-    assert!(text.contains("tensor.empty"));
-    assert!(text.contains("linalg.conv_2d_nhwc_hwcf"));
-    assert!(text.contains("outs(%tmp"));
+    assert!(text.contains("%tmp2 = tensor.empty() : tensor<1x8x8x4xf32>"));
+    assert!(text.contains(
+        "linalg.conv_2d_nhwc_hwcf ins(%0 : tensor<1x8x8x3xf32>, %1 : tensor<3x3x3x4xf32>) outs(%tmp2 : tensor<1x8x8x4xf32>) -> tensor<1x8x8x4xf32>"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- unify MLIR temporary tensor naming for matmul and conv2d to the `%tmp{dst}` pattern
- update lowering tests to expect the unified names

## Testing
- cargo check --features "mlir-lowering"
- cargo test --features "mlir-lowering"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371fd1101c8322b27825aa562ee31f)