### PR TITLE
docs: add full-stack AI framework roadmap (Phase 14)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,13 +149,137 @@ Establish MIND as the premier language for real-time neural signal processing an
 
 ---
 
+## Phase 14 — Full-Stack AI Framework
+
+### Vision
+
+MIND is evolving from a single-stack language focused on AI computation into a comprehensive full-stack AI framework that supports end-to-end machine learning. This stack will cover everything from building and training models to deploying them at scale in cloud and edge environments, providing a unified and cohesive experience for machine learning engineers, data scientists, and developers.
+
+### Goals
+
+- **End-to-End AI Development**: From research and prototyping to large-scale deployment
+- **Seamless Integration**: Work naturally with popular data engineering and AI tools
+- **Optimized Performance**: Efficient execution across CPU, GPU, and cloud environments
+- **Ease of Use**: Well-integrated tools, APIs, and deployment frameworks
+
+### Key Areas of Full-Stack Development
+
+#### 1. Frontend Layer
+
+**Language Enhancements:**
+- Extend the language to improve developer experience through enhanced IDE support
+- Advanced syntax highlighting and semantic code analysis
+- Improved debugging tools with step-through tensor inspection
+
+**Interactive Notebooks:**
+- Browser-based interactive notebooks for writing, testing, and visualizing MIND code
+- Jupyter-style cells with native MIND kernel support
+- Real-time tensor visualization and model architecture diagrams
+
+**Visualization Tools:**
+- Integrated tools for visualizing tensor data and intermediate representations
+- Model architecture visualization with automatic graph generation
+- Training progress dashboards with loss curves, metrics, and resource utilization
+
+#### 2. Backend Layer
+
+**Compiler Optimization:**
+- Extend the MIND Compiler to support advanced optimizations:
+  - Automatic model pruning and quantization
+  - Tensor fusion and operator scheduling
+  - Enhanced support for TPUs, GPUs, and specialized AI accelerators
+
+**Distributed Execution:**
+- Distributed execution framework for training on clusters and multi-GPU setups
+- Data parallelism and model parallelism strategies
+- Gradient synchronization with NCCL-style collectives
+
+#### 3. Middleware Layer
+
+**API Layer:**
+- REST and gRPC APIs for MIND-based model inference and serving
+- OpenAPI/Swagger documentation generation
+- Authentication and rate limiting for production deployments
+
+**Data Integration:**
+- Data engineering integrations for preprocessing and managing data pipelines:
+  - Apache Kafka for streaming data
+  - Apache Spark for batch processing
+  - Native connectors for cloud storage (S3, GCS, Azure Blob)
+
+**Model Serving:**
+- Scalable, real-time model serving APIs for production deployment
+- Batching and request queuing for throughput optimization
+- A/B testing and canary deployment support
+
+#### 4. Deployment Layer
+
+**Containerization:**
+- Pre-configured Docker images for training and serving MIND models
+- Multi-stage builds optimized for minimal production footprint
+- NVIDIA CUDA and ROCm base images for GPU workloads
+
+**CI/CD Pipelines:**
+- Continuous integration and deployment pipelines for automatic testing, training, and deployment
+- GitHub Actions and GitLab CI templates
+- Model versioning and artifact management
+
+**Kubernetes Integration:**
+- Helm charts for deploying MIND-based applications
+- Horizontal pod autoscaling based on inference load
+- Integration with Kubernetes operators for ML workflows (Kubeflow, MLflow)
+
+#### 5. Ecosystem Support
+
+**Pre-trained Models:**
+- Library of pre-trained models for standard use cases:
+  - Image classification (ResNet, EfficientNet variants)
+  - Natural language processing (transformers, embeddings)
+  - Time-series forecasting and anomaly detection
+
+**Framework Interoperability:**
+- Import/export compatibility with other frameworks:
+  - ONNX model import/export
+  - TensorFlow SavedModel conversion
+  - PyTorch model migration tools
+
+**Data Pipeline Connectors:**
+- Seamless integration with data lakes and cloud platforms
+- Connectors for popular databases (PostgreSQL, MongoDB, ClickHouse)
+- Integration with feature stores (Feast, Tecton)
+
+### Phased Rollout
+
+**Phase 14.1 — Frontend Language and Developer Tools:**
+- Enhanced language features for easier model development
+- Full IDE support with syntax highlighting and auto-completion
+- Integration of interactive notebooks for AI experimentation
+
+**Phase 14.2 — Compiler Optimizations and Backend Support:**
+- Extension of MIND's compiler to support advanced tensor optimizations
+- Development of runtime support for distributed training
+- Full support for cloud-based, multi-GPU, and distributed computing environments
+
+**Phase 14.3 — Middleware Development:**
+- Creation of MIND's API layer for inference and model serving
+- Integration with data engineering frameworks (Kafka, Spark, etc.)
+- Development of real-time serving APIs for production-ready AI models
+
+**Phase 14.4 — Full-Stack Deployment and Ecosystem Integration:**
+- Docker images and Kubernetes deployment support for MIND models
+- Pre-trained models and ecosystem tools for end-users
+- Full integration with CI/CD pipelines and cloud-native deployments
+
+---
+
 ## Summary
 
-These extended phases (10–13) guide MIND into the next major development era:
+These extended phases (10–14) guide MIND into the next major development era:
 - richer SDK and examples,
 - formal benchmarks,
 - early cloud compiler,
 - enterprise-grade runtime,
-- and robust edge interfaces.
+- robust edge interfaces,
+- and comprehensive full-stack AI framework capabilities.
 
-Together they represent the roadmap toward **MIND v1.0** and production-ready adoption across multiple industries.
+Together they represent the roadmap toward **MIND v1.0** and production-ready adoption across multiple industries, enabling end-to-end machine learning from research to deployment.


### PR DESCRIPTION
Add Phase 14 to the extended roadmap outlining the vision for transforming MIND into a comprehensive full-stack AI framework. This includes frontend developer tools, backend optimizations, middleware APIs, deployment infrastructure, and ecosystem support.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
