### PR TITLE
Remove deprecated cargo-deny informational key

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,4 @@
 [advisories]
-# Use explicit informational handling so lint levels remain forward compatible
-informational = "warn"
 vulnerability = "deny"
 unsound = "deny"
 unmaintained = "warn"


### PR DESCRIPTION
## Summary
- remove the deprecated `informational` advisory key from the cargo-deny configuration
- keep the existing advisory ignore entry for the CVSS v4 parsing issue

## Testing
- not run (config-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69475d113c3c8321b27e4745f5429b65)