### PR TITLE
Update cargo-deny configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,14 +1,19 @@
 [advisories]
+version = 2
 vulnerability = "deny"
 unsound = "deny"
 unmaintained = "warn"
 yanked = "warn"
+ignore = [
+  "RUSTSEC-2024-0445",
+]
 
 [[advisories.ignore]]
 id = "RUSTSEC-2024-0445"
 reason = "Current cargo-deny release cannot parse CVSS v4 metadata; ignore until tooling updates"
 
 [licenses]
+version = 2
 unlicensed = "deny"
 copyleft = "warn"
 default = "allow"
@@ -18,7 +23,7 @@ allow = [
   "BSD-3-Clause",
   "BSD-2-Clause",
   "ISC",
-  "Unicode-DFS-2016"
+  "Unicode-DFS-2016",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary
- align cargo-deny configuration with versioned schema and explicit ignore for the CVSS v4 advisory
- keep license policy definitions while adopting newer configuration formatting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69475e13abf88321b0094f6e972020b5)