### PR TITLE
Integrate Core v1 shape diagnostics into compilation

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -58,6 +58,12 @@ Every diagnostic carries a stable code for the Core v1 pipeline phase:
 - Autodiff: `E4xxx`
 - MLIR lowering: `E5xxx`
 
+Shape validation for Core v1 operators is also surfaced during type checking:
+
+- Broadcast compatibility: `E2101`
+- Rank or shape expectation mismatches (including invalid reductions): `E2102`
+- Matmul inner-dimension mismatches: `E2103`
+
 See [`docs/versioning.md`](versioning.md) for how these classes fit the stability
 contract.
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -4,6 +4,11 @@ The Core v1 surface exposes a small, auditable set of tensor operators. The
 registry lives in `src/ops/core_v1.rs` and is consumable from the CLI via
 `mindc ops --core-v1`.
 
+Elementwise ops (`add`, `sub`, `mul`, `div`, `tensor.relu`) and matrix
+multiplication (`tensor.matmul`) are tagged with Core v1 shape rule categories
+so the shared shape engine can validate broadcasting and inner-dimension
+compatibility during compilation.
+
 | name             | arity    | differentiable | notes                                      |
 | ---------------- | -------- | -------------- | ------------------------------------------ |
 | add              | 2        | yes            | Elementwise add with broadcasting.         |

--- a/src/ops/core_v1.rs
+++ b/src/ops/core_v1.rs
@@ -12,6 +12,7 @@
 
 // Part of the MIND project (Machine Intelligence Native Design).
 
+use crate::shapes::engine::ShapeRuleKind;
 use crate::types::DType;
 
 /// Fixed-function metadata for a Core v1 operator.
@@ -28,6 +29,8 @@ pub struct OpSignature {
     pub differentiable: bool,
     /// Short description of the op contract.
     pub summary: &'static str,
+    /// Optional Core v1 shape rule category enforced by the shape engine.
+    pub shape_rule: Option<ShapeRuleKind>,
 }
 
 /// Arity description for ops that accept a fixed or variadic input count.
@@ -50,6 +53,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::I32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Elementwise addition with standard broadcasting.",
+            shape_rule: Some(ShapeRuleKind::ElementwiseBinary),
         },
         OpSignature {
             name: "sub",
@@ -57,6 +61,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::I32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Elementwise subtraction with standard broadcasting.",
+            shape_rule: Some(ShapeRuleKind::ElementwiseBinary),
         },
         OpSignature {
             name: "mul",
@@ -64,6 +69,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::I32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Elementwise multiplication with standard broadcasting.",
+            shape_rule: Some(ShapeRuleKind::ElementwiseBinary),
         },
         OpSignature {
             name: "div",
@@ -71,6 +77,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Elementwise division with standard broadcasting.",
+            shape_rule: Some(ShapeRuleKind::ElementwiseBinary),
         },
         OpSignature {
             name: "tensor.sum",
@@ -78,6 +85,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Reduction over axes with optional keepdims.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.mean",
@@ -85,6 +93,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Mean reduction over axes with optional keepdims.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.reshape",
@@ -92,6 +101,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[],
             differentiable: true,
             summary: "Reshape tensor to a new compatible shape.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.expand_dims",
@@ -99,6 +109,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[],
             differentiable: true,
             summary: "Insert a length-1 dimension at the given axis.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.squeeze",
@@ -106,6 +117,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[],
             differentiable: true,
             summary: "Remove length-1 dimensions.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.transpose",
@@ -113,6 +125,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[],
             differentiable: true,
             summary: "Permute tensor axes.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.dot",
@@ -120,6 +133,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "1D dot product.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.matmul",
@@ -127,6 +141,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Matrix multiplication for rank ≥ 2 tensors.",
+            shape_rule: Some(ShapeRuleKind::MatMul2D),
         },
         OpSignature {
             name: "tensor.conv2d",
@@ -134,6 +149,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "2D convolution with stride/padding parameters.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.index",
@@ -141,6 +157,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[],
             differentiable: false,
             summary: "Basic integer indexing.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.slice",
@@ -148,6 +165,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[],
             differentiable: false,
             summary: "Half-open slicing per axis.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.gather",
@@ -155,6 +173,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Gather elements along an axis using integer indices.",
+            shape_rule: None,
         },
         OpSignature {
             name: "tensor.relu",
@@ -162,6 +181,7 @@ pub const fn core_v1_ops() -> &'static [OpSignature] {
             allowed_dtypes: &[DType::F32, DType::BF16, DType::F16],
             differentiable: true,
             summary: "Elementwise ReLU activation.",
+            shape_rule: Some(ShapeRuleKind::ElementwiseUnary),
         },
     ]
 }

