### PR TITLE
chore: add missing licenses to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,10 +10,12 @@ version = 2
 allow = [
   "MIT",
   "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
   "BSD-3-Clause",
   "BSD-2-Clause",
   "ISC",
-  "Unicode-DFS-2016",
+  "MPL-2.0",
+  "Unicode-3.0",
 ]
 
 [bans]


### PR DESCRIPTION
Add licenses for dependencies that were failing cargo-deny checks:
- Apache-2.0 WITH LLVM-exception (ar_archive_writer)
- MPL-2.0 (colored)
- Unicode-3.0 (unicode-ident)

Also remove unused license entries (BSD-3-Clause, ISC, Unicode-DFS-2016) that were causing warnings.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
