### PR TITLE
Update cargo-deny configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,9 +1,14 @@
 [advisories]
+# Use explicit informational handling so lint levels remain forward compatible
+informational = "warn"
 vulnerability = "deny"
 unsound = "deny"
 unmaintained = "warn"
 yanked = "warn"
-ignore = ["RUSTSEC-2024-0445"]
+
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0445"
+reason = "Current cargo-deny release cannot parse CVSS v4 metadata; ignore until tooling updates"
 
 [licenses]
 unlicensed = "deny"


### PR DESCRIPTION
## Summary
- add explicit informational linting and clarify the ignore entry for RUSTSEC-2024-0445
- document the reason for ignoring the CVSS v4 advisory until tooling support catches up

## Testing
- not run (cargo-deny not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69475b546c1c8321a519fff1ff0d56df)