### PR TITLE
Add experimental GPU backend contract and target flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ cargo run --features "mlir-lowering autodiff" --bin mindc -- examples/hello_tens
 MLIR emission requires the `mlir-lowering` feature. Autodiff support is
 experimental and currently focused on single-output entry points.
 
+## GPU backend (experimental)
+
+The crate exposes an experimental GPU backend contract and a `--target=gpu`
+flag in `mindc`. CPU remains the only implemented target; selecting the GPU
+target returns a structured "backend not available" error. See
+[`docs/gpu.md`](docs/gpu.md) for the device/target model and current status.
+
 ## Core Concepts
 
 * [Type System](docs/type-system.md) — ranks, shapes, polymorphism, and effect tracking.

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,0 +1,33 @@
+# GPU backend (experimental)
+
+MIND exposes an abstract GPU backend contract for future accelerator
+integrations. The open-core crate does **not** ship a GPU implementation; the
+surface exists for tooling and downstream runtimes to build upon.
+
+## Device model
+
+- `DeviceKind` distinguishes CPU and GPU devices. CPU is the only stable,
+  implemented device in this crate.
+- GPU execution is allowed to be non-deterministic at the bit level (e.g., due
+  to floating-point associativity). Backends must still preserve the semantic
+  meaning of IR operations.
+
+## Target model
+
+- `BackendTarget::Cpu` is the default compilation target and is fully supported.
+- `BackendTarget::Gpu` is experimental and currently unimplemented.
+- Downstream tools can inspect the target to decide whether to dispatch to a
+  custom backend.
+
+## Error model
+
+Requesting the GPU target currently returns a structured
+`CompileError::BackendUnavailable` error from the pipeline. The `mindc` CLI
+surfaces this as:
+
+```
+error[backend]: gpu backend not available (experimental interface only)
+```
+
+This behavior ensures an explicit failure instead of a panic or implicit
+fallback when the GPU path is selected.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod mlir;
 pub mod opt;
 pub mod parser;
 pub mod pipeline;
+pub mod runtime;
 pub mod runtime_interface;
 pub mod shapes;
 pub mod stdlib;
@@ -62,6 +63,7 @@ pub use autodiff::{
     GradientResult,
 };
 pub use pipeline::{compile_source, CompileError, CompileOptions, CompileProducts};
+pub use runtime::types::{BackendTarget, DeviceKind};
 #[cfg(feature = "mlir-lowering")]
 pub use pipeline::{lower_to_mlir, MlirProducts};
 

--- a/src/runtime/gpu.rs
+++ b/src/runtime/gpu.rs
@@ -1,0 +1,29 @@
+//! Experimental GPU backend contract for MIND.
+//!
+//! This module defines the abstract interface a GPU backend must implement.
+//! No concrete GPU implementation is provided in this crate. The GPU surface is
+//! **experimental** and not covered by the Core v1 stability guarantees.
+
+use crate::ir::Instr;
+use crate::runtime::types::{RuntimeError, TensorHandle};
+use crate::runtime_interface::TensorDesc;
+
+/// Abstract contract for GPU execution backends.
+///
+/// A concrete implementation is responsible for device memory management and
+/// implementing the semantics of the IR operations it chooses to support.
+pub trait GPUBackend {
+    /// Allocates a device tensor with the given description.
+    fn allocate(&self, desc: &TensorDesc) -> Result<TensorHandle, RuntimeError>;
+
+    /// Executes a single IR instruction on device-resident tensor handles.
+    fn run_op(
+        &self,
+        op: &Instr,
+        inputs: &[TensorHandle],
+        outputs: &[TensorHandle],
+    ) -> Result<(), RuntimeError>;
+
+    /// Synchronises device execution, ensuring all prior operations are visible.
+    fn synchronize(&self) -> Result<(), RuntimeError>;
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,0 +1,10 @@
+//! Runtime abstractions for execution backends.
+//!
+//! This module hosts shared runtime surface types and experimental backend
+//! contracts. CPU remains the only implemented backend in this crate; GPU
+//! interfaces are provided solely for forward compatibility.
+
+pub mod gpu;
+pub mod types;
+
+pub use types::{BackendTarget, DeviceKind, RuntimeError, TensorHandle};

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -1,0 +1,46 @@
+//! Shared runtime surface types for execution backends.
+//!
+//! GPU-related variants are **experimental**. CPU remains the only stable and
+//! implemented backend in this crate.
+
+use std::fmt;
+
+/// Logical device on which computations are executed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceKind {
+    Cpu,
+    Gpu,
+}
+
+/// High-level backend target requested by the user or tooling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum BackendTarget {
+    /// Stable, default execution path.
+    #[default]
+    Cpu,
+    /// Experimental GPU target (interface only in this crate).
+    Gpu,
+}
+
+impl fmt::Display for BackendTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BackendTarget::Cpu => write!(f, "cpu"),
+            BackendTarget::Gpu => write!(f, "gpu"),
+        }
+    }
+}
+
+/// Opaque handle to runtime-managed tensor storage.
+pub type TensorHandle = usize;
+
+/// Structured runtime error for backend implementations.
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    /// Backend functionality requested but not available.
+    #[error("backend unavailable: {target}")]
+    BackendUnavailable { target: BackendTarget },
+    /// Generic backend failure message.
+    #[error("backend error: {message}")]
+    Message { message: String },
+}

