### PR TITLE
Clarify Core v1 GPU profile stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ cargo run --features "mlir-lowering autodiff" --bin mindc -- examples/hello_tens
 MLIR emission requires the `mlir-lowering` feature. Autodiff support is
 experimental and currently focused on single-output entry points.
 
-## GPU backend (experimental)
+## GPU backend profile
 
-The crate exposes an experimental GPU backend contract and a `--target=gpu`
-flag in `mindc`. CPU remains the only implemented target; selecting the GPU
-target returns a structured "backend not available" error. See
-[`docs/gpu.md`](docs/gpu.md) for the device/target model and current status.
+The crate exposes the Core v1 GPU profile and a `--target=gpu` flag in `mindc`.
+CPU remains the only implemented target, but the GPU contract (enums, error
+model, and `GPUBackend` trait) is treated as stable for downstream runtimes.
+Selecting the GPU target returns a structured "backend not available" error.
+See [`docs/gpu.md`](docs/gpu.md) for the device/target model and current
+status.
 
 ## Core Concepts
 

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,13 +1,15 @@
-# GPU backend (experimental)
+# GPU backend profile
 
-MIND exposes an abstract GPU backend contract for future accelerator
-integrations. The open-core crate does **not** ship a GPU implementation; the
-surface exists for tooling and downstream runtimes to build upon.
+MIND exposes a stable Core v1 GPU profile that defines the contract for GPU
+backends. The open-core crate does **not** ship a GPU implementation, but the
+API surface and error model are intended to remain stable so downstream tooling
+can target them.
 
 ## Device model
 
-- `DeviceKind` distinguishes CPU and GPU devices. CPU is the only stable,
-  implemented device in this crate.
+- `DeviceKind` distinguishes CPU and GPU devices. The CPU variant is implemented
+  in this crate, and the GPU variant is part of the stable profile for
+  downstream backends.
 - GPU execution is allowed to be non-deterministic at the bit level (e.g., due
   to floating-point associativity). Backends must still preserve the semantic
   meaning of IR operations.
@@ -15,9 +17,10 @@ surface exists for tooling and downstream runtimes to build upon.
 ## Target model
 
 - `BackendTarget::Cpu` is the default compilation target and is fully supported.
-- `BackendTarget::Gpu` is experimental and currently unimplemented.
+- `BackendTarget::Gpu` is defined by the Core v1 GPU profile. No concrete GPU
+  backend ships with this crate, but downstream runtimes can implement it.
 - Downstream tools can inspect the target to decide whether to dispatch to a
-  custom backend.
+  custom backend via the `GPUBackend` trait.
 
 ## Error model
 
@@ -30,4 +33,6 @@ error[backend]: gpu backend not available (experimental interface only)
 ```
 
 This behavior ensures an explicit failure instead of a panic or implicit
-fallback when the GPU path is selected.
+fallback when the GPU path is selected. The presence of a distinct
+backend-selection error for unsupported or unavailable GPU targets is part of
+the Core v1 GPU profile and must be preserved across compatible releases.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -32,6 +32,9 @@ MIND Core currently publishes 0.y.z versions with the following rules:
   `AutodiffError`.
 - **Canonicalization guarantees**: deterministic rewrites prior to lowering.
 - **`mindc` base flags and textual IR output**.
+- **Core v1 GPU profile**: `DeviceKind`/`BackendTarget` enum variants for CPU and
+  GPU, the runtime backend-selection error model (e.g., `BackendUnavailable`),
+  and the `GPUBackend` trait surface that executes canonical IR on GPU devices.
 
 ### Conditionally stable surfaces
 
@@ -42,7 +45,8 @@ MIND Core currently publishes 0.y.z versions with the following rules:
 
 - New operations added to the IR.
 - New feature flags exposed by the CLI or libraries.
-- Future non-CPU backends and related lowering pipelines.
+- Concrete GPU or accelerator backend implementations and device-specific
+  lowering pipelines.
 
 ## References
 


### PR DESCRIPTION
## Summary
- describe the Core v1 GPU profile as a stable contract in the stability matrix and GPU docs
- highlight the stable GPU enums, backend-selection errors, and GPUBackend trait surface
- clarify in the README that GPU backends are unimplemented but the contract is fixed

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69379f145ee4832292c60f84da56325b)