### PR TITLE
Add Core v1 shape engine and validation tests

### DIFF
--- a/src/shapes/engine.rs
+++ b/src/shapes/engine.rs
@@ -1,0 +1,227 @@
+use std::fmt;
+
+/// A rank-N tensor shape represented as a list of extents.
+///
+/// Core v1 treats shapes as ordered lists of non-negative extents. The
+/// engine does not attempt to encode symbolic dimensions; it is purely
+/// numeric and intended for concrete validation and tests.
+pub type Shape = Vec<usize>;
+
+/// High-level shape rule categories for Core v1 operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShapeRuleKind {
+    /// Unary elementwise op: output shape equals input shape.
+    ElementwiseUnary,
+    /// Binary elementwise op: broadcasting is applied to operands.
+    ElementwiseBinary,
+    /// Full reduction to a scalar (rank-0) value.
+    ReduceAll,
+    /// Matrix multiplication of two rank-2 tensors.
+    MatMul2D,
+}
+
+/// Error kinds produced by the shape engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShapeErrorKind {
+    /// Operator is unknown to the Core v1 shape engine.
+    UnknownOp,
+    /// Rank or size mismatch for the given rule.
+    RankMismatch {
+        expected: String,
+        actual_lhs: Vec<usize>,
+        actual_rhs: Option<Vec<usize>>,
+    },
+    /// Broadcasting failed for the given input shapes.
+    BroadcastError {
+        lhs: Vec<usize>,
+        rhs: Vec<usize>,
+    },
+}
+
+/// Rich shape error containing the operator name and a structured kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShapeError {
+    pub op: String,
+    pub kind: ShapeErrorKind,
+}
+
+impl fmt::Display for ShapeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            ShapeErrorKind::UnknownOp => {
+                write!(f, "shape rule not defined for op `{}`", self.op)
+            }
+            ShapeErrorKind::RankMismatch {
+                expected,
+                actual_lhs,
+                actual_rhs,
+            } => {
+                if let Some(rhs) = actual_rhs {
+                    write!(
+                        f,
+                        "rank mismatch for op `{}`: expected {}, got lhs={:?}, rhs={:?}",
+                        self.op, expected, actual_lhs, rhs
+                    )
+                } else {
+                    write!(
+                        f,
+                        "rank mismatch for op `{}`: expected {}, got lhs={:?}",
+                        self.op, expected, actual_lhs
+                    )
+                }
+            }
+            ShapeErrorKind::BroadcastError { lhs, rhs } => write!(
+                f,
+                "cannot broadcast shapes {:?} and {:?} for op `{}`",
+                lhs, rhs, self.op
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ShapeError {}
+
+/// Returns the coarse shape rule kind for a Core v1 operator name.
+///
+/// The mapping intentionally focuses on the small Core v1 surface and
+/// uses the same string identifiers as the operator registry.
+pub fn rule_for_op(op: &str) -> Option<ShapeRuleKind> {
+    match op {
+        // Unary elementwise.
+        "tensor.relu" | "tensor.neg" | "tensor.exp" | "tensor.log" => {
+            Some(ShapeRuleKind::ElementwiseUnary)
+        }
+
+        // Binary elementwise.
+        "tensor.add" | "tensor.sub" | "tensor.mul" | "tensor.div" => {
+            Some(ShapeRuleKind::ElementwiseBinary)
+        }
+
+        // Full reduction to scalar.
+        "tensor.sum_all" => Some(ShapeRuleKind::ReduceAll),
+
+        // 2D matrix multiplication.
+        "tensor.matmul" => Some(ShapeRuleKind::MatMul2D),
+
+        _ => None,
+    }
+}
+
+/// Convenience helper: true if the given op is treated as Core v1
+/// elementwise (unary or binary).
+pub fn is_elementwise(op: &str) -> bool {
+    matches!(
+        rule_for_op(op),
+        Some(ShapeRuleKind::ElementwiseUnary | ShapeRuleKind::ElementwiseBinary)
+    )
+}
+
+/// Compute the broadcasted shape for two input shapes following the
+/// standard "numpy-style" broadcasting rules.
+///
+/// Shapes are aligned from the right; dimensions must be equal or 1,
+/// otherwise broadcasting fails.
+pub fn broadcast_shapes(lhs: &[usize], rhs: &[usize]) -> Result<Shape, ShapeErrorKind> {
+    let mut result = Vec::new();
+
+    let max_rank = lhs.len().max(rhs.len());
+    for i in 0..max_rank {
+        let a = lhs.get(lhs.len().wrapping_sub(1).wrapping_sub(i)).copied().unwrap_or(1);
+        let b = rhs.get(rhs.len().wrapping_sub(1).wrapping_sub(i)).copied().unwrap_or(1);
+
+        let dim = if a == b || a == 1 {
+            b
+        } else if b == 1 {
+            a
+        } else {
+            return Err(ShapeErrorKind::BroadcastError {
+                lhs: lhs.to_vec(),
+                rhs: rhs.to_vec(),
+            });
+        };
+
+        result.push(dim);
+    }
+
+    result.reverse();
+    Ok(result)
+}
+
+/// Infer the output shape for a Core v1 operator given its input shapes.
+///
+/// This helper is deliberately minimal and does not yet attempt to
+/// model axis parameters or partial reductions; it focuses on the
+/// common, fully-determined cases that are easy to validate in tests.
+pub fn infer_output_shape(op: &str, inputs: &[&[usize]]) -> Result<Shape, ShapeError> {
+    let rule = match rule_for_op(op) {
+        Some(rule) => rule,
+        None => {
+            return Err(ShapeError {
+                op: op.to_string(),
+                kind: ShapeErrorKind::UnknownOp,
+            })
+        }
+    };
+
+    match rule {
+        ShapeRuleKind::ElementwiseUnary => {
+            let lhs = inputs
+                .get(0)
+                .ok_or_else(|| ShapeError {
+                    op: op.to_string(),
+                    kind: ShapeErrorKind::RankMismatch {
+                        expected: "one input tensor".to_string(),
+                        actual_lhs: Vec::new(),
+                        actual_rhs: None,
+                    },
+                })?;
+            Ok(lhs.to_vec())
+        }
+        ShapeRuleKind::ElementwiseBinary => {
+            let lhs = inputs.get(0).copied().unwrap_or(&[]);
+            let rhs = inputs.get(1).copied().unwrap_or(&[]);
+            broadcast_shapes(lhs, rhs).map_err(|kind| ShapeError {
+                op: op.to_string(),
+                kind,
+            })
+        }
+        ShapeRuleKind::ReduceAll => {
+            let lhs = inputs.get(0).copied().unwrap_or(&[]);
+            if lhs.is_empty() {
+                // Reducing a scalar stays scalar.
+                Ok(Vec::new())
+            } else {
+                // Full reduction → rank-0 scalar.
+                Ok(Vec::new())
+            }
+        }
+        ShapeRuleKind::MatMul2D => {
+            let lhs = inputs.get(0).copied().unwrap_or(&[]);
+            let rhs = inputs.get(1).copied().unwrap_or(&[]);
+
+            if lhs.len() != 2 || rhs.len() != 2 {
+                return Err(ShapeError {
+                    op: op.to_string(),
+                    kind: ShapeErrorKind::RankMismatch {
+                        expected: "two rank-2 tensors".to_string(),
+                        actual_lhs: lhs.to_vec(),
+                        actual_rhs: Some(rhs.to_vec()),
+                    },
+                });
+            }
+
+            if lhs[1] != rhs[0] {
+                return Err(ShapeError {
+                    op: op.to_string(),
+                    kind: ShapeErrorKind::RankMismatch {
+                        expected: "lhs.shape[1] == rhs.shape[0]".to_string(),
+                        actual_lhs: lhs.to_vec(),
+                        actual_rhs: Some(rhs.to_vec()),
+                    },
+                });
+            }
+
+            Ok(vec![lhs[0], rhs[1]])
+        }
+    }
+}

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -11,6 +11,8 @@
 
 //! Shared tensor shape helpers for the MIND compiler.
 
+pub mod engine;
+
 use std::collections::BTreeSet;
 
 use crate::linalg;

--- a/tests/shapes_engine.rs
+++ b/tests/shapes_engine.rs
@@ -1,0 +1,87 @@
+use mind::shapes::engine::{
+    broadcast_shapes, infer_output_shape, is_elementwise, rule_for_op, ShapeErrorKind, ShapeRuleKind,
+};
+
+#[test]
+fn rule_for_known_ops() {
+    assert_eq!(rule_for_op("tensor.relu"), Some(ShapeRuleKind::ElementwiseUnary));
+    assert_eq!(rule_for_op("tensor.add"), Some(ShapeRuleKind::ElementwiseBinary));
+    assert_eq!(rule_for_op("tensor.sum_all"), Some(ShapeRuleKind::ReduceAll));
+    assert_eq!(rule_for_op("tensor.matmul"), Some(ShapeRuleKind::MatMul2D));
+    assert!(rule_for_op("tensor.unknown").is_none());
+}
+
+#[test]
+fn elementwise_flag_matches_rules() {
+    assert!(is_elementwise("tensor.add"));
+    assert!(is_elementwise("tensor.relu"));
+    assert!(!is_elementwise("tensor.matmul"));
+    assert!(!is_elementwise("tensor.sum_all"));
+}
+
+#[test]
+fn broadcast_shapes_simple() {
+    let a = [2, 3];
+    let b = [1, 3];
+    let out = broadcast_shapes(&a, &b).expect("broadcast should succeed");
+    assert_eq!(out, vec![2, 3]);
+}
+
+#[test]
+fn broadcast_shapes_error() {
+    let a = [2, 3];
+    let b = [4, 3];
+    let err = broadcast_shapes(&a, &b).unwrap_err();
+    match err {
+        ShapeErrorKind::BroadcastError { lhs, rhs } => {
+            assert_eq!(lhs, vec![2, 3]);
+            assert_eq!(rhs, vec![4, 3]);
+        }
+        _ => panic!("expected BroadcastError"),
+    }
+}
+
+#[test]
+fn infer_elementwise_binary_broadcast() {
+    let out = infer_output_shape("tensor.add", &[&[2, 3][..], &[1, 3][..]])
+        .expect("elementwise add should broadcast");
+    assert_eq!(out, vec![2, 3]);
+}
+
+#[test]
+fn infer_elementwise_unary_identity() {
+    let out = infer_output_shape("tensor.relu", &[&[4, 5, 6][..]]).expect("relu should preserve shape");
+    assert_eq!(out, vec![4, 5, 6]);
+}
+
+#[test]
+fn infer_matmul_2d_ok() {
+    let out =
+        infer_output_shape("tensor.matmul", &[&[2, 3][..], &[3, 4][..]]).expect("matmul should work");
+    assert_eq!(out, vec![2, 4]);
+}
+
+#[test]
+fn infer_matmul_mismatched_inner_dim() {
+    let err = infer_output_shape("tensor.matmul", &[&[2, 3][..], &[4, 5][..]]).unwrap_err();
+    match err.kind {
+        ShapeErrorKind::RankMismatch { .. } => {}
+        _ => panic!("expected RankMismatch for mismatched inner dims"),
+    }
+}
+
+#[test]
+fn infer_reduce_all_to_scalar() {
+    let out = infer_output_shape("tensor.sum_all", &[&[2, 2][..]]).expect("sum_all should reduce to scalar");
+    // Rank-0 scalar represented as an empty shape.
+    assert_eq!(out, Vec::<usize>::new());
+}
+
+#[test]
+fn infer_unknown_op_reports_error() {
+    let err = infer_output_shape("tensor.unknown", &[&[1, 2][..]]).unwrap_err();
+    match err.kind {
+        ShapeErrorKind::UnknownOp => {}
+        _ => panic!("expected UnknownOp error"),
+    }
+}


### PR DESCRIPTION
## Summary
- add a Core v1 shape engine covering elementwise operators, reductions, broadcasting, and matmul
- expose reusable helpers for broadcasting compatibility and shape inference
- add shape engine tests covering successful cases and expected failures

## Testing
- cargo test --test shapes_engine


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937cf5e7ca88322bcccf0cd4280ab46)