--- a/tests/fixtures/invalid_broadcast.mind
+++ b/tests/fixtures/invalid_broadcast.mind
@@ -1,0 +1,3 @@
+let x: Tensor[f32,(2,3)] = 0;
+let y: Tensor[f32,(4,3)] = 0;
+x + y

--- a/tests/mindc.rs
+++ b/tests/mindc.rs
@@ -179,6 +179,30 @@ fn mindc_prints_json_diagnostics_with_flag() {
 }
 
 #[test]
+fn mindc_reports_shape_errors_with_codes() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--bin",
+            "mindc",
+            "--",
+            "tests/fixtures/invalid_broadcast.mind",
+            "--diagnostic-format",
+            "json",
+        ])
+        .output()
+        .expect("run mindc shape error");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let first_line = stderr.lines().next().unwrap_or("");
+    let value: serde_json::Value = serde_json::from_str(first_line).expect("json diagnostic");
+    assert_eq!(value["code"], "E2101");
+    assert_eq!(value["phase"], "type-check");
+}
+
+#[test]
 fn mindc_color_env_overridden_by_flag() {
     let output = Command::new("cargo")
         .env("MINDC_COLOR", "always")

--- a/tests/shape_integration.rs
+++ b/tests/shape_integration.rs
@@ -1,0 +1,57 @@
+use mind::pipeline::{compile_source_with_name, CompileError, CompileOptions};
+use mind::runtime::types::BackendTarget;
+
+fn compile_opts() -> CompileOptions {
+    CompileOptions {
+        func: None,
+        enable_autodiff: false,
+        target: BackendTarget::Cpu,
+    }
+}
+
+fn expect_shape_code(src: &str, code: &str) {
+    let err = compile_source_with_name(src, Some("shape.mind"), &compile_opts())
+        .expect_err("program should fail shape validation");
+    match err {
+        CompileError::TypeError(diags) => {
+            let codes: Vec<&str> = diags.iter().map(|d| d.code).collect();
+            assert!(
+                codes.iter().any(|c| *c == code),
+                "expected diagnostic code {code}, saw {codes:?}"
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn elementwise_broadcast_failure_surfaces_shape_code() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 0;
+        let y: Tensor[f32,(4,3)] = 0;
+        x + y
+    "#;
+    expect_shape_code(src, "E2101");
+}
+
+#[test]
+fn matmul_inner_dimension_mismatch_reports_shape_code() {
+    let src = r#"
+        let a: Tensor[f32,(2,3)] = 0;
+        let b: Tensor[f32,(5,4)] = 0;
+        tensor.matmul(a, b)
+    "#;
+    expect_shape_code(src, "E2103");
+}
+
+#[test]
+fn valid_broadcast_program_compiles() {
+    let src = r#"
+        let x: Tensor[f32,(2,3)] = 0;
+        let y: Tensor[f32,(1,3)] = 0;
+        x + y
+    "#;
+    let products = compile_source_with_name(src, Some("shape_ok.mind"), &compile_opts())
+        .expect("valid shapes should compile");
+    assert!(!products.ir.instrs.is_empty());
+}


### PR DESCRIPTION
## Summary
- route elementwise and matmul shape validation through the shared Core v1 shape engine and classify diagnostics into stable codes
- tag Core v1 operator metadata with shape rule categories and document the new shape-related error codes
- add integration and CLI tests that exercise broadcast and matmul shape failures

## Testing
- cargo test --test shape_integration -- --nocapture


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937de7f0a2c832288d176ff916efc74)