### PR TITLE
Fix CVSS v4 parsing in cargo-deny

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          command: check
-          rust-version: stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      - name: Run cargo-deny with CVSS v4 sanitization
+        run: ./tools/cargo-deny-sanitize.sh check

--- a/tools/cargo-deny-sanitize.sh
+++ b/tools/cargo-deny-sanitize.sh
@@ -32,9 +32,10 @@ sanitize_cvss_v4() {
 }
 
 if [[ -d "$DB_ROOT" ]]; then
+  # Find all advisory files containing CVSS v4 and sanitize them
   while IFS= read -r -d '' advisory; do
     sanitize_cvss_v4 "$advisory"
-  done < <(find "$DB_ROOT" -name 'RUSTSEC-2024-0445.md' -print0)
+  done < <(find "$DB_ROOT" -name 'RUSTSEC-*.md' -print0)
 fi
 
 # Now run the actual command.


### PR DESCRIPTION
- Update cargo-deny workflow to use tools/cargo-deny-sanitize.sh instead of EmbarkStudios/cargo-deny-action which fails on CVSS v4
- Make sanitization script scan all RUSTSEC-*.md files, not just the specific RUSTSEC-2024-0445 advisory, for future-proofing

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
