### PR TITLE
Core v1 diagnostics & CLI UX Big Shot (JSON output, colors, consistent error surface)

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -11,19 +11,52 @@ MIND Core normalizes public-facing errors so tooling can parse them reliably.
 - **MLIR lowering errors**: failures while translating canonical IR into MLIR
   (behind the `mlir-lowering` feature).
 
-## CLI formatting
+## Diagnostic formats
 
-CLI-facing errors are prefixed to identify their source:
+`mindc` supports structured and human diagnostics:
 
 ```
-error[parse]: …
-error[type-check]: …
-error[ir-verify]: …
-error[autodiff]: …
-error[mlir]: …
+mindc --diagnostic-format human   # default; multi-line with spans and notes
+mindc --diagnostic-format short   # single line, grep-friendly
+mindc --diagnostic-format json    # one diagnostic per line of JSON
 ```
+
+JSON diagnostics are line-delimited with a stable shape:
+
+```
+{
+  "phase": "parse",
+  "code": "E1001",
+  "severity": "error",
+  "message": "unexpected token `)`; expected identifier",
+  "span": {
+    "file": "simple.mind",
+    "line": 3,
+    "column": 11,
+    "length": 1
+  },
+  "notes": [
+    "while parsing function `main`"
+  ],
+  "help": "check for an extra trailing comma or remove the unmatched `)`"
+}
+```
+
+Human output uses consistent phase prefixes (`error[parse]`, `error[type-check]`,
+etc.), includes caret highlights when spans are available, and respects
+`--color` / `MINDC_COLOR` for ANSI styling.
 
 All error variants propagate non-zero exit codes from the CLI.
+
+## Error codes
+
+Every diagnostic carries a stable code for the Core v1 pipeline phase:
+
+- Parse: `E1xxx`
+- Type-check: `E2xxx`
+- IR verification: `E3xxx`
+- Autodiff: `E4xxx`
+- MLIR lowering: `E5xxx`
 
 See [`docs/versioning.md`](versioning.md) for how these classes fit the stability
 contract.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -32,6 +32,8 @@ MIND Core currently publishes 0.y.z versions with the following rules:
   `AutodiffError`.
 - **Canonicalization guarantees**: deterministic rewrites prior to lowering.
 - **`mindc` base flags and textual IR output**.
+- **Compiler diagnostics**: error codes (`E1xxx`…`E5xxx`) and the JSON diagnostic
+  field names for the `--diagnostic-format json` surface.
 - **Core v1 GPU profile**: `DeviceKind`/`BackendTarget` enum variants for CPU and
   GPU, the runtime backend-selection error model (e.g., `BackendUnavailable`),
   and the `GPUBackend` trait surface that executes canonical IR on GPU devices.

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -12,29 +12,55 @@
 
 // Part of the MIND project (Machine Intelligence Native Design).
 
-//! Pretty diagnostics: spans, line/col, caret-highlights.
+//! Structured diagnostics for the Core v1 compiler pipeline.
 
-use std::ops::Range;
+use std::fmt::Write as _;
+use std::io::{IsTerminal, Write};
 
-/// Byte-span in the original source (inclusive start, exclusive end).
-pub type Span = Range<usize>;
+use colored::Colorize;
+use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Location {
-    pub line: usize, // 1-based
-    pub col: usize,  // 1-based (Unicode-agnostic; counts bytes)
+/// Severity level for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Diagnostic {
-    pub message: String,
-    pub span: Span,
-    pub start: Location,
-    pub end: Location,
+impl Severity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        }
+    }
 }
 
-/// Compute (line, col) from byte offset.
-fn offset_to_loc(src: &str, offset: usize) -> Location {
+/// Normalized source location for a diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Span {
+    pub file: Option<String>,
+    pub line: usize,
+    pub column: usize,
+    pub length: usize,
+}
+
+impl Span {
+    /// Construct a span from byte offsets within a source string.
+    pub fn from_offsets(source: &str, start: usize, end: usize, file: Option<&str>) -> Self {
+        let (line, column) = offset_to_line_col(source, start);
+        let length = end.saturating_sub(start).max(1);
+        Span {
+            file: file.map(str::to_string),
+            line,
+            column,
+            length,
+        }
+    }
+}
+
+fn offset_to_line_col(src: &str, offset: usize) -> (usize, usize) {
     let mut line = 1usize;
     let mut col = 1usize;
     let mut count = 0usize;
@@ -50,56 +76,234 @@ fn offset_to_loc(src: &str, offset: usize) -> Location {
         }
         count += ch.len_utf8();
     }
