### PR TITLE
docs: Add Phase 13 neuroscience and BCI roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ status.
 * [IR core](docs/ir.md) — deterministic IR pipeline with verifier and printer.
 * [IR & MLIR](docs/ir-mlir.md) — compiler pipeline from parser to MLIR dialects.
 
+## Applications
+
+### Neuroscience & Brain-Computer Interfaces
+
+MIND's combination of static shape inference, reverse-mode autodiff, ultra-low-latency compilation, and deterministic execution makes it uniquely suited for real-time neural signal processing and brain-computer interface (BCI) applications:
+
+* **Real-time Neural Decoding** — Sub-millisecond inference for invasive BCI systems (Neuralink-style implants, ECoG arrays)
+* **Multi-channel Time-Series** — Native tensor operations for Channel × Time × Batch neural data
+* **On-device Adaptation** — Gradient-based decoder optimization directly on implanted devices using autodiff
+* **Reproducible Research** — Deterministic builds critical for FDA-regulated medical devices and neuroscience studies
+* **Edge Deployment** — Deploy to resource-constrained BCI hardware (ARM Cortex-M, RISC-V) with minimal runtime overhead
+
+See [Phase 13 in the roadmap](docs/roadmap.md#phase-13--neuroscience--brain-computer-interfaces) for planned neuroscience-specific standard library modules, data format support, and benchmarks.
+
+### Other Applications
+
+MIND's design also supports machine learning research, embedded AI, and safety-critical intelligent systems requiring auditable execution and reproducible builds.
+
 ## Stability & Versioning
 
 MIND Core v1 follows the public contract in mind-spec Core v1. The stability

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,9 +95,63 @@ Enable enterprise and safety-critical adoption through stable runtime features, 
 
 ---
 
+## Phase 13 — Neuroscience & Brain-Computer Interfaces
+
+### Goals
+Establish MIND as the premier language for real-time neural signal processing and brain-computer interface (BCI) applications. Leverage MIND's native tensor operations, static shape inference, and high-performance compilation for ultra-low-latency neural decoding in next-generation BCI systems (Neuralink-style implants, research BMIs, clinical neurotechnology).
+
+### Deliverables
+
+**Near-term (Phase 13.1):**
+- Add `mind::neuro` standard library module:
+  - Specialized tensor types for neural time-series (Channel × Time × Batch)
+  - Common signal processing filters: bandpass, notch, ICA decomposition
+  - Feature extraction primitives: CSP (Common Spatial Patterns), wavelet transforms, spectral power
+- IO support for neuroscience data formats:
+  - EDF/EDF+ (European Data Format) for clinical EEG
+  - GDF (General Data Format) for BCI research
+  - Optional integration with existing Rust neuro crates
+- Example implementations:
+  - Spike detection algorithms for invasive recordings
+  - Motor intent decoding from ECoG/multi-unit activity
+  - Basic P300 and SSVEP classifiers for non-invasive BCI
+
+**Medium-term (Phase 13.2):**
+- Optimized neural decoders:
+  - RNN/LSTM templates for sequence-to-intent decoding
+  - Transformer-based models for multi-modal neural data
+  - Integration with autodiff for on-device decoder adaptation
+- Tutorials and examples:
+  - BCI Competition datasets (motor imagery, P300)
+  - OpenNeuro integration for reproducible research
+  - Real-time decoding pipeline examples
+- Performance benchmarks:
+  - Sub-millisecond inference for invasive BCI
+  - Comparison with existing frameworks (MNE-Python, FieldTrip)
+
+**Long-term (Phase 13.3):**
+- Closed-loop BCI support:
+  - Real-time feedback mechanisms
+  - Online learning and decoder adaptation
+  - Safety-critical execution guarantees for medical devices
+- Research collaborations:
+  - Partner with neuroscience labs for validation
+  - Contribute to open BCI standards (IEEE, INCF)
+  - Support for neuromorphic hardware targets
+
+### Integration with Existing Features
+
+- **Tensors**: Multi-channel neural data naturally maps to MIND's tensor model (channels, time, trials, batches)
+- **Autodiff**: Enable gradient-based decoder optimization directly on implanted devices
+- **MLIR/LLVM**: Generate highly optimized code for real-time constraints (<1ms latency)
+- **Edge Runtime**: Deploy to resource-constrained BCI hardware (ARM Cortex-M, RISC-V)
+- **Determinism**: Critical for reproducible neuroscience and FDA-regulated medical devices
+
+---
+
 ## Summary
 
-These extended phases (10–12) guide MIND into the next major development era:
+These extended phases (10–13) guide MIND into the next major development era:
 - richer SDK and examples,
 - formal benchmarks,
 - early cloud compiler,


### PR DESCRIPTION
- Add Phase 13 to roadmap.md covering neuroscience and brain-computer interface support
- Include near-term, medium-term, and long-term BCI deliverables
- Add Applications section to README.md highlighting BCI use cases
- Emphasize MIND's strengths for real-time neural decoding and edge BCI deployment
- Update roadmap summary to reference phases 10-13

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
