### PR TITLE
Fix rank mismatch error classification

### DIFF
--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -1587,7 +1587,7 @@ fn classify_error_code(msg: &str) -> &'static str {
         SHAPE_INNER_DIM_CODE
     } else if msg.contains("broadcast") {
         SHAPE_BROADCAST_CODE
-    } else if msg.contains("rank mismatch") || msg.contains("rank ") {
+    } else if msg.contains("rank mismatch") {
         SHAPE_RANK_CODE
     } else {
         TYPE_ERR_CODE


### PR DESCRIPTION
## Summary
- update error code classification to only match explicit "rank mismatch" messages
- avoid misclassifying unrelated errors containing the word "rank"

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e76244d4832292d76fc9d0eae969)