### PR TITLE
Fix cargo-deny v2 licenses schema and address review feedback

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -24,7 +24,7 @@ jobs:
         id: cache-cargo-deny
         with:
           path: ~/.cargo/bin/cargo-deny
-          key: cargo-deny-0.16
+          key: cargo-deny-0.16-${{ runner.os }}
 
       - name: Install cargo-deny
         if: steps.cache-cargo-deny.outputs.cache-hit != 'true'

--- a/deny.toml
+++ b/deny.toml
@@ -7,9 +7,6 @@ ignore = [
 
 [licenses]
 version = 2
-unlicensed = "deny"
-copyleft = "warn"
-default = "allow"
 allow = [
   "MIT",
   "Apache-2.0",

--- a/tools/cargo-deny-sanitize.sh
+++ b/tools/cargo-deny-sanitize.sh
@@ -29,6 +29,8 @@ sanitize_cvss_v4() {
     # Remove only the CVSS line to keep the advisory content intact.
     local tmpfile
     tmpfile=$(mktemp) || { echo "Failed to create temporary file for $advisory_file" >&2; return 1; }
+    # Ensure tmpfile is cleaned up on exit from this function
+    trap 'rm -f "$tmpfile"' RETURN
     sed '/^cvss = "CVSS:4\.0\//d' "$advisory_file" > "$tmpfile"
     mv "$tmpfile" "$advisory_file"
   fi


### PR DESCRIPTION
- deny.toml: Remove deprecated v2 license fields (unlicensed, copyleft, default) - v2 uses deny-by-default with explicit allow list only
- cargo-deny.yml: Include runner.os in cache key for future-proofing
- cargo-deny-sanitize.sh: Add trap to clean up tmpfile on function exit

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
