### PR TITLE
Align backend unavailable diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ experimental and currently focused on single-output entry points.
 The crate exposes the Core v1 GPU profile and a `--target=gpu` flag in `mindc`.
 CPU remains the only implemented target, but the GPU contract (enums, error
 model, and `GPUBackend` trait) is treated as stable for downstream runtimes.
-Selecting the GPU target returns a structured "backend not available" error.
+Selecting the GPU target returns a structured "no backend available for target gpu" error.
 See [`docs/gpu.md`](docs/gpu.md) for the device/target model and current
 status.
 

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -29,7 +29,7 @@ Requesting the GPU target currently returns a structured
 surfaces this as:
 
 ```
-error[backend]: gpu backend not available (experimental interface only)
+error[backend]: no backend available for target gpu
 ```
 
 This behavior ensures an explicit failure instead of a panic or implicit

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -220,7 +220,7 @@ fn gpu_cases() -> Vec<ConformanceCase> {
             expected_mlir: None,
             #[cfg(feature = "autodiff")]
             expected_grad_ir: None,
-            expected_error: Some("backend not available"),
+            expected_error: Some("no backend available"),
             run_autodiff: false,
         });
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -99,9 +99,9 @@ impl CompileError {
                 "--autodiff requires --func <name>",
             )],
             CompileError::BackendUnavailable { target } => vec![Diagnostic::error(
-                "ir-verify",
-                "E3002",
-                format!("{target} backend not available (experimental interface only)"),
+                "backend",
+                "E5001",
+                format!("no backend available for target {target:?}"),
             )],
             #[cfg(feature = "autodiff")]
             CompileError::Autodiff(e) => {

--- a/tests/conformance/gpu_profile/backend_unavailable.error
+++ b/tests/conformance/gpu_profile/backend_unavailable.error
@@ -1,1 +1,1 @@
-backend not available
+no backend available for target gpu

--- a/tests/mindc.rs
+++ b/tests/mindc.rs
@@ -150,7 +150,7 @@ fn mindc_reports_unavailable_gpu_backend() {
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
     assert!(stderr.contains("error[backend]"));
-    assert!(stderr.contains("backend not available"));
+    assert!(stderr.contains("no backend available"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- set BackendUnavailable diagnostics to use the backend phase and updated error code/message
- refresh CLI tests, conformance expectations, and docs to match the new backend diagnostic text

## Testing
- cargo test --test diagnostics
- cargo test --test mindc

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c02104a8832280a4134a68d126ac)