-    Location { line, col }
+    (line, col)
 }
 
-/// Extract the single source line containing `span.start`.
-fn line_at(src: &str, span: Span) -> (String, usize /* line_start_offset */) {
-    let bytes = src.as_bytes();
-    let mut b = span.start;
-    while b > 0 && bytes[b - 1] != b'\n' {
-        b -= 1;
-    }
-    let mut e = span.start;
-    while e < bytes.len() && bytes[e] != b'\n' {
-        e += 1;
-    }
-    (src[b..e].to_string(), b)
-}
-
-/// Render caret-highlight under the selected span (single-line best effort).
-pub fn render(src: &str, diag: &Diagnostic) -> String {
-    let span = diag.span.clone();
-    let (line_str, line_off) = line_at(src, span.clone());
-    let caret_start = span.start.saturating_sub(line_off);
-    let caret_len = span.end.saturating_sub(span.start).max(1);
-
-    let mut carets = String::new();
-    for _ in 0..caret_start {
-        carets.push(' ');
-    }
-    for _ in 0..caret_len {
-        carets.push('^');
-    }
-
-    format!(
-        "error: {}\n--> line {}, col {}\n{}\n{}",
-        diag.message, diag.start.line, diag.start.col, line_str, carets
-    )
+/// Machine-readable diagnostic emitted by the compiler.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Diagnostic {
+    pub phase: &'static str,
+    pub code: &'static str,
+    pub severity: Severity,
+    pub message: String,
+    pub span: Option<Span>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+    pub help: Option<String>,
 }
 
 impl Diagnostic {
-    /// Construct from a chumsky `Simple` error.
-    pub fn from_chumsky(src: &str, e: chumsky::error::Simple<char>) -> Self {
-        let span = e.span();
-        let start = offset_to_loc(src, span.start);
-        let end = offset_to_loc(src, span.end);
-        let message = e.to_string();
+    pub fn error(phase: &'static str, code: &'static str, message: impl Into<String>) -> Self {
         Diagnostic {
-            message,
-            span,
-            start,
-            end,
+            phase,
+            code,
+            severity: Severity::Error,
+            message: message.into(),
+            span: None,
+            notes: Vec::new(),
+            help: None,
         }
     }
+
+    pub fn with_span(mut self, span: Span) -> Self {
+        self.span = Some(span);
+        self
+    }
+
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.notes.push(note.into());
+        self
+    }
+
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    /// Attach a file name if it was missing.
+    pub fn fill_file(mut self, file: Option<&str>) -> Self {
+        if let (Some(name), Some(span)) = (file, self.span.as_mut()) {
+            if span.file.is_none() {
+                span.file = Some(name.to_string());
+            }
+        }
+        self
+    }
+}
+
+/// CLI-facing diagnostic output formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticFormat {
+    Human,
+    Short,
+    Json,
+}
+
+impl DiagnosticFormat {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.to_ascii_lowercase().as_str() {
+            "human" => Some(DiagnosticFormat::Human),
+            "short" => Some(DiagnosticFormat::Short),
+            "json" => Some(DiagnosticFormat::Json),
+            _ => None,
+        }
+    }
+}
+
+/// Color handling for CLI diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorChoice {
+    Auto,
+    Always,
+    Never,
+}
+
+impl ColorChoice {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.to_ascii_lowercase().as_str() {
+            "auto" => Some(ColorChoice::Auto),
+            "always" => Some(ColorChoice::Always),
+            "never" => Some(ColorChoice::Never),
+            _ => None,
+        }
+    }
+
+    fn should_color(self, is_terminal: bool) -> bool {
+        match self {
+            ColorChoice::Always => true,
+            ColorChoice::Never => false,
+            ColorChoice::Auto => is_terminal,
+        }
+    }
+}
+
+/// Emitter that renders diagnostics in human, short, or JSON formats.
+pub struct DiagnosticEmitter {
+    format: DiagnosticFormat,
+    color: ColorChoice,
+    is_tty: bool,
+}
+
+impl DiagnosticEmitter {
+    pub fn new(format: DiagnosticFormat, color: ColorChoice) -> Self {
+        let is_tty = std::io::stderr().is_terminal();
+        DiagnosticEmitter {
+            format,
+            color,
+            is_tty,
+        }
+    }
+
+    pub fn emit(&self, diag: &Diagnostic, source: Option<&str>, mut writer: impl Write) {
+        match self.format {
+            DiagnosticFormat::Json => {
+                let _ = serde_json::to_writer(&mut writer, diag);
+                let _ = writeln!(writer);
+            }
+            DiagnosticFormat::Short => {
+                let _ = writeln!(writer, "{}", self.render_short(diag));
+            }
+            DiagnosticFormat::Human => {
+                let rendered = self.render_human(diag, source);
+                let _ = writeln!(writer, "{rendered}");
+            }
+        }
+    }
+
+    pub fn emit_all(&self, diags: &[Diagnostic], source: Option<&str>) {
+        for diag in diags {
+            self.emit(diag, source, std::io::stderr());
+        }
+    }
+
+    fn render_prefix(&self, diag: &Diagnostic) -> String {
+        let mut prefix = format!("{}[{}]", diag.severity.as_str(), diag.phase);
+        if !diag.code.is_empty() {
+            let _ = write!(prefix, "[{}]", diag.code);
+        }
+        if self.color.should_color(self.is_tty) {
+            match diag.severity {
+                Severity::Error => prefix = prefix.red().bold().to_string(),
+                Severity::Warning => prefix = prefix.yellow().bold().to_string(),
+            }
+        }
+        prefix
+    }
+
+    fn render_location(&self, span: &Span) -> String {
+        match &span.file {
+            Some(file) => format!("{file}:{}:{}", span.line, span.column),
+            None => format!("line {} column {}", span.line, span.column),
+        }
+    }
+
+    fn render_short(&self, diag: &Diagnostic) -> String {
+        let prefix = self.render_prefix(diag);
+        let mut out = format!("{prefix}: {}", diag.message);
+        if let Some(span) = &diag.span {
+            let loc = self.render_location(span);
+            let _ = write!(out, " ({loc})");
+        }
+        out
+    }
+
+    pub fn render_human(&self, diag: &Diagnostic, source: Option<&str>) -> String {
+        let mut out = String::new();
+        let prefix = self.render_prefix(diag);
+        let _ = write!(out, "{prefix}: {}", diag.message);
+
+        if let Some(span) = &diag.span {
+            let loc = self.render_location(span);
+            let _ = write!(out, "\n  --> {loc}");
+            if let Some(src) = source {
+                if let Some(line_str) = source_line(src, span.line) {
+                    let indicator = caret_line(span.column, span.length);
+                    let _ = write!(out, "\n   | {line_str}\n   | {indicator}");
+                }
+            }
+        }
+
+        for note in &diag.notes {
+            let label = if self.color.should_color(self.is_tty) {
+                "note".cyan().bold().to_string()
+            } else {
+                "note".to_string()
+            };
+            let _ = write!(out, "\n{label}: {note}");
+        }
+
+        if let Some(help) = &diag.help {
+            let label = if self.color.should_color(self.is_tty) {
+                "help".green().bold().to_string()
+            } else {
+                "help".to_string()
+            };
+            let _ = write!(out, "\n{label}: {help}");
+        }
+
+        out
+    }
+}
+
+fn source_line(src: &str, line: usize) -> Option<String> {
+    src.lines()
+        .nth(line.saturating_sub(1))
+        .map(|l| l.to_string())
+}
+
+fn caret_line(col: usize, len: usize) -> String {
+    let mut out = String::new();
+    for _ in 1..col {
+        out.push(' ');
+    }
+    for _ in 0..len.max(1) {
+        out.push('^');
+    }
+    out
+}
+
+/// Convenience wrapper for human diagnostics without ANSI colors.
+pub fn render(source: &str, diag: &Diagnostic) -> String {
+    DiagnosticEmitter::new(DiagnosticFormat::Human, ColorChoice::Never)
+        .render_human(diag, Some(source))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@
 //!   release when the `mlir-lowering` feature is enabled.
 //! * **Experimental**: new ops, experimental flags, and future non-CPU backends.
 //!
+//! Diagnostics follow the Core v1 error model with structured spans and
+//! machine-readable JSON output (`mindc --diagnostic-format json`).
+//!
 //! See `docs/versioning.md` for the full policy and surface definitions.
 pub mod ast;
 pub mod conformance;
@@ -66,7 +69,9 @@ pub use autodiff::{
 pub use conformance::{
     run_conformance, ConformanceFailure, ConformanceOptions, ConformanceProfile,
 };
-pub use pipeline::{compile_source, CompileError, CompileOptions, CompileProducts};
+pub use pipeline::{
+    compile_source, compile_source_with_name, CompileError, CompileOptions, CompileProducts,
+};
 #[cfg(feature = "mlir-lowering")]
 pub use pipeline::{lower_to_mlir, MlirProducts};
 pub use runtime::types::{BackendTarget, DeviceKind};

--- a/tests/diagnostics.rs
+++ b/tests/diagnostics.rs
@@ -1,0 +1,75 @@
+// Copyright 2025 STARGA Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Part of the MIND project (Machine Intelligence Native Design).
+
+use mind::diagnostics::{
+    ColorChoice, Diagnostic, DiagnosticEmitter, DiagnosticFormat, Severity, Span,
+};
+
+fn sample_diag() -> Diagnostic {
+    Diagnostic {
+        phase: "parse",
+        code: "E1001",
+        severity: Severity::Error,
+        message: "unexpected token".to_string(),
+        span: Some(Span {
+            file: Some("sample.mind".to_string()),
+            line: 3,
+            column: 5,
+            length: 1,
+        }),
+        notes: vec!["while parsing function `main`".to_string()],
+        help: Some("remove the stray token".to_string()),
+    }
+}
+
+#[test]
+fn human_output_smoke() {
+    let diag = sample_diag();
+    let emitter = DiagnosticEmitter::new(DiagnosticFormat::Human, ColorChoice::Never);
+    let rendered = emitter.render_human(&diag, Some("let x = );"));
+
+    assert!(rendered.contains("error[parse][E1001]"));
+    assert!(rendered.contains("sample.mind:3:5"));
+    assert!(rendered.contains("while parsing function"));
+    assert!(rendered.contains("help: remove the stray token"));
+}
+
+#[test]
+fn json_output_smoke() {
+    let diag = sample_diag();
+    let emitter = DiagnosticEmitter::new(DiagnosticFormat::Json, ColorChoice::Never);
+    let mut buf = Vec::new();
+    emitter.emit(&diag, None, &mut buf);
+    let body = String::from_utf8(buf).expect("utf8");
+    let value: serde_json::Value = serde_json::from_str(body.trim()).expect("json diagnostic");
+
+    assert_eq!(value["phase"], "parse");
+    assert_eq!(value["code"], "E1001");
+    assert_eq!(value["severity"], "error");
+}
+
+#[test]
+fn json_includes_span() {
+    let diag = sample_diag();
+    let emitter = DiagnosticEmitter::new(DiagnosticFormat::Json, ColorChoice::Never);
+    let mut buf = Vec::new();
+    emitter.emit(&diag, None, &mut buf);
+    let body = String::from_utf8(buf).expect("utf8");
+    let value: serde_json::Value = serde_json::from_str(body.trim()).expect("json diagnostic");
+
+    assert_eq!(value["span"]["file"], "sample.mind");
+    assert_eq!(value["span"]["line"], 3);
+    assert_eq!(value["span"]["column"], 5);
+    assert_eq!(value["span"]["length"], 1);
+}


### PR DESCRIPTION
## Summary
- introduce structured diagnostics with spans, severity, and JSON/human/short emitters plus color control
- wire mindc to parse diagnostic and color flags, propagate stable phase/code information across pipeline errors
- document the diagnostic formats/code guarantees and add targeted tests for emitter output and CLI flag behavior

## Testing
- cargo test human_output_smoke --test diagnostics
- cargo test json_output_smoke --test diagnostics
- cargo test json_includes_span --test diagnostics
- cargo test mindc_prints_json_diagnostics_with_flag --test mindc
- cargo test mindc_color_env_overridden_by_flag --test mindc


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937bb3814e083228a0a9ac01f720002)