### PR TITLE
Improve autodiff error handling and canonicalization

### DIFF
--- a/docs/autodiff.md
+++ b/docs/autodiff.md
@@ -28,7 +28,9 @@ println!("{}", gradients);
 ```
 
 The result bundles a full gradient IR module plus a deterministic mapping from
-primal value IDs to their gradients.
+primal value IDs to their gradients. Gradients are emitted in canonical form
+and, by default, the autodiff engine runs IR verification on both the primal
+and gradient modules.
 
 ## Supported ops (Phase 1)
 
@@ -37,8 +39,8 @@ primal value IDs to their gradients.
 - Shape-preserving ops: reshape, expand/squeeze dims, slice/index/gather
 - Reduction ops: mean (explicit axes) and sum (passthrough)
 
-Unsupported or ambiguous cases return `AutodiffError` with a deterministic
-message so callers can fall back or report the limitation.
+Unsupported or ambiguous cases return `AutodiffError` with structured messages
+so callers can fall back or report the limitation directly to users.
 
 ## Testing determinism
 

--- a/src/autodiff/rules.rs
+++ b/src/autodiff/rules.rs
@@ -43,7 +43,7 @@ pub(super) fn apply_rule(
                     ops.add_grad(*rhs, drhs);
                 }
                 BinOp::Div => {
-                    return Err(AutodiffError::UnsupportedOp("div"));
+                    return Err(AutodiffError::UnsupportedOp { op: "div" });
                 }
             }
             Ok(())
@@ -57,7 +57,7 @@ pub(super) fn apply_rule(
             ops.add_grad(*b, db);
             Ok(())
         }
-        Instr::Conv2d { .. } => Err(AutodiffError::UnsupportedOp("conv2d")),
+        Instr::Conv2d { .. } => Err(AutodiffError::UnsupportedOp { op: "conv2d" }),
         Instr::Dot { a, b, .. } => {
             let da = ops.add_binop(BinOp::Mul, upstream, *b);
             let db = ops.add_binop(BinOp::Mul, upstream, *a);


### PR DESCRIPTION
## Summary
- add structured autodiff error variants and configurable gradient verification options
- canonicalize generated gradient modules without dropping gradient instructions
- document autodiff canonicalization and verification behavior for public API users

## Testing
- cargo test --features autodiff -- --nocapture


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69374b05ffc08322a49266ccb2b1594f)