### PR TITLE
Clarify cargo-deny ignore for RUSTSEC-2024-0445

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,10 +4,13 @@ vulnerability = "deny"
 unsound = "deny"
 unmaintained = "warn"
 yanked = "warn"
+ignore = [
+  "RUSTSEC-2024-0445",
+]
 
 [[advisories.ignore]]
 id = "RUSTSEC-2024-0445"
-reason = "Current cargo-deny release cannot parse CVSS v4 metadata; ignore until tooling updates"
+reason = "Ignoring due to CVSS v4 metadata parsing issue in current cargo-deny release."
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary
- add an explicit advisories.ignore list entry for RUSTSEC-2024-0445
- clarify the reason for ignoring the advisory due to CVSS v4 parsing limitations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694761114ad083219a75dad094d85fbe)