### PR TITLE
Fix clippy warnings in IR canonicalization

### DIFF
--- a/src/bin/mindc.rs
+++ b/src/bin/mindc.rs
@@ -151,13 +151,13 @@ fn print_version() {
 
     #[cfg(feature = "mlir-lowering")]
     let components = {
-        let mut components = vec!["core-ir=1.0", "core-autodiff=1.0"];
+        let mut components = ["core-ir=1.0", "core-autodiff=1.0"].to_vec();
         components.push("mlir-lowering=0.1");
         components
     };
 
     #[cfg(not(feature = "mlir-lowering"))]
-    let components = vec!["core-ir=1.0", "core-autodiff=1.0"];
+    let components = ["core-ir=1.0", "core-autodiff=1.0"];
 
     println!("{}", components.join("  "));
 }

--- a/src/opt/ir_canonical.rs
+++ b/src/opt/ir_canonical.rs
@@ -41,7 +41,9 @@ fn prune_dead(instrs: &[Instr]) -> Vec<Instr> {
             }
             other => {
                 let dst = instruction_dst(other);
-                if dst.map_or(true, |id| used.contains(&id)) {
+                // Keep instructions whose destination is either unused (None) or present
+                // in the `used` set. Clippy prefers `is_none_or` over `map_or(true, ...)`.
+                if dst.is_none_or(|id| used.contains(&id)) {
                     for operand in instruction_operands(other) {
                         used.insert(operand);
                     }
@@ -72,7 +74,7 @@ fn reorder_commutative_ops(instrs: &mut [Instr]) {
     }
 }
 
-fn constant_fold(instrs: &mut Vec<Instr>) {
+fn constant_fold(instrs: &mut [Instr]) {
     let mut constants: BTreeMap<ValueId, i64> = BTreeMap::new();
     for instr in instrs.iter_mut() {
         match instr {


### PR DESCRIPTION
## Summary
- replace the map_or call in IR canonicalization with is_none_or to satisfy clippy
- take constant_fold arguments by slice rather than Vec
- fix mindc version output components to avoid clippy’s useless_vec lint

## Testing
- cargo fmt --all
- cargo check
- cargo clippy --no-default-features -- -D warnings
- cargo test
- cargo test --features autodiff
- cargo test --features "mlir-lowering autodiff"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693794eee88483229126f71edc26b5a1)