### PR TITLE
chore(fmt): apply formatting fixes and remove unstable wrap_comments option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 max_width = 100
 use_small_heuristics = "Default"
-wrap_comments = true
 newline_style = "Unix"
 edition = "2021"

--- a/src/eval/autodiff.rs
+++ b/src/eval/autodiff.rs
@@ -1008,10 +1008,8 @@ pub fn backprop_to_vars_with_tenv(
     tenv: &HashMap<String, TensorEnvEntry>,
 ) -> BTreeMap<String, TensorVal> {
     // Create inverse mapping from NodeId to variable name for data lookup
-    let node_to_name: HashMap<NodeId, &str> = vars
-        .iter()
-        .map(|(name, id)| (*id, name.as_str()))
-        .collect();
+    let node_to_name: HashMap<NodeId, &str> =
+        vars.iter().map(|(name, id)| (*id, name.as_str())).collect();
     let mut adj: HashMap<NodeId, TensorVal> = HashMap::new();
     if let Some(loss_node) = tape.nodes.get(loss.0) {
         adj.insert(

--- a/src/eval/conv2d_grad.rs
+++ b/src/eval/conv2d_grad.rs
@@ -161,16 +161,8 @@ pub fn conv2d_output_shape(
     let (oh, ow) = match padding {
         ConvPadding::Valid => {
             // When kernel is larger than input, output is 0 (no valid positions)
-            let oh = if H >= KH {
-                (H - KH) / stride_h + 1
-            } else {
-                0
-            };
-            let ow = if W >= KW {
-                (W - KW) / stride_w + 1
-            } else {
-                0
-            };
+            let oh = if H >= KH { (H - KH) / stride_h + 1 } else { 0 };
+            let ow = if W >= KW { (W - KW) / stride_w + 1 } else { 0 };
             (oh, ow)
         }
         ConvPadding::Same => (ceil_div(H, stride_h), ceil_div(W, stride_w)),
@@ -230,7 +222,9 @@ mod tests {
     #[test]
     fn test_conv2d_vjp_same_stride2() {
         // Test SAME padding with stride 2
-        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
+        let x = vec![
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ];
         let x_shape = [1, 3, 4, 1];
         let w = vec![1.0, 1.0, 1.0, 1.0];
         let w_shape = [2, 2, 1, 1];
@@ -281,6 +275,10 @@ mod tests {
         let x_shape = [1, 2, 2, 1];
         let w_shape = [3, 3, 1, 1];
         let out = conv2d_output_shape(x_shape, w_shape, 1, 1, ConvPadding::Valid);
-        assert_eq!(out, [1, 0, 0, 1], "kernel > input should produce 0-sized output");
+        assert_eq!(
+            out,
+            [1, 0, 0, 1],
+            "kernel > input should produce 0-sized output"
+        );
     }
 }

--- a/src/eval/ir_interp.rs
+++ b/src/eval/ir_interp.rs
@@ -156,7 +156,8 @@ pub fn eval_ir(ir: &IRModule) -> Value {
                 dst, input_shape, ..
             } => {
                 // Create a tensor with the input shape
-                let shape: Vec<ShapeDim> = input_shape.iter().map(|d| ShapeDim::Known(*d)).collect();
+                let shape: Vec<ShapeDim> =
+                    input_shape.iter().map(|d| ShapeDim::Known(*d)).collect();
                 let v = Value::Tensor(TensorVal::new(crate::types::DType::F32, shape, None));
                 vals.insert(*dst, v.clone());
                 last = v;
@@ -165,7 +166,8 @@ pub fn eval_ir(ir: &IRModule) -> Value {
                 dst, filter_shape, ..
             } => {
                 // Create a tensor with the filter shape
-                let shape: Vec<ShapeDim> = filter_shape.iter().map(|d| ShapeDim::Known(*d)).collect();
+                let shape: Vec<ShapeDim> =
+                    filter_shape.iter().map(|d| ShapeDim::Known(*d)).collect();
                 let v = Value::Tensor(TensorVal::new(crate::types::DType::F32, shape, None));
                 vals.insert(*dst, v.clone());
                 last = v;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -907,10 +907,9 @@ fn apply_tensor_scalar(
         if let Some(buf) = tensor_buf.as_ref() {
             match (buf, &dtype) {
                 (Buffer::I32(values), DType::I32) => {
-                    if matches!(op, BinOp::Div) && !tensor_on_left
-                        && values.contains(&0) {
-                            return Err(EvalError::DivZero);
-                        }
+                    if matches!(op, BinOp::Div) && !tensor_on_left && values.contains(&0) {
+                        return Err(EvalError::DivZero);
+                    }
                     let scalar_i32 = scalar as i32;
                     let mut out = Vec::with_capacity(values.len());
                     for &v in values {
@@ -937,10 +936,9 @@ fn apply_tensor_scalar(
                     result.buf = Some(Buffer::I32(out));
                 }
                 (Buffer::F32(values), DType::F32) => {
-                    if matches!(op, BinOp::Div) && !tensor_on_left
-                        && values.contains(&0.0) {
-                            return Err(EvalError::DivZero);
-                        }
+                    if matches!(op, BinOp::Div) && !tensor_on_left && values.contains(&0.0) {
+                        return Err(EvalError::DivZero);
+                    }
                     let scalar_f32 = scalar as f32;
                     let mut out = Vec::with_capacity(values.len());
                     for &v in values {

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -634,18 +634,17 @@ pub(crate) fn relu_tensor(mut tensor: TensorVal, mode: ExecMode) -> Result<Tenso
             materialize_filled(&mut tensor);
             #[cfg(feature = "cpu-exec")]
             {
-                if tensor.dtype == DType::F32
-                    && tensor.as_f32().is_some() {
-                        match crate::exec::cpu::exec_relu(&tensor) {
-                            Ok(out) => return Ok(out),
-                            Err(err) => {
-                                let mapped = crate::eval::exec_error_to_eval(err);
-                                if matches!(mapped, EvalError::DivZero) {
-                                    return Err(mapped);
-                                }
+                if tensor.dtype == DType::F32 && tensor.as_f32().is_some() {
+                    match crate::exec::cpu::exec_relu(&tensor) {
+                        Ok(out) => return Ok(out),
+                        Err(err) => {
+                            let mapped = crate::eval::exec_error_to_eval(err);
+                            if matches!(mapped, EvalError::DivZero) {
+                                return Err(mapped);
                             }
                         }
                     }
+                }
             }
         }
     }
@@ -781,15 +780,18 @@ pub(crate) fn conv2d_tensor(
             materialize_filled(&mut w);
             #[cfg(all(feature = "cpu-exec", feature = "cpu-conv"))]
             {
-                if x.dtype == DType::F32 && w.dtype == DType::F32
-                    && x.as_f32().is_some() && w.as_f32().is_some() {
-                        match crate::exec::conv::exec_conv2d(&x, &w, stride_h, stride_w, padding) {
-                            Ok(t) => return Ok(t),
-                            Err(err) => {
-                                return Err(crate::eval::exec_error_to_eval(err));
-                            }
+                if x.dtype == DType::F32
+                    && w.dtype == DType::F32
+                    && x.as_f32().is_some()
+                    && w.as_f32().is_some()
+                {
+                    match crate::exec::conv::exec_conv2d(&x, &w, stride_h, stride_w, padding) {
+                        Ok(t) => return Ok(t),
+                        Err(err) => {
+                            return Err(crate::eval::exec_error_to_eval(err));
                         }
                     }
+                }
             }
             #[cfg(all(feature = "cpu-exec", not(feature = "cpu-conv")))]
             {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -112,8 +112,8 @@ pub enum Instr {
     /// Given upstream gradient dy (NHWC) and filter (HWIO), computes dx (NHWC).
     Conv2dGradInput {
         dst: ValueId,
-        dy: ValueId,          // upstream gradient, NHWC
-        filter: ValueId,      // HWIO
+        dy: ValueId,             // upstream gradient, NHWC
+        filter: ValueId,         // HWIO
         input_shape: [usize; 4], // N, H, W, C - needed to allocate dst
         stride_h: usize,
         stride_w: usize,
@@ -123,8 +123,8 @@ pub enum Instr {
     /// Given upstream gradient dy (NHWC) and input (NHWC), computes dw (HWIO).
     Conv2dGradFilter {
         dst: ValueId,
-        input: ValueId,       // NHWC
-        dy: ValueId,          // upstream gradient, NHWC
+        input: ValueId,           // NHWC
+        dy: ValueId,              // upstream gradient, NHWC
         filter_shape: [usize; 4], // KH, KW, C, O - needed to allocate dst
         stride_h: usize,
         stride_w: usize,

--- a/tests/conv2d_exec.rs
+++ b/tests/conv2d_exec.rs
@@ -43,8 +43,8 @@ fn conv2d_valid_runs() {
     // In open-core build, conv2d stubs return Unsupported. With proprietary
     // runtime, the operation executes and produces output shape (1,2,2,1).
     let has_expected_shape = stdout.contains("(1,2,2,1)");
-    let has_unsupported_error = stderr.contains("proprietary MIND runtime")
-        || stdout.contains("proprietary MIND runtime");
+    let has_unsupported_error =
+        stderr.contains("proprietary MIND runtime") || stdout.contains("proprietary MIND runtime");
 
     assert!(
         has_expected_shape || has_unsupported_error,

--- a/tests/conv2d_grad.rs
+++ b/tests/conv2d_grad.rs
@@ -17,7 +17,7 @@
 //! These tests verify correctness of the analytical gradients computed by
 //! conv2d_vjp_nhwc_hwio_f32 against numerical finite-difference approximations.
 
-use mind::eval::conv2d_grad::{conv2d_vjp_nhwc_hwio_f32, conv2d_output_shape};
+use mind::eval::conv2d_grad::{conv2d_output_shape, conv2d_vjp_nhwc_hwio_f32};
 use mind::types::ConvPadding;
 
 /// Compute forward Conv2d: y = conv2d(x, w)
@@ -142,8 +142,9 @@ fn numerical_gradient_x(
         x_plus[i] = x[i] + eps;
         x_minus[i] = x[i] - eps;
         let loss_plus = compute_loss(&x_plus, x_shape, w, w_shape, r, stride_h, stride_w, padding);
-        let loss_minus =
-            compute_loss(&x_minus, x_shape, w, w_shape, r, stride_h, stride_w, padding);
+        let loss_minus = compute_loss(
+            &x_minus, x_shape, w, w_shape, r, stride_h, stride_w, padding,
+        );
         grad[i] = (loss_plus - loss_minus) / (2.0 * eps);
         x_plus[i] = x[i];
         x_minus[i] = x[i];
@@ -171,8 +172,9 @@ fn numerical_gradient_w(
         w_plus[i] = w[i] + eps;
         w_minus[i] = w[i] - eps;
         let loss_plus = compute_loss(x, x_shape, &w_plus, w_shape, r, stride_h, stride_w, padding);
-        let loss_minus =
-            compute_loss(x, x_shape, &w_minus, w_shape, r, stride_h, stride_w, padding);
+        let loss_minus = compute_loss(
+            x, x_shape, &w_minus, w_shape, r, stride_h, stride_w, padding,
+        );
         grad[i] = (loss_plus - loss_minus) / (2.0 * eps);
         w_plus[i] = w[i];
         w_minus[i] = w[i];


### PR DESCRIPTION
## Summary
- Applied `cargo fmt --all` to standardize formatting across the repository
- Removed unstable `wrap_comments = true` from `rustfmt.toml` to avoid warnings on stable Rust
- Ensured the repository is clean and aligned with `cargo fmt` defaults

## Testing
- `cargo fmt --all -- --check`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694751e0bdb4832195bf8de741a358fa)