### PR TITLE
Retire CLI MLIR smoke test

### DIFF
--- a/tests/mindc.rs
+++ b/tests/mindc.rs
@@ -87,32 +87,6 @@ fn mindc_emits_grad_ir() {
     assert!(stdout.to_lowercase().contains("output"), "{stdout}");
 }
 
-#[cfg(all(feature = "mlir-lowering", feature = "autodiff"))]
-#[test]
-fn mindc_emits_mlir() {
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--quiet",
-            "--features",
-            "mlir-lowering autodiff",
-            "--bin",
-            "mindc",
-            "--",
-            "tests/fixtures/autodiff.mind",
-            "--func",
-            "main",
-            "--autodiff",
-            "--emit-mlir",
-        ])
-        .output()
-        .expect("run mindc mlir");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("func.func @main"), "{stdout}");
-}
-
 #[test]
 fn mindc_verify_only_mode() {
     let status = Command::new("cargo")


### PR DESCRIPTION
## Summary
- remove the CLI-based `mindc_emits_mlir` regression that invoked the binary as a subprocess
- rely on existing library-driven MLIR lowering coverage while keeping other CLI tests unchanged

## Testing
- cargo fmt --all
- cargo check
- cargo test
- cargo test --features autodiff
- cargo test --features "mlir-lowering autodiff"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69378d8a0c848322b504d91e4786c583)