### PR TITLE
Tidy gradient canonicalization: remove redundant clear and comment

### DIFF
--- a/src/autodiff/engine.rs
+++ b/src/autodiff/engine.rs
@@ -127,7 +127,7 @@ pub fn differentiate_with_options(
 }
 
 fn canonicalize_gradients(result: &mut GradientResult) {
-    let mut gradient_outputs: BTreeSet<ValueId> = result.gradients.values().copied().collect();
+    let gradient_outputs: BTreeSet<ValueId> = result.gradients.values().copied().collect();
 
     for root in &gradient_outputs {
         result.gradient_module.instrs.push(Instr::Output(*root));
@@ -151,9 +151,6 @@ fn canonicalize_gradients(result: &mut GradientResult) {
         }
     }
     result.gradient_module.next_id = max_seen;
-
-    // Consume the set to avoid an "unused variable" warning.
-    gradient_outputs.clear();
 }
 
 struct GradientBuilder<'a> {


### PR DESCRIPTION
## Summary
- remove the redundant gradient_outputs.clear call and outdated comment in canonicalize_gradients
- keep the gradient_outputs set immutable since it is only read
- tidy the gradient canonicalization helper without changing behavior

## Testing
- cargo check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375b4a05fc832280e4c20ab3fd44d9)