### PR TITLE
chore: remove unused BSD-3-Clause and ISC licenses from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,9 +11,7 @@ allow = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
-  "BSD-3-Clause",
   "BSD-2-Clause",
-  "ISC",
   "MPL-2.0",
   "Unicode-3.0",
 ]


### PR DESCRIPTION
These licenses were not being used by any dependencies and were causing "license-not-encountered" warnings in cargo-deny.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
