### PR TITLE
Use Display formatter for backend target diagnostic

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -101,7 +101,7 @@ impl CompileError {
             CompileError::BackendUnavailable { target } => vec![Diagnostic::error(
                 "backend",
                 "E5001",
-                format!("no backend available for target {target:?}"),
+                format!("no backend available for target {target}"),
             )],
             #[cfg(feature = "autodiff")]
             CompileError::Autodiff(e) => {


### PR DESCRIPTION
## Summary
- switch backend-unavailable diagnostic to use `BackendTarget`'s Display formatting
- keep backend phase and E5001 code while ensuring target renders as lowercase `gpu`

## Testing
- cargo test --test diagnostics
- cargo test --test mindc
- cargo test --test conformance

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c5c525908322b4ba0ebead9c6852)