### PR TITLE
Expose gradient options and avoid duplicate gradient canonicalization

### DIFF
--- a/src/autodiff/engine.rs
+++ b/src/autodiff/engine.rs
@@ -127,9 +127,9 @@ pub fn differentiate_with_options(
 }
 
 fn canonicalize_gradients(result: &mut GradientResult) {
-    let mut gradient_roots: BTreeSet<ValueId> = result.gradients.values().copied().collect();
+    let mut gradient_outputs: BTreeSet<ValueId> = result.gradients.values().copied().collect();
 
-    for root in &gradient_roots {
+    for root in &gradient_outputs {
         result.gradient_module.instrs.push(Instr::Output(*root));
     }
 
@@ -137,7 +137,7 @@ fn canonicalize_gradients(result: &mut GradientResult) {
 
     result.gradient_module.instrs.retain(|instr| {
         if let Instr::Output(id) = instr {
-            if gradient_roots.contains(id) {
+            if gradient_outputs.contains(id) {
                 return false;
             }
         }
@@ -152,8 +152,8 @@ fn canonicalize_gradients(result: &mut GradientResult) {
     }
     result.gradient_module.next_id = max_seen;
 
-    // Ensure the set is used for determinism and to silence warnings.
-    gradient_roots.clear();
+    // Consume the set to avoid an "unused variable" warning.
+    gradient_outputs.clear();
 }
 
 struct GradientBuilder<'a> {

--- a/src/autodiff/mod.rs
+++ b/src/autodiff/mod.rs
@@ -27,4 +27,7 @@
 mod engine;
 mod rules;
 
-pub use engine::{differentiate_function, AutodiffError, GradientResult};
+pub use engine::{
+    differentiate_function, differentiate_with_options, AutodiffError, GradientOptions,
+    GradientResult,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,10 @@ pub mod types;
 #[cfg(feature = "autodiff")]
 pub mod autodiff;
 #[cfg(feature = "autodiff")]
-pub use autodiff::{differentiate_function, AutodiffError, GradientResult};
+pub use autodiff::{
+    differentiate_function, differentiate_with_options, AutodiffError, GradientOptions,
+    GradientResult,
+};
 pub use pipeline::{compile_source, CompileError, CompileOptions, CompileProducts};
 #[cfg(feature = "mlir-lowering")]
 pub use pipeline::{lower_to_mlir, MlirProducts};

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -102,12 +102,7 @@ pub fn compile_source(
             .func
             .as_deref()
             .ok_or(CompileError::MissingFunctionName)?;
-        let mut grad = autodiff::differentiate_function(&ir, func)?;
-        let mut grad_ir = grad.gradient_module.clone();
-        ir::verify_module(&grad_ir)?;
-        opt::ir_canonical::canonicalize_module(&mut grad_ir);
-        ir::verify_module(&grad_ir)?;
-        grad.gradient_module = grad_ir;
+        let grad = autodiff::differentiate_function(&ir, func)?;
         Some(grad)
     } else {
         None


### PR DESCRIPTION
## Summary
- rename internal gradient outputs set and clarify canonicalization comment
- export gradient configuration APIs through autodiff and crate root
- rely on autodiff canonicalization/verification instead of duplicating work in the pipeline

## Testing
- cargo fmt


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937567de0dc8322a360d7bd1c4fd96e)