### PR TITLE
Fix cargo-deny configuration keys

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,13 +1,11 @@
 [advisories]
-version = 2
-vulnerabilities = "deny"
+vulnerability = "deny"
 unsound = "deny"
 unmaintained = "warn"
 yanked = "warn"
 ignore = ["RUSTSEC-2024-0445"]
 
 [licenses]
-version = 2
 unlicensed = "deny"
 copyleft = "warn"
 default = "allow"
@@ -21,6 +19,5 @@ allow = [
 ]
 
 [bans]
-version = 2
 multiple-versions = "warn"
 wildcards = "deny"


### PR DESCRIPTION
## Summary
- update cargo-deny configuration keys to align with current schema
- remove obsolete version entries and correct vulnerability key naming

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947589dc01c8321b94ec14e8c478d73)