### PR TITLE
Run cargo deny in offline mode to use sanitized DB

### DIFF
--- a/tools/cargo-deny-sanitize.sh
+++ b/tools/cargo-deny-sanitize.sh
@@ -53,7 +53,8 @@ for advisory_file in $(find "$DB_ROOT" -name 'RUSTSEC-*.md' -type f); do
   fi
 done
 
-echo "Sanitization complete. Running cargo deny..." >&2
+echo "Sanitization complete. Running cargo deny in offline mode..." >&2
 
-# Now run the actual command (skip fetch since we already have the DB)
-cargo deny "$@"
+# Run cargo deny in offline mode to use our pre-fetched, sanitized database
+# Without --offline, cargo deny would re-fetch and overwrite our changes
+cargo deny --offline "$@"


### PR DESCRIPTION
The issue was that cargo deny was re-fetching the advisory database, overwriting our sanitized version. Adding --offline flag forces it to use the pre-fetched, CVSS v4-sanitized database instead.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
