### PR TITLE
Fix type mismatches and autodiff test issues

### DIFF
--- a/examples/cnn_classifier.mind
+++ b/examples/cnn_classifier.mind
@@ -98,14 +98,14 @@ fn train_step(x: diff tensor<f32[batch, 1, 28, 28]>,
     return (w1_new, b1_new, w2_new, b2_new, w3_new, b3_new);
 }
 
-// Inference (no gradients needed)
-fn predict(x: tensor<f32[batch, 1, 28, 28]>,
-           w1: tensor<f32[16, 1, 3, 3]>,
-           b1: tensor<f32[16]>,
-           w2: tensor<f32[32, 16, 3, 3]>,
-           b2: tensor<f32[32]>,
-           w3: tensor<f32[800, 10]>,
-           b3: tensor<f32[10]>) -> tensor<i32[batch]> {
+// Inference (uses diff types to match forward, but no gradient computation)
+fn predict(x: diff tensor<f32[batch, 1, 28, 28]>,
+           w1: diff tensor<f32[16, 1, 3, 3]>,
+           b1: diff tensor<f32[16]>,
+           w2: diff tensor<f32[32, 16, 3, 3]>,
+           b2: diff tensor<f32[32]>,
+           w3: diff tensor<f32[800, 10]>,
+           b3: diff tensor<f32[10]>) -> tensor<i32[batch]> {
     let logits = forward(x, w1, b1, w2, b2, w3, b3);
     return argmax(logits, axis=1);  // Predicted class per sample
 }

--- a/examples/tiny_edge_model.mind
+++ b/examples/tiny_edge_model.mind
@@ -17,7 +17,7 @@
 
 // Layer 1: Input(10) → Hidden(16) with ReLU
 // Parameters: 10×16 = 160 f32 weights = 640 bytes
-fn layer1(x: tensor<f32[10]>, w1: tensor<f32[10, 16]>) -> tensor<f32[16]> {
+fn layer1(x: diff tensor<f32[10]>, w1: diff tensor<f32[10, 16]>) -> diff tensor<f32[16]> {
     let z = matmul(reshape(x, [1, 10]), w1);  // [1,10] @ [10,16] = [1,16]
     let h = relu(reshape(z, [16]));            // ReLU activation
     return h;
@@ -25,7 +25,7 @@ fn layer1(x: tensor<f32[10]>, w1: tensor<f32[10, 16]>) -> tensor<f32[16]> {
 
 // Layer 2: Hidden(16) → Hidden(8) with ReLU
 // Parameters: 16×8 = 128 f32 weights = 512 bytes
-fn layer2(h: tensor<f32[16]>, w2: tensor<f32[16, 8]>) -> tensor<f32[8]> {
+fn layer2(h: diff tensor<f32[16]>, w2: diff tensor<f32[16, 8]>) -> diff tensor<f32[8]> {
     let z = matmul(reshape(h, [1, 16]), w2);   // [1,16] @ [16,8] = [1,8]
     let h2 = relu(reshape(z, [8]));             // ReLU activation
     return h2;
@@ -33,17 +33,17 @@ fn layer2(h: tensor<f32[16]>, w2: tensor<f32[16, 8]>) -> tensor<f32[8]> {
 
 // Output layer: Hidden(8) → Output(1) for binary classification
 // Parameters: 8×1 = 8 f32 weights = 32 bytes
-fn output_layer(h: tensor<f32[8]>, w3: tensor<f32[8, 1]>) -> tensor<f32> {
+fn output_layer(h: diff tensor<f32[8]>, w3: diff tensor<f32[8, 1]>) -> diff tensor<f32> {
     let z = matmul(reshape(h, [1, 8]), w3);    // [1,8] @ [8,1] = [1,1]
     let logit = reshape(z, []);                 // Scalar output
     return sigmoid(logit);                      // Probability ∈ [0,1]
 }
 
-// Full forward pass (inference only)
-fn predict(x: tensor<f32[10]>,
-           w1: tensor<f32[10, 16]>,
-           w2: tensor<f32[16, 8]>,
-           w3: tensor<f32[8, 1]>) -> tensor<f32> {
+// Full forward pass (works for both training and inference)
+fn predict(x: diff tensor<f32[10]>,
+           w1: diff tensor<f32[10, 16]>,
+           w2: diff tensor<f32[16, 8]>,
+           w3: diff tensor<f32[8, 1]>) -> diff tensor<f32> {
     let h1 = layer1(x, w1);
     let h2 = layer2(h1, w2);
     let prob = output_layer(h2, w3);

--- a/tests/autodiff/matmul_gradient.mind
+++ b/tests/autodiff/matmul_gradient.mind
@@ -7,7 +7,8 @@ fn test_matmul_grad() {
                                       [5.0, 6.0, 7.0, 8.0],
                                       [9.0, 10.0, 11.0, 12.0]];
     let c = matmul(a, b);
-    let grad_a = backward(c, a);  // dc/da = matmul(dc/dc, b^T)
-    let grad_b = backward(c, b);  // dc/db = matmul(a^T, dc/dc)
+    let loss = sum(c);  // Scalar loss required for backward
+    let grad_a = backward(loss, a);  // dloss/da = matmul(dloss/dc, b^T)
+    let grad_b = backward(loss, b);  // dloss/db = matmul(a^T, dloss/dc)
     return (grad_a, grad_b);
 }

--- a/tests/autodiff/simple_gradient.mind
+++ b/tests/autodiff/simple_gradient.mind
@@ -8,6 +8,6 @@ fn square(x: diff tensor<f32>) -> diff tensor<f32> {
 fn test_gradient() {
     let x: diff tensor<f32> = 3.0;
     let y = square(x);
-    let grad_x = backward(y);  // Should be 2*3 = 6.0
+    let grad_x = backward(y, x);  // Should be 2*3 = 6.0
     return grad_x;
 }


### PR DESCRIPTION
Address Copilot suggestions from PR #129:

**Autodiff tests:**
- simple_gradient.mind: Fix backward() to take 2 args: backward(y, x)
- matmul_gradient.mind: Add scalar loss before backward calls

**Type mismatches in examples:**
- cnn_classifier.mind: Change predict() to use diff types to match forward()
- tiny_edge_model.mind: Change all layer functions to use diff types for consistency between training and inference

These fixes resolve type system consistency issues and ensure proper gradient computation in autodiff tests.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
