### PR TITLE
Tidy versioning docs minor pattern and normalize autodiff error class description

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -6,8 +6,8 @@ MIND Core normalizes public-facing errors so tooling can parse them reliably.
 
 - **Parse / type errors**: surfaced as structured diagnostics.
 - **IR verification errors**: failures of the public IR invariants.
-- **Autodiff errors**: `AutodiffError::{UnsupportedOp, InvalidAxis, UnsupportedShape,
-  Verification, MissingOutput, MultipleOutputs}` and related validation errors.
+- **Autodiff errors**: failures and validation errors encountered during automatic
+  differentiation of Core IR modules.
 - **MLIR lowering errors**: failures while translating canonical IR into MLIR
   (behind the `mlir-lowering` feature).
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -10,7 +10,7 @@ MIND Core currently publishes 0.y.z versions with the following rules:
 
 - **Patch (0.y.*)**: bug fixes, documentation updates, and tooling-only changes
   that do not alter IR semantics or CLI contracts.
-- **Minor (0.*.z)**: additive IR extensions are allowed, including new
+- **Minor (0.y.*)**: additive IR extensions are allowed, including new
   instructions and flags. Existing IR semantics must remain compatible.
 
 ## What counts as breaking

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -14,6 +14,8 @@
 
 use mind::pipeline::{compile_source, CompileOptions};
 use mind::runtime::types::BackendTarget;
+#[cfg(feature = "autodiff")]
+use mind::ir::Instr;
 
 #[test]
 fn compile_source_stabilizes_ir() {


### PR DESCRIPTION
## Summary
- correct the minor version notation in the versioning documentation to match the 0.y.z pattern
- describe autodiff error class conceptually to align with other error category wording
- gate the pipeline autodiff test imports so feature builds compile cleanly

## Testing
- cargo check
- cargo test
- cargo test --features autodiff
- cargo test --features "mlir-lowering autodiff"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937792de5f083228ba84e9c173a5ab4)