--- a/src/runtime_interface.rs
+++ b/src/runtime_interface.rs
@@ -1,15 +1,6 @@
+use crate::runtime::types::TensorHandle;
+pub use crate::runtime::types::DeviceKind;
 use crate::types::{DType, ShapeDim};
-
-/// Logical device on which computations are executed.
-///
-/// This is intentionally minimal and may be extended in the future
-/// with concrete device identifiers or backend-specific metadata.
-#[derive(Clone, Copy, Debug)]
-pub enum DeviceKind {
-    Cpu,
-    Gpu,
-    Other,
-}
 
 /// Describes a tensor visible to the runtime.
 ///
@@ -37,10 +28,10 @@ pub trait MindRuntime {
     /// Allocate storage for a tensor with the given descriptor.
     ///
     /// Returns an opaque handle that can later be passed to `run_op`.
-    fn allocate(&self, desc: &TensorDesc) -> usize;
+    fn allocate(&self, desc: &TensorDesc) -> TensorHandle;
 
     /// Execute an operation identified by `op` over the input and output handles.
-    fn run_op(&self, op: &str, inputs: &[usize], outputs: &[usize]);
+    fn run_op(&self, op: &str, inputs: &[TensorHandle], outputs: &[TensorHandle]);
 
     /// Ensure that all enqueued operations are visible to the host.
     fn synchronize(&self) {}

--- a/tests/mindc.rs
+++ b/tests/mindc.rs
@@ -39,6 +39,28 @@ fn mindc_emits_ir() {
     assert!(stdout.to_lowercase().contains("output"), "{stdout}");
 }
 
+#[test]
+fn mindc_accepts_cpu_target_flag() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--bin",
+            "mindc",
+            "--",
+            "tests/fixtures/simple.mind",
+            "--emit-ir",
+            "--target",
+            "cpu",
+        ])
+        .output()
+        .expect("run mindc with cpu target");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.to_lowercase().contains("output"), "{stdout}");
+}
+
 #[cfg(feature = "autodiff")]
 #[test]
 fn mindc_emits_grad_ir() {
@@ -132,4 +154,27 @@ fn mindc_reports_prefixed_errors() {
             || stderr.contains("error[ir-verify]"),
         "stderr should include standardized prefix: {stderr}"
     );
+}
+
+#[test]
+fn mindc_reports_unavailable_gpu_backend() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--bin",
+            "mindc",
+            "--",
+            "tests/fixtures/simple.mind",
+            "--target",
+            "gpu",
+        ])
+        .output()
+        .expect("run mindc gpu target");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    assert!(stderr.contains("error[backend]"));
+    assert!(stderr.contains("backend not available"));
 }

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -12,8 +12,8 @@
 
 // Part of the MIND project (Machine Intelligence Native Design).
 
-use mind::ir::Instr;
 use mind::pipeline::{compile_source, CompileOptions};
+use mind::runtime::types::BackendTarget;
 
 #[test]
 fn compile_source_stabilizes_ir() {
@@ -21,6 +21,7 @@ fn compile_source_stabilizes_ir() {
     let opts = CompileOptions {
         func: None,
         enable_autodiff: false,
+        target: BackendTarget::Cpu,
     };
 
     let first = compile_source(src, &opts).expect("first compile");
@@ -38,6 +39,7 @@ fn compile_source_runs_autodiff() {
     let opts = CompileOptions {
         func: Some("main".to_string()),
         enable_autodiff: true,
+        target: BackendTarget::Cpu,
     };
 
     let ir_only = compile_source(
@@ -45,6 +47,7 @@ fn compile_source_runs_autodiff() {
         &CompileOptions {
             func: Some("main".to_string()),
             enable_autodiff: false,
+            target: BackendTarget::Cpu,
         },
     )
     .expect("compiled without autodiff");
@@ -84,6 +87,7 @@ fn lower_to_mlir_produces_stable_text() {
     let opts = CompileOptions {
         func: None,
         enable_autodiff: false,
+        target: BackendTarget::Cpu,
     };
 
     let compiled = compile_source(src, &opts).expect("compiled IR");


### PR DESCRIPTION
## Summary
- add shared DeviceKind/BackendTarget enums and an experimental GPUBackend trait surface
- propagate backend targets through the pipeline and CLI with a structured error when GPU is requested
- document the experimental GPU contract and cover the new CLI flag in tests

## Testing
- cargo check
- cargo test
- cargo test --features autodiff
- cargo test --features "mlir-lowering autodiff"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937708853b883228e8050f299ea0219)