### PR TITLE
fix(autodiff/conv2d): address review feedback

### DIFF
--- a/src/eval/mlir_export.rs
+++ b/src/eval/mlir_export.rs
@@ -957,8 +957,8 @@ fn element_count(shape: &[ShapeDim], axes: &[usize]) -> usize {
 
 /// Emit MLIR for Conv2dGradInput (backward pass w.r.t. input).
 ///
-/// Uses linalg.generic with explicit index math to compute dx from dy and filter.
-/// This is a correctness-first implementation using scf loops.
+/// Emits a stub that allocates a zero-filled output tensor of the correct shape.
+/// Full computation is deferred to runtime or a specialized backend lowering pass.
 #[allow(clippy::too_many_arguments)]
 fn emit_conv2d_grad_input(
     emitter: &mut MlirEmitter,
@@ -1010,8 +1010,8 @@ fn emit_conv2d_grad_input(
 
 /// Emit MLIR for Conv2dGradFilter (backward pass w.r.t. filter).
 ///
-/// Uses linalg.generic to accumulate gradients into dw from dy and input.
-/// This is a correctness-first implementation.
+/// Emits a stub that allocates a zero-filled output tensor of the correct shape.
+/// Full computation is deferred to runtime or a specialized backend lowering pass.
 #[allow(clippy::too_many_arguments)]
 fn emit_conv2d_grad_filter(
     emitter: &mut MlirEmitter,


### PR DESCRIPTION
- Fix misleading MLIR docstrings (stubs, not full implementation)
- Fix edge case in conv2d_output_shape for Valid when kernel > input
- Remove redundant index computation in VJP loop

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
