### PR TITLE
Fix duplicate advisories ignore key

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,9 +4,6 @@ vulnerability = "deny"
 unsound = "deny"
 unmaintained = "warn"
 yanked = "warn"
-ignore = [
-  "RUSTSEC-2024-0445",
-]
 
 [[advisories.ignore]]
 id = "RUSTSEC-2024-0445"


### PR DESCRIPTION
## Summary
- remove the duplicate advisories ignore array from deny.toml
- keep the ignore entry with reason using the supported array-of-tables format

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69475fefc18883218553db6384a49b05)