### PR TITLE
Ensure core v1 ops registry test checks non-empty

### DIFF
--- a/tests/ops_registry.rs
+++ b/tests/ops_registry.rs
@@ -5,7 +5,7 @@ fn core_v1_contains_expected_ops() {
     let ops = core_v1::core_v1_ops();
     assert!(core_v1::is_core_v1_op("tensor.sum"));
     assert!(core_v1::is_core_v1_op("tensor.relu"));
-    assert_eq!(ops.len(), core_v1::core_v1_ops().len());
+    assert!(!ops.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace redundant length comparison in the core v1 ops registry test with a non-emptiness check to verify the registry is populated

## Testing
- cargo test --test ops_registry

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c75ceeec8322926561b0e34d3e7e)