### PR TITLE
Add cargo-deny CVSS v4 sanitization helper

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -48,11 +48,16 @@ MIND uses `cargo-deny` for dependency auditing:
 
 ```bash
 # Check for known vulnerabilities
-cargo deny check
+tools/cargo-deny-sanitize.sh check
 
 # Audit all dependencies
 cargo audit
 ```
+
+> **Note:** Until `cargo-deny` ships CVSS v4 support, run it through
+> `tools/cargo-deny-sanitize.sh` so the advisory database is sanitized (the
+> script removes the CVSS v4 line from `RUSTSEC-2024-0445` after `cargo deny
+> fetch`). This keeps the check working without mutating the ignore list.
 
 The `deny.toml` configuration enforces:
 - License compliance

--- a/tools/cargo-deny-sanitize.sh
+++ b/tools/cargo-deny-sanitize.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run cargo-deny but sanitize advisory entries that older cargo-deny versions
+# cannot parse (e.g., CVSS v4 metadata).
+COMMAND=${1:-}
+if [[ -z "$COMMAND" ]]; then
+  echo "usage: $(basename "$0") <cargo-deny-subcommand> [args...]" >&2
+  exit 1
+fi
+
+# Fetch advisory database first so we can patch it if needed.
+# Use separate args so we don't pass the subcommand twice.
+FETCH_ARGS=("fetch")
+for arg in "${@:2}"; do
+  FETCH_ARGS+=("$arg")
+done
+cargo deny "${FETCH_ARGS[@]}"
+
+CARGO_HOME_DIR=${CARGO_HOME:-"$HOME/.cargo"}
+DB_ROOT="$CARGO_HOME_DIR/advisory-dbs"
+
+sanitize_cvss_v4() {
+  local advisory_file="$1"
+  if rg -q '^cvss = "CVSS:4\.0/' "$advisory_file" 2>/dev/null; then
+    echo "Stripping CVSS v4 line from $advisory_file" >&2
+    # Remove only the CVSS line to keep the advisory content intact.
+    tmpfile=$(mktemp)
+    sed '/^cvss = "CVSS:4\.0\//d' "$advisory_file" > "$tmpfile"
+    mv "$tmpfile" "$advisory_file"
+  fi
+}
+
+if [[ -d "$DB_ROOT" ]]; then
+  while IFS= read -r -d '' advisory; do
+    sanitize_cvss_v4 "$advisory"
+  done < <(find "$DB_ROOT" -name 'RUSTSEC-2024-0445.md' -print0)
+fi
+
+# Now run the actual command.
+cargo deny "$@"


### PR DESCRIPTION
## Summary
- add a helper script that sanitizes CVSS v4 metadata in the advisory database before running cargo-deny
- document using the helper for cargo-deny checks until upstream supports CVSS v4

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694766c9e8dc832189461902cda92458)