### PR TITLE
Fix cargo-deny advisories ignore configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,13 +4,10 @@ vulnerability = "deny"
 unsound = "deny"
 unmaintained = "warn"
 yanked = "warn"
-ignore = [
-  "RUSTSEC-2024-0445",
-]
 
 [[advisories.ignore]]
 id = "RUSTSEC-2024-0445"
-reason = "Ignoring due to CVSS v4 metadata parsing issue in current cargo-deny release."
+reason = "Current cargo-deny release cannot parse CVSS v4 metadata; ignore until tooling updates"
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary
- remove duplicate advisories ignore key to avoid cargo-deny parse error
- retain RUSTSEC-2024-0445 ignore entry with explanatory reason

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947633c69ec8321b205c44d51fc6027)