### PR TITLE
Format shapes engine with stable rustfmt

### DIFF
--- a/src/shapes/engine.rs
+++ b/src/shapes/engine.rs
@@ -32,10 +32,7 @@ pub enum ShapeErrorKind {
         actual_rhs: Option<Vec<usize>>,
     },
     /// Broadcasting failed for the given input shapes.
-    BroadcastError {
-        lhs: Vec<usize>,
-        rhs: Vec<usize>,
-    },
+    BroadcastError { lhs: Vec<usize>, rhs: Vec<usize> },
 }
 
 /// Rich shape error containing the operator name and a structured kind.
@@ -126,8 +123,14 @@ pub fn broadcast_shapes(lhs: &[usize], rhs: &[usize]) -> Result<Shape, ShapeErro
 
     let max_rank = lhs.len().max(rhs.len());
     for i in 0..max_rank {
-        let a = lhs.get(lhs.len().wrapping_sub(1).wrapping_sub(i)).copied().unwrap_or(1);
-        let b = rhs.get(rhs.len().wrapping_sub(1).wrapping_sub(i)).copied().unwrap_or(1);
+        let a = lhs
+            .get(lhs.len().wrapping_sub(1).wrapping_sub(i))
+            .copied()
+            .unwrap_or(1);
+        let b = rhs
+            .get(rhs.len().wrapping_sub(1).wrapping_sub(i))
+            .copied()
+            .unwrap_or(1);
 
         let dim = if a == b || a == 1 {
             b
@@ -165,16 +168,14 @@ pub fn infer_output_shape(op: &str, inputs: &[&[usize]]) -> Result<Shape, ShapeE
 
     match rule {
         ShapeRuleKind::ElementwiseUnary => {
-            let lhs = inputs
-                .get(0)
-                .ok_or_else(|| ShapeError {
-                    op: op.to_string(),
-                    kind: ShapeErrorKind::RankMismatch {
-                        expected: "one input tensor".to_string(),
-                        actual_lhs: Vec::new(),
-                        actual_rhs: None,
-                    },
-                })?;
+            let lhs = inputs.get(0).ok_or_else(|| ShapeError {
+                op: op.to_string(),
+                kind: ShapeErrorKind::RankMismatch {
+                    expected: "one input tensor".to_string(),
+                    actual_lhs: Vec::new(),
+                    actual_rhs: None,
+                },
+            })?;
             Ok(lhs.to_vec())
         }
         ShapeRuleKind::ElementwiseBinary => {
@@ -207,10 +208,9 @@ pub fn infer_output_shape(op: &str, inputs: &[&[usize]]) -> Result<Shape, ShapeE
                     op: op.to_string(),
                     kind: ShapeErrorKind::RankMismatch {
                         // This variant is also used for general dimension
-                        // compatibility violations, not only for pure rank
-                        // mismatches; make the expectation explicit for matmul.
-                        expected: "matmul requires lhs.shape[1] == rhs.shape[0]"
-                            .to_string(),
+                        // compatibility violations, not only for pure rank mismatches; make the
+                        // expectation explicit for matmul.
+                        expected: "matmul requires lhs.shape[1] == rhs.shape[0]".to_string(),
                         actual_lhs: lhs.to_vec(),
                         actual_rhs: Some(rhs.to_vec()),
                     },

--- a/tests/shapes_engine.rs
+++ b/tests/shapes_engine.rs
@@ -1,12 +1,22 @@
 use mind::shapes::engine::{
-    broadcast_shapes, infer_output_shape, is_elementwise, rule_for_op, ShapeErrorKind, ShapeRuleKind,
+    broadcast_shapes, infer_output_shape, is_elementwise, rule_for_op, ShapeErrorKind,
+    ShapeRuleKind,
 };
 
 #[test]
 fn rule_for_known_ops() {
-    assert_eq!(rule_for_op("tensor.relu"), Some(ShapeRuleKind::ElementwiseUnary));
-    assert_eq!(rule_for_op("tensor.add"), Some(ShapeRuleKind::ElementwiseBinary));
-    assert_eq!(rule_for_op("tensor.sum_all"), Some(ShapeRuleKind::ReduceAll));
+    assert_eq!(
+        rule_for_op("tensor.relu"),
+        Some(ShapeRuleKind::ElementwiseUnary)
+    );
+    assert_eq!(
+        rule_for_op("tensor.add"),
+        Some(ShapeRuleKind::ElementwiseBinary)
+    );
+    assert_eq!(
+        rule_for_op("tensor.sum_all"),
+        Some(ShapeRuleKind::ReduceAll)
+    );
     assert_eq!(rule_for_op("tensor.matmul"), Some(ShapeRuleKind::MatMul2D));
     assert!(rule_for_op("tensor.unknown").is_none());
 }
@@ -50,14 +60,15 @@ fn infer_elementwise_binary_broadcast() {
 
 #[test]
 fn infer_elementwise_unary_identity() {
-    let out = infer_output_shape("tensor.relu", &[&[4, 5, 6][..]]).expect("relu should preserve shape");
+    let out =
+        infer_output_shape("tensor.relu", &[&[4, 5, 6][..]]).expect("relu should preserve shape");
     assert_eq!(out, vec![4, 5, 6]);
 }
 
 #[test]
 fn infer_matmul_2d_ok() {
-    let out =
-        infer_output_shape("tensor.matmul", &[&[2, 3][..], &[3, 4][..]]).expect("matmul should work");
+    let out = infer_output_shape("tensor.matmul", &[&[2, 3][..], &[3, 4][..]])
+        .expect("matmul should work");
     assert_eq!(out, vec![2, 4]);
 }
 
@@ -72,7 +83,8 @@ fn infer_matmul_mismatched_inner_dim() {
 
 #[test]
 fn infer_reduce_all_to_scalar() {
-    let out = infer_output_shape("tensor.sum_all", &[&[2, 2][..]]).expect("sum_all should reduce to scalar");
+    let out = infer_output_shape("tensor.sum_all", &[&[2, 2][..]])
+        .expect("sum_all should reduce to scalar");
     // Rank-0 scalar represented as an empty shape.
     assert_eq!(out, Vec::<usize>::new());
 }


### PR DESCRIPTION
## Summary
- apply stable rustfmt layout to shape engine implementation
- reflow test formatting to match stable rustfmt expectations

## Testing
- cargo +stable fmt --all -- --check *(fails: unable to download toolchain due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937dc38d854832291fd8642384f269f)