### PR TITLE
test(autodiff/conv2d): add test for kernel > input edge case

### DIFF
--- a/src/eval/conv2d_grad.rs
+++ b/src/eval/conv2d_grad.rs
@@ -274,4 +274,13 @@ mod tests {
         let out = conv2d_output_shape(x_shape, w_shape, 2, 2, ConvPadding::Same);
         assert_eq!(out, [2, 3, 3, 8]);
     }
+
+    #[test]
+    fn test_output_shape_kernel_larger_than_input() {
+        // Kernel (3x3) > Input (2x2) with Valid padding should produce 0-sized output
+        let x_shape = [1, 2, 2, 1];
+        let w_shape = [3, 3, 1, 1];
+        let out = conv2d_output_shape(x_shape, w_shape, 1, 1, ConvPadding::Valid);
+        assert_eq!(out, [1, 0, 0, 1], "kernel > input should produce 0-sized output");
+    }
 }


### PR DESCRIPTION
Verifies that conv2d_output_shape returns [N, 0, 0, O] when kernel dimensions exceed input dimensions with Valid padding.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
