### PR TITLE
Refactor conv2d VJP parameters and use div_ceil

### DIFF
--- a/src/eval/autodiff.rs
+++ b/src/eval/autodiff.rs
@@ -1552,9 +1552,16 @@ fn try_compute_conv2d_grad(
     };
 
     // Compute gradients
-    let (dx_data, dw_data) = conv2d_grad::conv2d_vjp_nhwc_hwio_f32(
-        x_data, x_shape, w_data, w_shape, &dy_data, dy_shape, stride_h, stride_w, padding,
-    );
+    let (dx_data, dw_data) = conv2d_grad::conv2d_vjp_nhwc_hwio_f32(conv2d_grad::Conv2dVjpParams {
+        x: x_data,
+        x_shape,
+        w: w_data,
+        w_shape,
+        dy: &dy_data,
+        dy_shape,
+        stride: [stride_h, stride_w],
+        padding,
+    });
 
     // Build result TensorVals with buffer data
     let mut dx = TensorVal::new(DType::F32, x_info.shape.clone(), None);

--- a/tests/conv2d_grad.rs
+++ b/tests/conv2d_grad.rs
@@ -17,7 +17,7 @@
 //! These tests verify correctness of the analytical gradients computed by
 //! conv2d_vjp_nhwc_hwio_f32 against numerical finite-difference approximations.
 
-use mind::eval::conv2d_grad::{conv2d_output_shape, conv2d_vjp_nhwc_hwio_f32};
+use mind::eval::conv2d_grad::{conv2d_output_shape, conv2d_vjp_nhwc_hwio_f32, Conv2dVjpParams};
 use mind::types::ConvPadding;
 
 /// Compute forward Conv2d: y = conv2d(x, w)
@@ -239,17 +239,16 @@ fn test_conv2d_grad_valid_stride1() {
         .collect();
 
     // Compute analytical gradients
-    let (dx_analytic, dw_analytic) = conv2d_vjp_nhwc_hwio_f32(
-        &x,
+    let (dx_analytic, dw_analytic) = conv2d_vjp_nhwc_hwio_f32(Conv2dVjpParams {
+        x: &x,
         x_shape,
-        &w,
+        w: &w,
         w_shape,
-        &r,
-        out_shape,
-        1,
-        1,
-        ConvPadding::Valid,
-    );
+        dy: &r,
+        dy_shape: out_shape,
+        stride: [1, 1],
+        padding: ConvPadding::Valid,
+    });
 
     // Compute numerical gradients
     let eps = 1e-4;
@@ -308,17 +307,16 @@ fn test_conv2d_grad_same_stride2() {
         .collect();
 
     // Compute analytical gradients
-    let (dx_analytic, dw_analytic) = conv2d_vjp_nhwc_hwio_f32(
-        &x,
+    let (dx_analytic, dw_analytic) = conv2d_vjp_nhwc_hwio_f32(Conv2dVjpParams {
+        x: &x,
         x_shape,
-        &w,
+        w: &w,
         w_shape,
-        &r,
-        out_shape,
-        2,
-        2,
-        ConvPadding::Same,
-    );
+        dy: &r,
+        dy_shape: out_shape,
+        stride: [2, 2],
+        padding: ConvPadding::Same,
+    });
 
     // Compute numerical gradients
     let eps = 1e-4;
@@ -377,17 +375,16 @@ fn test_conv2d_grad_small_exact() {
     // dy = 1 (upstream gradient)
     let dy = vec![1.0];
 
-    let (dx, dw) = conv2d_vjp_nhwc_hwio_f32(
-        &x,
+    let (dx, dw) = conv2d_vjp_nhwc_hwio_f32(Conv2dVjpParams {
+        x: &x,
         x_shape,
-        &w,
+        w: &w,
         w_shape,
-        &dy,
-        y_shape,
-        1,
-        1,
-        ConvPadding::Valid,
-    );
+        dy: &dy,
+        dy_shape: y_shape,
+        stride: [1, 1],
+        padding: ConvPadding::Valid,
+    });
 
     // dx = dy * w (scatter)
     // dx[0,0,0,0] = dy * w[0,0,0,0] = 1 * 1 = 1


### PR DESCRIPTION
## Summary
- replace the manual ceiling-division helper with the standard `div_ceil` method
- add a `Conv2dVjpParams` struct to simplify the `conv2d_vjp_nhwc_hwio_f32` signature and update call sites

## Testing
- cargo clippy

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694755938a98832192bb982be0e07cde)