### PR TITLE
Use first() for rhs access in type checker

### DIFF
--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -155,7 +155,7 @@ fn shape_engine_error(op_display: &str, err: engine::ShapeError, span: AstSpan) 
                     actual_lhs.get(1).copied().unwrap_or(0),
                     actual_rhs
                         .as_ref()
-                        .and_then(|rhs| rhs.get(0).copied())
+                        .and_then(|rhs| rhs.first().copied())
                         .unwrap_or(0)
                 )
             } else {


### PR DESCRIPTION
## Summary
- use `first()` instead of `get(0)` when pulling the first rhs shape element to satisfy clippy::get-first.

## Testing
- cargo fmt --all
- cargo clippy --no-default-features --locked -- -D warnings


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e257920c8322a33df0337415b204)