### PR TITLE
Make autodiff fixture compatible with verified Phase-2 pipeline

### DIFF
--- a/tests/fixtures/autodiff.mind
+++ b/tests/fixtures/autodiff.mind
@@ -1,1 +1,1 @@
-3 * 3
+tensor.zeros(f32, ()) * tensor.zeros(f32, ()) + tensor.ones(f32, ())


### PR DESCRIPTION
## Summary
- replace tests/fixtures/autodiff.mind with a simple scalar tensor expression using only supported elementwise ops
- ensure autodiff/MLIR CLI runs on the new Phase-2-friendly program

## Testing
- cargo check
- cargo test
- cargo test --features autodiff
- cargo test --features "mlir-lowering autodiff"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937605dc7f08322a8344121753516fe)