### PR TITLE
feat(autodiff/conv2d): implement Conv2d gradients end-to-end

### DIFF
--- a/src/eval/conv2d_grad.rs
+++ b/src/eval/conv2d_grad.rs
@@ -1,0 +1,268 @@
+// Copyright 2025 STARGA Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Part of the MIND project (Machine Intelligence Native Design).
+
+//! Reference implementation of Conv2d gradient computation (VJP).
+//!
+//! This module provides correctness-first implementations of the backward
+//! pass for 2D convolution with NHWC input layout and HWIO filter layout.
+//! These are used by the eval-based autodiff and can serve as a reference
+//! oracle for verifying optimized MLIR lowerings.
+
+use crate::types::ConvPadding;
+
+/// Ceiling division for usize.
+#[inline]
+fn ceil_div(a: usize, b: usize) -> usize {
+    (a + b - 1) / b
+}
+
+/// Compute pad_top/pad_left for SAME padding given input and kernel and stride.
+fn same_padding_2d(
+    h: usize,
+    w: usize,
+    kh: usize,
+    kw: usize,
+    sh: usize,
+    sw: usize,
+) -> (usize, usize) {
+    let out_h = ceil_div(h, sh);
+    let out_w = ceil_div(w, sw);
+
+    let pad_h_total = (out_h.saturating_sub(1)) * sh + kh;
+    let pad_h_total = pad_h_total.saturating_sub(h);
+
+    let pad_w_total = (out_w.saturating_sub(1)) * sw + kw;
+    let pad_w_total = pad_w_total.saturating_sub(w);
+
+    (pad_h_total / 2, pad_w_total / 2)
+}
+
+/// NHWC indexing helper: index into a flat buffer with shape [N, H, W, C].
+#[inline]
+#[allow(non_snake_case)]
+fn idx_nhwc(n: usize, h: usize, w: usize, c: usize, H: usize, W: usize, C: usize) -> usize {
+    (((n * H + h) * W + w) * C) + c
+}
+
+/// HWIO indexing helper: index into a flat buffer with shape [KH, KW, C, O].
+#[inline]
+#[allow(non_snake_case)]
+fn idx_hwio(kh: usize, kw: usize, c: usize, o: usize, KW: usize, C: usize, O: usize) -> usize {
+    (((kh * KW + kw) * C + c) * O) + o
+}
+
+/// Compute (dX, dW) for Conv2d with:
+/// - X: NHWC [N, H, W, C]
+/// - W: HWIO [KH, KW, C, O]
+/// - dY: NHWC [N, OH, OW, O]
+///
+/// Returns:
+/// - dX: NHWC [N, H, W, C]
+/// - dW: HWIO [KH, KW, C, O]
+///
+/// This is a reference correctness-first implementation with complexity
+/// O(N * OH * OW * KH * KW * C * O).
+#[allow(non_snake_case)]
+pub fn conv2d_vjp_nhwc_hwio_f32(
+    x: &[f32],
+    x_shape: [usize; 4],
+    w: &[f32],
+    w_shape: [usize; 4],
+    dy: &[f32],
+    dy_shape: [usize; 4],
+    stride_h: usize,
+    stride_w: usize,
+    padding: ConvPadding,
+) -> (Vec<f32>, Vec<f32>) {
+    let [N, H, W_in, C] = x_shape;
+    let [KH, KW, Cw, O] = w_shape;
+    let [Ny, OH, OW, Oy] = dy_shape;
+
+    assert_eq!(N, Ny, "batch mismatch");
+    assert_eq!(C, Cw, "in_channels mismatch");
+    assert_eq!(O, Oy, "out_channels mismatch");
+
+    let (pad_top, pad_left) = match padding {
+        ConvPadding::Valid => (0usize, 0usize),
+        ConvPadding::Same => same_padding_2d(H, W_in, KH, KW, stride_h, stride_w),
+    };
+
+    let mut dx = vec![0.0f32; N * H * W_in * C];
+    let mut dw = vec![0.0f32; KH * KW * C * O];
+
+    for n in 0..N {
+        for oh in 0..OH {
+            for ow in 0..OW {
+                for o in 0..O {
+                    let dy_i = idx_nhwc(n, oh, ow, o, OH, OW, O);
+                    let g = dy[dy_i];
+
+                    // For each kernel position
+                    for kh in 0..KH {
+                        let ih_base = oh * stride_h + kh;
+                        let ih = ih_base as isize - pad_top as isize;
+                        if ih < 0 || ih >= H as isize {
+                            continue;
+                        }
+
+                        for kw in 0..KW {
+                            let iw_base = ow * stride_w + kw;
+                            let iw = iw_base as isize - pad_left as isize;
+                            if iw < 0 || iw >= W_in as isize {
+                                continue;
+                            }
+
+                            let ih = ih as usize;
+                            let iw = iw as usize;
+
+                            for c in 0..C {
+                                // dx += dy * w
+                                let w_i = idx_hwio(kh, kw, c, o, KW, C, O);
+                                let dx_i = idx_nhwc(n, ih, iw, c, H, W_in, C);
+                                dx[dx_i] += g * w[w_i];
+
+                                // dw += dy * x
+                                let x_i = idx_nhwc(n, ih, iw, c, H, W_in, C);
+                                dw[w_i] += g * x[x_i];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (dx, dw)
+}
+
+/// Compute output shape for Conv2d.
+#[allow(non_snake_case)]
+pub fn conv2d_output_shape(
+    x_shape: [usize; 4],
+    w_shape: [usize; 4],
+    stride_h: usize,
+    stride_w: usize,
+    padding: ConvPadding,
+) -> [usize; 4] {
+    let [N, H, W, _C] = x_shape;
+    let [KH, KW, _Cw, O] = w_shape;
+
+    let (oh, ow) = match padding {
+        ConvPadding::Valid => {
+            let oh = (H.saturating_sub(KH)) / stride_h + 1;
+            let ow = (W.saturating_sub(KW)) / stride_w + 1;
+            (oh, ow)
+        }
+        ConvPadding::Same => (ceil_div(H, stride_h), ceil_div(W, stride_w)),
+    };
+
+    [N, oh, ow, O]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_conv2d_vjp_valid_stride1() {
+        // Simple 1x3x3x1 input, 2x2x1x1 filter, stride 1, valid padding
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let x_shape = [1, 3, 3, 1];
+        let w = vec![1.0, 0.0, 0.0, 1.0];
+        let w_shape = [2, 2, 1, 1];
+        // Output shape: [1, 2, 2, 1]
+        // Forward: y[0,0,0,0] = x[0,0,0]*w[0,0] + x[0,0,1]*w[0,1] + x[0,1,0]*w[1,0] + x[0,1,1]*w[1,1]
+        //        = 1*1 + 2*0 + 4*0 + 5*1 = 6
+        // y[0,0,1,0] = 2*1 + 3*0 + 5*0 + 6*1 = 8
+        // y[0,1,0,0] = 4*1 + 5*0 + 7*0 + 8*1 = 12
+        // y[0,1,1,0] = 5*1 + 6*0 + 8*0 + 9*1 = 14
+        let dy = vec![1.0, 1.0, 1.0, 1.0];
+        let dy_shape = [1, 2, 2, 1];
+
+        let (dx, dw) = conv2d_vjp_nhwc_hwio_f32(
+            &x,
+            x_shape,
+            &w,
+            w_shape,
+            &dy,
+            dy_shape,
+            1,
+            1,
+            ConvPadding::Valid,
+        );
+
+        // Check shapes
+        assert_eq!(dx.len(), 9);
+        assert_eq!(dw.len(), 4);
+
+        // dw[kh,kw,c,o] = sum over (n,oh,ow) of dy[n,oh,ow,o] * x[n, oh*s+kh, ow*s+kw, c]
+        // For all dy = 1:
+        // dw[0,0,0,0] = x[0,0,0] + x[0,0,1] + x[0,1,0] + x[0,1,1] = 1+2+4+5 = 12
+        // dw[0,1,0,0] = x[0,0,1] + x[0,0,2] + x[0,1,1] + x[0,1,2] = 2+3+5+6 = 16
+        // dw[1,0,0,0] = x[0,1,0] + x[0,1,1] + x[0,2,0] + x[0,2,1] = 4+5+7+8 = 24
+        // dw[1,1,0,0] = x[0,1,1] + x[0,1,2] + x[0,2,1] + x[0,2,2] = 5+6+8+9 = 28
+        assert_eq!(dw[0], 12.0);
+        assert_eq!(dw[1], 16.0);
+        assert_eq!(dw[2], 24.0);
+        assert_eq!(dw[3], 28.0);
+    }
+
+    #[test]
+    fn test_conv2d_vjp_same_stride2() {
+        // Test SAME padding with stride 2
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
+        let x_shape = [1, 3, 4, 1];
+        let w = vec![1.0, 1.0, 1.0, 1.0];
+        let w_shape = [2, 2, 1, 1];
+        // SAME padding with stride 2: output shape is ceil(3/2) x ceil(4/2) = 2x2
+        let dy = vec![1.0, 1.0, 1.0, 1.0];
+        let dy_shape = [1, 2, 2, 1];
+
+        let (dx, dw) = conv2d_vjp_nhwc_hwio_f32(
+            &x,
+            x_shape,
+            &w,
+            w_shape,
+            &dy,
+            dy_shape,
+            2,
+            2,
+            ConvPadding::Same,
+        );
+
+        // Check shapes
+        assert_eq!(dx.len(), 12);
+        assert_eq!(dw.len(), 4);
+
+        // Just verify it runs without panicking and produces finite values
+        assert!(dx.iter().all(|v| v.is_finite()));
+        assert!(dw.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn test_output_shape_valid() {
+        let x_shape = [2, 5, 6, 3];
+        let w_shape = [3, 3, 3, 8];
+        let out = conv2d_output_shape(x_shape, w_shape, 1, 1, ConvPadding::Valid);
+        assert_eq!(out, [2, 3, 4, 8]);
+    }
+
+    #[test]
+    fn test_output_shape_same() {
+        let x_shape = [2, 5, 6, 3];
+        let w_shape = [3, 3, 3, 8];
+        let out = conv2d_output_shape(x_shape, w_shape, 2, 2, ConvPadding::Same);
+        assert_eq!(out, [2, 3, 3, 8]);
+    }
+}

--- a/src/eval/ir_interp.rs
+++ b/src/eval/ir_interp.rs
@@ -152,6 +152,24 @@ pub fn eval_ir(ir: &IRModule) -> Value {
                 vals.insert(*dst, value.clone());
                 last = value;
             }
+            Instr::Conv2dGradInput {
+                dst, input_shape, ..
+            } => {
+                // Create a tensor with the input shape
+                let shape: Vec<ShapeDim> = input_shape.iter().map(|d| ShapeDim::Known(*d)).collect();
+                let v = Value::Tensor(TensorVal::new(crate::types::DType::F32, shape, None));
+                vals.insert(*dst, v.clone());
+                last = v;
+            }
+            Instr::Conv2dGradFilter {
+                dst, filter_shape, ..
+            } => {
+                // Create a tensor with the filter shape
+                let shape: Vec<ShapeDim> = filter_shape.iter().map(|d| ShapeDim::Known(*d)).collect();
+                let v = Value::Tensor(TensorVal::new(crate::types::DType::F32, shape, None));
+                vals.insert(*dst, v.clone());
+                last = v;
+            }
             Instr::Index { dst, src, .. } => {
                 let value = vals.get(src).cloned().unwrap_or(Value::Int(0));
                 vals.insert(*dst, value.clone());

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -39,6 +39,7 @@ use crate::exec;
 use value::Buffer;
 
 pub mod autodiff;
+pub mod conv2d_grad;
 pub mod ir_interp;
 pub mod lower;
 #[cfg(feature = "mlir-build")]
@@ -761,7 +762,8 @@ pub fn eval_grad_map(
         .filter(|(name, _)| wrt.contains(name))
         .collect();
 
-    let mut grads = crate::eval::autodiff::backprop_to_vars(loss_id, &tape, &requested);
+    let mut grads =
+        crate::eval::autodiff::backprop_to_vars_with_tenv(loss_id, &tape, &requested, &tenv);
     for name in wrt {
         if !grads.contains_key(name) {
             if let Some(entry) = tenv.get(name) {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -108,6 +108,28 @@ pub enum Instr {
         stride_w: usize,
         padding: ConvPadding,
     },
+    /// Backward pass for Conv2d: compute gradient with respect to input.
+    /// Given upstream gradient dy (NHWC) and filter (HWIO), computes dx (NHWC).
+    Conv2dGradInput {
+        dst: ValueId,
+        dy: ValueId,          // upstream gradient, NHWC
+        filter: ValueId,      // HWIO
+        input_shape: [usize; 4], // N, H, W, C - needed to allocate dst
+        stride_h: usize,
+        stride_w: usize,
+        padding: ConvPadding,
+    },
+    /// Backward pass for Conv2d: compute gradient with respect to filter.
+    /// Given upstream gradient dy (NHWC) and input (NHWC), computes dw (HWIO).
+    Conv2dGradFilter {
+        dst: ValueId,
+        input: ValueId,       // NHWC
+        dy: ValueId,          // upstream gradient, NHWC
+        filter_shape: [usize; 4], // KH, KW, C, O - needed to allocate dst
+        stride_h: usize,
+        stride_w: usize,
+        padding: ConvPadding,
+    },
     Index {
         dst: ValueId,
         src: ValueId,
@@ -141,6 +163,8 @@ pub(crate) fn instruction_dst(instr: &Instr) -> Option<ValueId> {
         | Instr::Dot { dst, .. }
         | Instr::MatMul { dst, .. }
         | Instr::Conv2d { dst, .. }
+        | Instr::Conv2dGradInput { dst, .. }
+        | Instr::Conv2dGradFilter { dst, .. }
         | Instr::Index { dst, .. }
         | Instr::Slice { dst, .. }
         | Instr::Gather { dst, .. } => Some(*dst),

--- a/src/ir/print.rs
+++ b/src/ir/print.rs
@@ -172,6 +172,50 @@ fn format_instr(instr: &Instr, out: &mut String) {
             )
             .unwrap();
         }
+        Instr::Conv2dGradInput {
+            dst,
+            dy,
+            filter,
+            input_shape,
+            stride_h,
+            stride_w,
+            padding,
+        } => {
+            writeln!(
+                out,
+                "  {} = conv2d_grad_input {} {} input_shape={:?} strides=({}, {}) padding={}",
+                value_name(*dst),
+                value_name(*dy),
+                value_name(*filter),
+                input_shape,
+                stride_h,
+                stride_w,
+                format_padding(*padding)
+            )
+            .unwrap();
+        }
+        Instr::Conv2dGradFilter {
+            dst,
+            input,
+            dy,
+            filter_shape,
+            stride_h,
+            stride_w,
+            padding,
+        } => {
+            writeln!(
+                out,
+                "  {} = conv2d_grad_filter {} {} filter_shape={:?} strides=({}, {}) padding={}",
+                value_name(*dst),
+                value_name(*input),
+                value_name(*dy),
+                filter_shape,
+                stride_h,
+                stride_w,
+                format_padding(*padding)
+            )
+            .unwrap();
+        }
         Instr::Index { dst, src, indices } => {
             writeln!(
                 out,

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -131,6 +131,38 @@ fn validate_operands(
                 });
             }
         }
+        Instr::Conv2dGradInput {
+            dy,
+            filter,
+            stride_h,
+            stride_w,
+            ..
+        } => {
+            check_defined(*dy)?;
+            check_defined(*filter)?;
+            if *stride_h == 0 || *stride_w == 0 {
+                return Err(IrVerifyError::InvalidOperand {
+                    instr_index,
+                    message: "conv2d_grad_input strides must be positive".to_string(),
+                });
+            }
+        }
+        Instr::Conv2dGradFilter {
+            input,
+            dy,
+            stride_h,
+            stride_w,
+            ..
+        } => {
+            check_defined(*input)?;
+            check_defined(*dy)?;
+            if *stride_h == 0 || *stride_w == 0 {
+                return Err(IrVerifyError::InvalidOperand {
+                    instr_index,
+                    message: "conv2d_grad_filter strides must be positive".to_string(),
+                });
+            }
+        }
         Instr::Gather {
             src, indices, axis, ..
         } => {

--- a/src/opt/ir_canonical.rs
+++ b/src/opt/ir_canonical.rs
@@ -142,6 +142,8 @@ fn instruction_operands(instr: &Instr) -> Vec<ValueId> {
         | Instr::Slice { src, .. } => vec![*src],
         Instr::Dot { a, b, .. } | Instr::MatMul { a, b, .. } => vec![*a, *b],
         Instr::Conv2d { input, filter, .. } => vec![*input, *filter],
+        Instr::Conv2dGradInput { dy, filter, .. } => vec![*dy, *filter],
+        Instr::Conv2dGradFilter { input, dy, .. } => vec![*input, *dy],
         Instr::Gather { src, indices, .. } => vec![*src, *indices],
         Instr::Output(id) => vec![*id],
     }

--- a/tests/conv2d_grad.rs
+++ b/tests/conv2d_grad.rs
@@ -1,0 +1,409 @@
+// Copyright 2025 STARGA Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Part of the MIND project (Machine Intelligence Native Design).
+
+//! Tests for Conv2d gradient computation (VJP).
+//!
+//! These tests verify correctness of the analytical gradients computed by
+//! conv2d_vjp_nhwc_hwio_f32 against numerical finite-difference approximations.
+
+use mind::eval::conv2d_grad::{conv2d_vjp_nhwc_hwio_f32, conv2d_output_shape};
+use mind::types::ConvPadding;
+
+/// Compute forward Conv2d: y = conv2d(x, w)
+/// Input x: NHWC [N, H, W, C]
+/// Filter w: HWIO [KH, KW, C, O]
+/// Output y: NHWC [N, OH, OW, O]
+fn conv2d_forward(
+    x: &[f32],
+    x_shape: [usize; 4],
+    w: &[f32],
+    w_shape: [usize; 4],
+    stride_h: usize,
+    stride_w: usize,
+    padding: ConvPadding,
+) -> (Vec<f32>, [usize; 4]) {
+    let out_shape = conv2d_output_shape(x_shape, w_shape, stride_h, stride_w, padding);
+    let [n, oh, ow, o] = out_shape;
+    let [_n, h, ww, c] = x_shape;
+    let [kh, kw, _c, _o] = w_shape;
+
+    let (pad_top, pad_left) = compute_padding(h, ww, kh, kw, stride_h, stride_w, padding);
+
+    let mut y = vec![0.0f32; n * oh * ow * o];
+
+    for ni in 0..n {
+        for ohi in 0..oh {
+            for owi in 0..ow {
+                for oi in 0..o {
+                    let mut sum = 0.0f32;
+                    for khi in 0..kh {
+                        let ih = (ohi * stride_h + khi) as isize - pad_top as isize;
+                        if ih < 0 || ih >= h as isize {
+                            continue;
+                        }
+                        for kwi in 0..kw {
+                            let iw = (owi * stride_w + kwi) as isize - pad_left as isize;
+                            if iw < 0 || iw >= ww as isize {
+                                continue;
+                            }
+                            for ci in 0..c {
+                                let x_idx = idx_nhwc(ni, ih as usize, iw as usize, ci, h, ww, c);
+                                let w_idx = idx_hwio(khi, kwi, ci, oi, kw, c, o);
+                                sum += x[x_idx] * w[w_idx];
+                            }
+                        }
+                    }
+                    let y_idx = idx_nhwc(ni, ohi, owi, oi, oh, ow, o);
+                    y[y_idx] = sum;
+                }
+            }
+        }
+    }
+
+    (y, out_shape)
+}
+
+fn compute_padding(
+    h: usize,
+    w: usize,
+    kh: usize,
+    kw: usize,
+    sh: usize,
+    sw: usize,
+    padding: ConvPadding,
+) -> (usize, usize) {
+    match padding {
+        ConvPadding::Valid => (0, 0),
+        ConvPadding::Same => {
+            let oh = (h + sh - 1) / sh;
+            let ow = (w + sw - 1) / sw;
+            let pad_h = (oh.saturating_sub(1)) * sh + kh;
+            let pad_h = pad_h.saturating_sub(h);
+            let pad_w = (ow.saturating_sub(1)) * sw + kw;
+            let pad_w = pad_w.saturating_sub(w);
+            (pad_h / 2, pad_w / 2)
+        }
+    }
+}
+
+#[inline]
+fn idx_nhwc(n: usize, h: usize, w: usize, c: usize, hh: usize, ww: usize, cc: usize) -> usize {
+    (((n * hh + h) * ww + w) * cc) + c
+}
+
+#[inline]
+fn idx_hwio(kh: usize, kw: usize, c: usize, o: usize, kww: usize, cc: usize, oo: usize) -> usize {
+    (((kh * kww + kw) * cc + c) * oo) + o
+}
+
+/// Compute loss = sum(conv2d(x, w) * r) where r is a fixed upstream tensor.
+fn compute_loss(
+    x: &[f32],
+    x_shape: [usize; 4],
+    w: &[f32],
+    w_shape: [usize; 4],
+    r: &[f32],
+    stride_h: usize,
+    stride_w: usize,
+    padding: ConvPadding,
+) -> f32 {
+    let (y, _) = conv2d_forward(x, x_shape, w, w_shape, stride_h, stride_w, padding);
+    y.iter().zip(r.iter()).map(|(a, b)| a * b).sum()
+}
+
+/// Compute numerical gradient using finite differences.
+fn numerical_gradient_x(
+    x: &[f32],
+    x_shape: [usize; 4],
+    w: &[f32],
+    w_shape: [usize; 4],
+    r: &[f32],
+    stride_h: usize,
+    stride_w: usize,
+    padding: ConvPadding,
+    eps: f32,
+) -> Vec<f32> {
+    let mut grad = vec![0.0f32; x.len()];
+    let mut x_plus = x.to_vec();
+    let mut x_minus = x.to_vec();
+
+    for i in 0..x.len() {
+        x_plus[i] = x[i] + eps;
+        x_minus[i] = x[i] - eps;
+        let loss_plus = compute_loss(&x_plus, x_shape, w, w_shape, r, stride_h, stride_w, padding);
+        let loss_minus =
+            compute_loss(&x_minus, x_shape, w, w_shape, r, stride_h, stride_w, padding);
+        grad[i] = (loss_plus - loss_minus) / (2.0 * eps);
+        x_plus[i] = x[i];
+        x_minus[i] = x[i];
+    }
+
+    grad
+}
+
+fn numerical_gradient_w(
+    x: &[f32],
+    x_shape: [usize; 4],
+    w: &[f32],
+    w_shape: [usize; 4],
+    r: &[f32],
+    stride_h: usize,
+    stride_w: usize,
+    padding: ConvPadding,
+    eps: f32,
+) -> Vec<f32> {
+    let mut grad = vec![0.0f32; w.len()];
+    let mut w_plus = w.to_vec();
+    let mut w_minus = w.to_vec();
+
+    for i in 0..w.len() {
+        w_plus[i] = w[i] + eps;
+        w_minus[i] = w[i] - eps;
+        let loss_plus = compute_loss(x, x_shape, &w_plus, w_shape, r, stride_h, stride_w, padding);
+        let loss_minus =
+            compute_loss(x, x_shape, &w_minus, w_shape, r, stride_h, stride_w, padding);
+        grad[i] = (loss_plus - loss_minus) / (2.0 * eps);
+        w_plus[i] = w[i];
+        w_minus[i] = w[i];
+    }
+
+    grad
+}
+
+fn check_gradient_match(analytic: &[f32], numerical: &[f32], rtol: f32, atol: f32) -> bool {
+    if analytic.len() != numerical.len() {
+        return false;
+    }
+
+    for (i, (a, n)) in analytic.iter().zip(numerical.iter()).enumerate() {
+        let diff = (a - n).abs();
+        let tol = atol + rtol * n.abs().max(a.abs());
+        if diff > tol {
+            eprintln!(
+                "Gradient mismatch at index {}: analytic={}, numerical={}, diff={}, tol={}",
+                i, a, n, diff, tol
+            );
+            return false;
+        }
+    }
+
+    true
+}
+
+#[test]
+fn test_conv2d_grad_valid_stride1() {
+    // Test case 1: padding=Valid, stride=1
+    let x_shape = [1, 5, 6, 2];
+    let w_shape = [3, 3, 2, 3];
+
+    let [n, h, ww, c] = x_shape;
+    let [kh, kw, _c, o] = w_shape;
+
+    // Initialize with deterministic values
+    let mut x: Vec<f32> = (0..(n * h * ww * c))
+        .map(|i| ((i % 7) as f32 - 3.0) * 0.1)
+        .collect();
+    let mut w: Vec<f32> = (0..(kh * kw * c * o))
+        .map(|i| ((i % 11) as f32 - 5.0) * 0.1)
+        .collect();
+
+    // Normalize to avoid numerical issues
+    let x_norm: f32 = x.iter().map(|v| v * v).sum::<f32>().sqrt();
+    let w_norm: f32 = w.iter().map(|v| v * v).sum::<f32>().sqrt();
+    for v in &mut x {
+        *v /= x_norm.max(1.0);
+    }
+    for v in &mut w {
+        *v /= w_norm.max(1.0);
+    }
+
+    let out_shape = conv2d_output_shape(x_shape, w_shape, 1, 1, ConvPadding::Valid);
+    let [n_o, oh, ow, o_o] = out_shape;
+
+    // Upstream gradient (random but deterministic)
+    let r: Vec<f32> = (0..(n_o * oh * ow * o_o))
+        .map(|i| ((i % 13) as f32 - 6.0) * 0.1)
+        .collect();
+
+    // Compute analytical gradients
+    let (dx_analytic, dw_analytic) = conv2d_vjp_nhwc_hwio_f32(
+        &x,
+        x_shape,
+        &w,
+        w_shape,
+        &r,
+        out_shape,
+        1,
+        1,
+        ConvPadding::Valid,
+    );
+
+    // Compute numerical gradients
+    let eps = 1e-4;
+    let dx_numerical =
+        numerical_gradient_x(&x, x_shape, &w, w_shape, &r, 1, 1, ConvPadding::Valid, eps);
+    let dw_numerical =
+        numerical_gradient_w(&x, x_shape, &w, w_shape, &r, 1, 1, ConvPadding::Valid, eps);
+
+    // Check match with tolerance
+    let rtol = 1e-3;
+    let atol = 1e-4;
+
+    assert!(
+        check_gradient_match(&dx_analytic, &dx_numerical, rtol, atol),
+        "dx gradient mismatch for padding=Valid, stride=1"
+    );
+    assert!(
+        check_gradient_match(&dw_analytic, &dw_numerical, rtol, atol),
+        "dw gradient mismatch for padding=Valid, stride=1"
+    );
+}
+
+#[test]
+fn test_conv2d_grad_same_stride2() {
+    // Test case 2: padding=Same, stride=2
+    let x_shape = [1, 5, 6, 2];
+    let w_shape = [3, 3, 2, 3];
+
+    let [n, h, ww, c] = x_shape;
+    let [kh, kw, _c, o] = w_shape;
+
+    // Initialize with deterministic values
+    let mut x: Vec<f32> = (0..(n * h * ww * c))
+        .map(|i| ((i % 7) as f32 - 3.0) * 0.1)
+        .collect();
+    let mut w: Vec<f32> = (0..(kh * kw * c * o))
+        .map(|i| ((i % 11) as f32 - 5.0) * 0.1)
+        .collect();
+
+    // Normalize
+    let x_norm: f32 = x.iter().map(|v| v * v).sum::<f32>().sqrt();
+    let w_norm: f32 = w.iter().map(|v| v * v).sum::<f32>().sqrt();
+    for v in &mut x {
+        *v /= x_norm.max(1.0);
+    }
+    for v in &mut w {
+        *v /= w_norm.max(1.0);
+    }
+
+    let out_shape = conv2d_output_shape(x_shape, w_shape, 2, 2, ConvPadding::Same);
+    let [n_o, oh, ow, o_o] = out_shape;
+
+    // Upstream gradient
+    let r: Vec<f32> = (0..(n_o * oh * ow * o_o))
+        .map(|i| ((i % 13) as f32 - 6.0) * 0.1)
+        .collect();
+
+    // Compute analytical gradients
+    let (dx_analytic, dw_analytic) = conv2d_vjp_nhwc_hwio_f32(
+        &x,
+        x_shape,
+        &w,
+        w_shape,
+        &r,
+        out_shape,
+        2,
+        2,
+        ConvPadding::Same,
+    );
+
+    // Compute numerical gradients
+    let eps = 1e-4;
+    let dx_numerical =
+        numerical_gradient_x(&x, x_shape, &w, w_shape, &r, 2, 2, ConvPadding::Same, eps);
+    let dw_numerical =
+        numerical_gradient_w(&x, x_shape, &w, w_shape, &r, 2, 2, ConvPadding::Same, eps);
+
+    // Check match with tolerance
+    let rtol = 1e-3;
+    let atol = 1e-4;
+
+    assert!(
+        check_gradient_match(&dx_analytic, &dx_numerical, rtol, atol),
+        "dx gradient mismatch for padding=Same, stride=2"
+    );
+    assert!(
+        check_gradient_match(&dw_analytic, &dw_numerical, rtol, atol),
+        "dw gradient mismatch for padding=Same, stride=2"
+    );
+}
+
+#[test]
+fn test_conv2d_output_shape_valid() {
+    let x_shape = [2, 5, 6, 3];
+    let w_shape = [3, 3, 3, 8];
+    let out = conv2d_output_shape(x_shape, w_shape, 1, 1, ConvPadding::Valid);
+    assert_eq!(out, [2, 3, 4, 8]);
+}
+
+#[test]
+fn test_conv2d_output_shape_same() {
+    let x_shape = [2, 5, 6, 3];
+    let w_shape = [3, 3, 3, 8];
+    let out = conv2d_output_shape(x_shape, w_shape, 2, 2, ConvPadding::Same);
+    assert_eq!(out, [2, 3, 3, 8]);
+}
+
+#[test]
+fn test_conv2d_grad_small_exact() {
+    // Small exact test case to verify basic correctness
+    // 1x2x2x1 input, 2x2x1x1 filter, stride 1, valid padding
+    // Output: 1x1x1x1
+
+    let x = vec![1.0, 2.0, 3.0, 4.0];
+    let x_shape = [1, 2, 2, 1];
+
+    let w = vec![1.0, 0.0, 0.0, 1.0]; // Identity-like filter
+    let w_shape = [2, 2, 1, 1];
+
+    // Forward: y = 1*1 + 2*0 + 3*0 + 4*1 = 5
+    let (y, y_shape) = conv2d_forward(&x, x_shape, &w, w_shape, 1, 1, ConvPadding::Valid);
+    assert_eq!(y_shape, [1, 1, 1, 1]);
+    assert!((y[0] - 5.0).abs() < 1e-6);
+
+    // dy = 1 (upstream gradient)
+    let dy = vec![1.0];
+
+    let (dx, dw) = conv2d_vjp_nhwc_hwio_f32(
+        &x,
+        x_shape,
+        &w,
+        w_shape,
+        &dy,
+        y_shape,
+        1,
+        1,
+        ConvPadding::Valid,
+    );
+
+    // dx = dy * w (scatter)
+    // dx[0,0,0,0] = dy * w[0,0,0,0] = 1 * 1 = 1
+    // dx[0,0,1,0] = dy * w[0,1,0,0] = 1 * 0 = 0
+    // dx[0,1,0,0] = dy * w[1,0,0,0] = 1 * 0 = 0
+    // dx[0,1,1,0] = dy * w[1,1,0,0] = 1 * 1 = 1
+    assert!((dx[0] - 1.0).abs() < 1e-6, "dx[0] = {}", dx[0]);
+    assert!((dx[1] - 0.0).abs() < 1e-6, "dx[1] = {}", dx[1]);
+    assert!((dx[2] - 0.0).abs() < 1e-6, "dx[2] = {}", dx[2]);
+    assert!((dx[3] - 1.0).abs() < 1e-6, "dx[3] = {}", dx[3]);
+
+    // dw = dy * x (gather)
+    // dw[0,0,0,0] = dy * x[0,0,0,0] = 1 * 1 = 1
+    // dw[0,1,0,0] = dy * x[0,0,1,0] = 1 * 2 = 2
+    // dw[1,0,0,0] = dy * x[0,1,0,0] = 1 * 3 = 3
+    // dw[1,1,0,0] = dy * x[0,1,1,0] = 1 * 4 = 4
+    assert!((dw[0] - 1.0).abs() < 1e-6, "dw[0] = {}", dw[0]);
+    assert!((dw[1] - 2.0).abs() < 1e-6, "dw[1] = {}", dw[1]);
+    assert!((dw[2] - 3.0).abs() < 1e-6, "dw[2] = {}", dw[2]);
+    assert!((dw[3] - 4.0).abs() < 1e-6, "dw[3] = {}", dw[3]);
+}


### PR DESCRIPTION
This PR implements complete Conv2d gradient computation across the eval-based autodiff, IR ops, and MLIR lowering layers.

Phase 1 - Eval-based autodiff (src/eval/autodiff.rs):
- Replace placeholder gradient computation with real gradients when tensor buffer data is available (cpu-buffers feature)
- Add backprop_to_vars_with_tenv() for tensor environment access
- Falls back to shape-only gradients when data is unavailable

Phase 2 - Reference VJP implementation (src/eval/conv2d_grad.rs):
- Add conv2d_vjp_nhwc_hwio_f32() for NHWC input / HWIO filter layout
- Correctness-first O(N*OH*OW*KH*KW*C*O) implementation
- Supports both Valid and Same padding modes
- Helper function conv2d_output_shape() for shape computation

Phase 3 - IR ops (src/ir/mod.rs):
- Add Conv2dGradInput: computes dx from dy and filter
- Add Conv2dGradFilter: computes dw from input and dy
- Update print.rs, verify.rs, ir_interp.rs, ir_canonical.rs

Phase 4 - MLIR lowering (src/eval/mlir_export.rs):
- Add emit_conv2d_grad_input() and emit_conv2d_grad_filter()
- Allocate zero-initialized output tensors with correct shapes
- Record operation metadata for runtime/specialized lowering

Tests (tests/conv2d_grad.rs):
- Finite-difference gradient checks for padding=Valid, stride=1
- Finite-difference gradient checks for padding=Same, stride=2
- Small exact test case with hand-computed expected values
- Output shape computation tests

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
