### PR TITLE
fix: Address Copilot review feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,27 @@ jobs:
           targets: ${{ matrix.target }}
           components: clippy,rustfmt
 
-      - name: Cache cargo registry
+      - name: Cache cargo registry (Unix)
+        if: runner.os != 'Windows'
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cache cargo registry (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~\.cargo\registry
+            ~\.cargo\git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -68,6 +81,13 @@ jobs:
         run: |
           git config --global --unset-all http.proxy  || true
           git config --global --unset-all https.proxy || true
+
+      - name: Remove git proxies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git config --global --unset http.proxy 2>$null
+          git config --global --unset https.proxy 2>$null
 
       - name: Cargo metadata (smoke)
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ All PRs must pass these checks:
 | Test | `cargo test --no-default-features` |
 | Clippy | `cargo clippy --no-default-features -- -D warnings` |
 | License | `cargo deny check` |
-| Docs | `cargo doc --no-default-features` |
+| Docs | `cargo doc --no-default-features --document-private-items` |
 
 ### Running Tests
 
@@ -211,7 +211,6 @@ src/
 Contributors are recognized in:
 
 - Release notes
-- AUTHORS file (for significant contributions)
 - GitHub contributor graphs
 
 Thank you for contributing to MIND!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 default-run = "mind"
 keywords = ["ai", "machine-learning", "compiler", "tensor", "autodiff"]
 categories = ["compilers", "science"]
-exclude = ["assets/", "benchmarks/", "docs/", "examples/", ".github/"]
+exclude = ["assets/", "benchmarks/", "examples/"]
 
 [dependencies]
 logos = "0.13"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,9 +45,9 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 ## Security Best Practices
 
-When using MIND in production:
+When using MIND in production (as a dependency in your own applications):
 
-1. **Pin dependencies**: Use `Cargo.lock` to ensure reproducible builds
+1. **Pin dependencies**: Commit your application's `Cargo.lock` to ensure reproducible builds
 2. **Verify checksums**: Validate release artifacts before deployment
 3. **Sandbox execution**: Run compiled MIND programs in isolated environments
 4. **Audit inputs**: Validate all external data before processing


### PR DESCRIPTION
- SECURITY.md: Clarify Cargo.lock advice for downstream users
- CONTRIBUTING.md: Fix docs command to match CI, remove AUTHORS reference
- Cargo.toml: Remove unnecessary .github and docs from exclude
- CI: Split cache steps for Unix/Windows, use Cargo.toml for cache key
- CI: Add Windows git proxy removal step

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
