### PR TITLE
Fix rustfmt ordering and update cargo-deny toolchain

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -21,3 +21,4 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check
+          rust-version: stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,9 @@ pub use autodiff::{
     GradientResult,
 };
 pub use pipeline::{compile_source, CompileError, CompileOptions, CompileProducts};
-pub use runtime::types::{BackendTarget, DeviceKind};
 #[cfg(feature = "mlir-lowering")]
 pub use pipeline::{lower_to_mlir, MlirProducts};
+pub use runtime::types::{BackendTarget, DeviceKind};
 
 #[cfg(feature = "mlir-lowering")]
 pub use mlir::{compile_ir_to_mlir_text, MlirLowerError};

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -91,7 +91,9 @@ pub fn compile_source(
     opts: &CompileOptions,
 ) -> Result<CompileProducts, CompileError> {
     if matches!(opts.target, BackendTarget::Gpu) {
-        return Err(CompileError::BackendUnavailable { target: opts.target });
+        return Err(CompileError::BackendUnavailable {
+            target: opts.target,
+        });
     }
 
     let module = parser::parse_with_diagnostics(source).map_err(CompileError::ParseError)?;

--- a/src/runtime_interface.rs
+++ b/src/runtime_interface.rs
@@ -1,5 +1,5 @@
-use crate::runtime::types::TensorHandle;
 pub use crate::runtime::types::DeviceKind;
+use crate::runtime::types::TensorHandle;
 use crate::types::{DType, ShapeDim};
 
 /// Describes a tensor visible to the runtime.

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -12,10 +12,10 @@
 
 // Part of the MIND project (Machine Intelligence Native Design).
 
-use mind::pipeline::{compile_source, CompileOptions};
-use mind::runtime::types::BackendTarget;
 #[cfg(feature = "autodiff")]
 use mind::ir::Instr;
+use mind::pipeline::{compile_source, CompileOptions};
+use mind::runtime::types::BackendTarget;
 
 #[test]
 fn compile_source_stabilizes_ir() {


### PR DESCRIPTION
## Summary
- reorder public re-exports in lib and runtime_interface to match rustfmt style
- format backend unavailable error construction in pipeline to satisfy rustfmt
- configure cargo-deny GitHub Action to use the stable Rust toolchain

## Testing
- cargo +stable fmt --all *(fails: rustup unable to download stable toolchain in CI sandbox)*
- cargo fmt --all
- cargo check
- cargo test *(pass)*
- cargo test --features autodiff *(fails: mindc_emits_grad_ir assertion on subprocess status)*
- cargo test --features "mlir-lowering autodiff" *(fails: mindc_emits_mlir assertion on subprocess status)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69377d0fa380832298338719ab872053)