### PR TITLE
fix: correct --disable-fetch argument order in cargo-deny-sanitize.sh

### DIFF
--- a/tools/cargo-deny-sanitize.sh
+++ b/tools/cargo-deny-sanitize.sh
@@ -57,4 +57,5 @@ echo "Sanitization complete. Running cargo deny with fetch disabled..." >&2
 
 # Run cargo deny with --disable-fetch to use our pre-fetched, sanitized database
 # This only disables advisory DB fetching, not cargo metadata (unlike --offline)
-cargo deny --disable-fetch "$@"
+# Note: --disable-fetch must come after the subcommand (e.g., `cargo deny check --disable-fetch`)
+cargo deny "$COMMAND" --disable-fetch "${@:2}"


### PR DESCRIPTION
The --disable-fetch flag must come after the subcommand, not before it. Changed from `cargo deny --disable-fetch "$@"` to
`cargo deny "$COMMAND" --disable-fetch "${@:2}"`.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
