### PR TITLE
Use --disable-fetch instead of --offline for cargo-deny

### DIFF
--- a/tools/cargo-deny-sanitize.sh
+++ b/tools/cargo-deny-sanitize.sh
@@ -53,8 +53,8 @@ for advisory_file in $(find "$DB_ROOT" -name 'RUSTSEC-*.md' -type f); do
   fi
 done
 
-echo "Sanitization complete. Running cargo deny in offline mode..." >&2
+echo "Sanitization complete. Running cargo deny with fetch disabled..." >&2
 
-# Run cargo deny in offline mode to use our pre-fetched, sanitized database
-# Without --offline, cargo deny would re-fetch and overwrite our changes
-cargo deny --offline "$@"
+# Run cargo deny with --disable-fetch to use our pre-fetched, sanitized database
+# This only disables advisory DB fetching, not cargo metadata (unlike --offline)
+cargo deny --disable-fetch "$@"


### PR DESCRIPTION
--offline prevents ALL network access including cargo metadata. --disable-fetch only disables advisory DB fetching while allowing cargo to resolve dependencies normally.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
