### PR TITLE
feat: add Mojo compilation benchmark infrastructure for comparison

### DIFF
--- a/benchmarks/mojo/README.md
+++ b/benchmarks/mojo/README.md
@@ -1,0 +1,196 @@
+# Mojo Compilation Benchmarks
+
+This directory contains equivalent Mojo programs for comparing compilation performance with MIND.
+
+## Quick Start
+
+### Prerequisites
+
+1. **Install Mojo SDK**:
+   ```bash
+   curl https://get.modular.com | sh -
+   modular auth <your-auth-key>
+   modular install mojo
+   ```
+
+2. **Add Mojo to PATH**:
+   ```bash
+   export MODULAR_HOME="$HOME/.modular"
+   export PATH="$MODULAR_HOME/pkg/packages.modular.com_mojo/bin:$PATH"
+   ```
+
+3. **Verify installation**:
+   ```bash
+   mojo --version
+   ```
+
+### Run Benchmarks
+
+```bash
+# Make executable
+chmod +x benchmark_mojo_compilation.py
+
+# Run benchmarks
+python3 benchmark_mojo_compilation.py
+```
+
+## Benchmark Programs
+
+All programs are equivalent to MIND's `benches/simple_benchmarks.rs`:
+
+| File | MIND Equivalent | Description |
+|------|-----------------|-------------|
+| `scalar_math.mojo` | `scalar_math` | Simple arithmetic: `1 + 2 * 3 - 4 / 2` |
+| `small_matmul.mojo` | `small_matmul` | Matrix mult: `[10,20] × [20,30]` |
+| `medium_matmul.mojo` | `medium_matmul` | Matrix mult: `[128,256] × [256,512]` |
+| `large_matmul.mojo` | `large_matmul` | Matrix mult: `[512,1024] × [1024,512]` |
+
+## Expected MIND Results (Baseline)
+
+From `docs/benchmarks/compiler_performance.md`:
+
+```
+Benchmark         MIND Compilation Time
+─────────────────────────────────────────
+scalar_math       17.9 µs
+small_matmul      29.1 µs
+medium_matmul     29.4 µs
+large_matmul      30.1 µs
+```
+
+## Interpreting Results
+
+The benchmark script (`benchmark_mojo_compilation.py`) will:
+
+1. **Compile each Mojo program** using `mojo build`
+2. **Measure compilation time** (not execution time)
+3. **Run 20 samples** with 3 warmup runs
+4. **Compare with MIND** baseline results
+5. **Calculate speedup ratio**:
+   - Speedup < 1.0: MIND is faster
+   - Speedup > 1.0: Mojo is faster
+   - Speedup = 1.0: Equal performance
+
+### Example Output
+
+```
+COMPILATION TIME COMPARISON: MIND vs Mojo
+================================================================================
+
+Benchmark            MIND (µs)       Mojo (µs)       Speedup
+--------------------------------------------------------------------------------
+scalar_math          17.893          [TBD]           [TBD]x
+small_matmul         29.111          [TBD]           [TBD]x
+medium_matmul        29.384          [TBD]           [TBD]x
+large_matmul         30.143          [TBD]           [TBD]x
+================================================================================
+```
+
+## Important Notes
+
+### What We're Measuring
+
+- ✅ **Compilation time**: Parse → Type-check → Codegen → Binary
+- ❌ **Not execution time**: We're not running the compiled programs
+
+This matches MIND's benchmarks which measure:
+```
+Parse → Type-check → IR lowering → Verification
+```
+
+### Fair Comparison Considerations
+
+1. **Scope Difference**:
+   - MIND: Source → IR (no LLVM backend in open-core)
+   - Mojo: Source → Optimized binary (full LLVM pipeline)
+
+2. **If Mojo is slower**: This is expected! Mojo does more work:
+   - LLVM optimization passes
+   - Binary generation
+   - Potential JIT warmup
+
+3. **If Mojo is faster**: Consider:
+   - Mojo may cache compilation artifacts
+   - Different scope of "compilation"
+   - JIT vs AOT differences
+
+### For Honest Comparison
+
+To be fair to both:
+
+**MIND should measure**:
+```bash
+cargo bench --features mlir-lowering --bench compiler
+```
+This includes MLIR lowering (closer to Mojo's scope).
+
+**Mojo should measure**:
+- Just front-end compilation (if possible to isolate)
+- Or compare full MIND compilation including MLIR → LLVM
+
+## Troubleshooting
+
+### Mojo not found
+
+```bash
+# Check PATH
+echo $PATH | grep modular
+
+# Add to PATH
+export MODULAR_HOME="$HOME/.modular"
+export PATH="$MODULAR_HOME/pkg/packages.modular.com_mojo/bin:$PATH"
+
+# Verify
+mojo --version
+```
+
+### Compilation errors
+
+If Mojo programs fail to compile, check:
+1. Mojo SDK version (update if old)
+2. Syntax changes in latest Mojo (API is evolving)
+3. Missing imports (Tensor, TensorShape, etc.)
+
+### Permission denied
+
+```bash
+chmod +x benchmark_mojo_compilation.py
+```
+
+## Extending Benchmarks
+
+To add more benchmarks:
+
+1. **Create `.mojo` file** with equivalent program
+2. **Add to `BENCHMARKS` dict** in `benchmark_mojo_compilation.py`
+3. **Add MIND baseline** to `compare_with_mind()` function
+4. **Run benchmarks**
+
+## Results
+
+After running, results are saved to:
+- `mojo_results.json` - Raw timing data
+- Console output - Comparison table
+
+Share results by:
+1. Opening a GitHub issue
+2. Including system specs (CPU, OS, Mojo version)
+3. Attaching `mojo_results.json`
+
+## Context: Why This Matters
+
+From the MIND benchmarks, we claim:
+> "MIND is 17,000x - 345,000x faster than PyTorch 2.0"
+
+This Mojo comparison helps answer:
+- Is MIND faster than Mojo? (Chris Lattner's ML language)
+- By how much?
+- Is the PyTorch comparison valid or cherry-picked?
+
+**Goal**: Honest, reproducible comparison to inform technical due diligence.
+
+---
+
+**Status**: Ready to run (Mojo SDK required)
+**Maintained by**: MIND benchmarking team
+**Last updated**: 2025-12-21

--- a/benchmarks/mojo/benchmark_mojo_compilation.py
+++ b/benchmarks/mojo/benchmark_mojo_compilation.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Mojo Compilation Benchmark
+Measures compilation time for Mojo programs to compare with MIND
+
+Usage:
+    python benchmark_mojo_compilation.py
+
+Requirements:
+    - Mojo SDK installed (https://docs.modular.com/mojo/manual/get-started/)
+    - mojo command in PATH
+"""
+
+import subprocess
+import time
+import statistics
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# Benchmark configuration
+SAMPLE_SIZE = 20
+WARMUP_RUNS = 3
+
+# Benchmark programs
+BENCHMARKS = {
+    "scalar_math": "scalar_math.mojo",
+    "small_matmul": "small_matmul.mojo",
+    "medium_matmul": "medium_matmul.mojo",
+    "large_matmul": "large_matmul.mojo",
+}
+
+
+def measure_compilation_time(mojo_file: Path) -> float:
+    """
+    Measure compilation time for a Mojo file.
+
+    Returns time in microseconds.
+    """
+    start = time.perf_counter()
+
+    # Compile Mojo file (don't run, just compile)
+    result = subprocess.run(
+        ["mojo", "build", str(mojo_file), "-o", "/tmp/mojo_bench_output"],
+        capture_output=True,
+        text=True,
+    )
+
+    end = time.perf_counter()
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Compilation failed: {result.stderr}")
+
+    # Convert to microseconds for comparison with MIND benchmarks
+    return (end - start) * 1_000_000
+
+
+def run_benchmark(name: str, mojo_file: Path) -> Dict[str, float]:
+    """
+    Run benchmark with warmup and multiple samples.
+
+    Returns statistics in microseconds.
+    """
+    print(f"Benchmarking {name}...")
+
+    # Warmup
+    print(f"  Warming up ({WARMUP_RUNS} runs)...")
+    for _ in range(WARMUP_RUNS):
+        try:
+            measure_compilation_time(mojo_file)
+        except RuntimeError as e:
+            print(f"  WARNING: Warmup failed: {e}")
+
+    # Actual measurements
+    print(f"  Measuring ({SAMPLE_SIZE} samples)...")
+    times = []
+    for i in range(SAMPLE_SIZE):
+        try:
+            t = measure_compilation_time(mojo_file)
+            times.append(t)
+            if (i + 1) % 5 == 0:
+                print(f"    {i + 1}/{SAMPLE_SIZE} samples collected...")
+        except RuntimeError as e:
+            print(f"  ERROR: Measurement {i+1} failed: {e}")
+            continue
+
+    if not times:
+        raise RuntimeError(f"All measurements failed for {name}")
+
+    # Calculate statistics
+    mean = statistics.mean(times)
+    median = statistics.median(times)
+    stdev = statistics.stdev(times) if len(times) > 1 else 0
+    min_time = min(times)
+    max_time = max(times)
+
+    return {
+        "mean_us": mean,
+        "median_us": median,
+        "stdev_us": stdev,
+        "min_us": min_time,
+        "max_us": max_time,
+        "samples": len(times),
+    }
+
+
+def compare_with_mind(mojo_results: Dict[str, Dict[str, float]]):
+    """
+    Compare Mojo results with MIND benchmarks.
+
+    MIND results from benches/simple_benchmarks.rs:
+    - scalar_math: 17.893 µs
+    - small_matmul: 29.111 µs
+    - medium_matmul: 29.384 µs
+    - large_matmul: 30.143 µs
+    """
+    mind_results = {
+        "scalar_math": 17.893,
+        "small_matmul": 29.111,
+        "medium_matmul": 29.384,
+        "large_matmul": 30.143,
+    }
+
+    print("\n" + "="*80)
+    print("COMPILATION TIME COMPARISON: MIND vs Mojo")
+    print("="*80)
+    print()
+    print(f"{'Benchmark':<20} {'MIND (µs)':<15} {'Mojo (µs)':<15} {'Speedup':<15}")
+    print("-" * 80)
+
+    for name in mind_results.keys():
+        if name in mojo_results:
+            mind_time = mind_results[name]
+            mojo_time = mojo_results[name]["mean_us"]
+            speedup = mojo_time / mind_time
+
+            print(f"{name:<20} {mind_time:<15.3f} {mojo_time:<15.3f} {speedup:<15.2f}x")
+        else:
+            print(f"{name:<20} {mind_results[name]:<15.3f} {'N/A':<15} {'N/A':<15}")
+
+    print("="*80)
+    print()
+    print("Interpretation:")
+    print("  Speedup < 1.0: MIND is faster")
+    print("  Speedup > 1.0: Mojo is faster")
+    print("  Speedup = 1.0: Equal performance")
+    print()
+
+
+def main():
+    print("Mojo Compilation Benchmark")
+    print("="*80)
+    print(f"Sample size: {SAMPLE_SIZE}")
+    print(f"Warmup runs: {WARMUP_RUNS}")
+    print()
+
+    # Check if mojo is available
+    try:
+        result = subprocess.run(["mojo", "--version"], capture_output=True, text=True)
+        print(f"Mojo version: {result.stdout.strip()}")
+    except FileNotFoundError:
+        print("ERROR: 'mojo' command not found!")
+        print("Please install Mojo SDK: https://docs.modular.com/mojo/manual/get-started/")
+        return 1
+
+    print()
+
+    # Get benchmark directory
+    bench_dir = Path(__file__).parent
+
+    # Run benchmarks
+    results = {}
+    for name, filename in BENCHMARKS.items():
+        mojo_file = bench_dir / filename
+
+        if not mojo_file.exists():
+            print(f"WARNING: {mojo_file} not found, skipping...")
+            continue
+
+        try:
+            results[name] = run_benchmark(name, mojo_file)
+            print(f"  ✓ {name}: {results[name]['mean_us']:.3f} µs (±{results[name]['stdev_us']:.3f})")
+            print()
+        except Exception as e:
+            print(f"  ✗ {name} failed: {e}")
+            print()
+
+    # Save results
+    results_file = bench_dir / "mojo_results.json"
+    with open(results_file, "w") as f:
+        json.dump(results, f, indent=2)
+
+    print(f"Results saved to: {results_file}")
+    print()
+
+    # Compare with MIND
+    compare_with_mind(results)
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/benchmarks/mojo/large_matmul.mojo
+++ b/benchmarks/mojo/large_matmul.mojo
@@ -1,0 +1,30 @@
+"""
+Mojo equivalent: Large matrix multiplication
+MIND equivalent: benches/simple_benchmarks.rs - large_matmul
+
+Matrix dimensions: [512, 1024] × [1024, 512] = [512, 512]
+"""
+
+from tensor import Tensor, TensorShape
+
+fn matmul_large():
+    # Initialize tensors
+    let a = Tensor[DType.float32](TensorShape(512, 1024))
+    let b = Tensor[DType.float32](TensorShape(1024, 512))
+
+    # Fill with ones
+    for i in range(512):
+        for j in range(1024):
+            a[i, j] = 1.0
+
+    for i in range(1024):
+        for j in range(512):
+            b[i, j] = 1.0
+
+    # Matrix multiplication
+    let result = a @ b
+
+    print("Result shape:", result.shape())
+
+fn main():
+    matmul_large()

--- a/benchmarks/mojo/medium_matmul.mojo
+++ b/benchmarks/mojo/medium_matmul.mojo
@@ -1,0 +1,30 @@
+"""
+Mojo equivalent: Medium matrix multiplication
+MIND equivalent: benches/simple_benchmarks.rs - medium_matmul
+
+Matrix dimensions: [128, 256] × [256, 512] = [128, 512]
+"""
+
+from tensor import Tensor, TensorShape
+
+fn matmul_medium():
+    # Initialize tensors
+    let a = Tensor[DType.float32](TensorShape(128, 256))
+    let b = Tensor[DType.float32](TensorShape(256, 512))
+
+    # Fill with ones
+    for i in range(128):
+        for j in range(256):
+            a[i, j] = 1.0
+
+    for i in range(256):
+        for j in range(512):
+            b[i, j] = 1.0
+
+    # Matrix multiplication
+    let result = a @ b
+
+    print("Result shape:", result.shape())
+
+fn main():
+    matmul_medium()

--- a/benchmarks/mojo/run_benchmarks.sh
+++ b/benchmarks/mojo/run_benchmarks.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+#
+# Mojo Compilation Benchmark Runner
+# Compares Mojo compilation speed with MIND
+#
+##===----------------------------------------------------------------------===##
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "================================================================================"
+echo "Mojo Compilation Benchmark Runner"
+echo "================================================================================"
+echo ""
+
+# Check if mojo is installed
+if ! command -v mojo &> /dev/null; then
+    echo -e "${RED}ERROR: 'mojo' command not found!${NC}"
+    echo ""
+    echo "Please install Mojo SDK:"
+    echo "  1. Visit: https://docs.modular.com/mojo/manual/get-started/"
+    echo "  2. Run: curl https://get.modular.com | sh -"
+    echo "  3. Authenticate: modular auth <your-key>"
+    echo "  4. Install: modular install mojo"
+    echo ""
+    echo "Then add to PATH:"
+    echo "  export MODULAR_HOME=\"\$HOME/.modular\""
+    echo "  export PATH=\"\$MODULAR_HOME/pkg/packages.modular.com_mojo/bin:\$PATH\""
+    echo ""
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Mojo found:${NC}"
+mojo --version
+echo ""
+
+# Check if Python 3 is available
+if ! command -v python3 &> /dev/null; then
+    echo -e "${RED}ERROR: 'python3' command not found!${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Python 3 found:${NC}"
+python3 --version
+echo ""
+
+# Get script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+echo "Running benchmarks..."
+echo ""
+
+# Run benchmark script
+python3 benchmark_mojo_compilation.py
+
+echo ""
+echo "================================================================================"
+echo "Benchmark complete!"
+echo "================================================================================"
+echo ""
+echo "Results saved to: $SCRIPT_DIR/mojo_results.json"
+echo ""
+echo "To compare with MIND, see:"
+echo "  - MIND results: ../../docs/benchmarks/compiler_performance.md"
+echo "  - This comparison: mojo_results.json"
+echo ""
+echo "Share your results by opening a GitHub issue with:"
+echo "  1. Your system specs (CPU, OS, RAM)"
+echo "  2. Mojo version (shown above)"
+echo "  3. The mojo_results.json file"
+echo ""

--- a/benchmarks/mojo/scalar_math.mojo
+++ b/benchmarks/mojo/scalar_math.mojo
@@ -1,0 +1,11 @@
+"""
+Mojo equivalent: Scalar arithmetic
+MIND equivalent: benches/simple_benchmarks.rs - scalar_math
+"""
+
+fn compute() -> Int:
+    return 1 + 2 * 3 - 4 / 2
+
+fn main():
+    let result = compute()
+    print(result)

--- a/benchmarks/mojo/small_matmul.mojo
+++ b/benchmarks/mojo/small_matmul.mojo
@@ -1,0 +1,31 @@
+"""
+Mojo equivalent: Small matrix multiplication
+MIND equivalent: benches/simple_benchmarks.rs - small_matmul
+
+Matrix dimensions: [10, 20] × [20, 30] = [10, 30]
+"""
+
+from tensor import Tensor, TensorShape
+from random import rand
+
+fn matmul_small():
+    # Initialize tensors
+    let a = Tensor[DType.float32](TensorShape(10, 20))
+    let b = Tensor[DType.float32](TensorShape(20, 30))
+
+    # Fill with ones (equivalent to MIND's initialization)
+    for i in range(10):
+        for j in range(20):
+            a[i, j] = 1.0
+
+    for i in range(20):
+        for j in range(30):
+            b[i, j] = 1.0
+
+    # Matrix multiplication
+    let result = a @ b
+
+    print("Result shape:", result.shape())
+
+fn main():
+    matmul_small()

--- a/docs/benchmarks/mojo_comparison.md
+++ b/docs/benchmarks/mojo_comparison.md
@@ -1,0 +1,337 @@
+# MIND vs Mojo: Compilation Performance Comparison
+
+**Status**: Benchmark Infrastructure Ready (Requires Mojo SDK to run)
+**Date**: 2025-12-21
+**Purpose**: Fair, reproducible comparison of compilation performance
+
+---
+
+## Executive Summary
+
+We've created equivalent benchmarks to compare MIND's compilation speed against Mojo, Chris Lattner's ML language from Modular. This addresses the critical question: **Is MIND actually faster than state-of-the-art ML compilers?**
+
+### What's Ready
+
+✅ **Mojo benchmark programs** (equivalent to MIND's benchmarks)
+✅ **Automated benchmark harness** (Python script)
+✅ **Fair comparison methodology** (documented below)
+✅ **MIND baseline results** (already measured)
+
+❌ **Actual Mojo results** (requires Mojo SDK installation)
+
+---
+
+## Why This Comparison Matters
+
+### Current MIND Claims
+
+From `docs/benchmarks/compiler_performance.md`:
+
+> "MIND is 17,000x - 345,000x faster than PyTorch 2.0 AOT compilation"
+
+**Investor Question**: *"But what about Mojo? That's the real competitor."*
+
+**Answer We Need**: Hard numbers comparing MIND vs Mojo on identical workloads.
+
+### Why Mojo is the Right Comparison
+
+1. **Same Domain**: Both target ML/AI workloads
+2. **Modern Architecture**: Both use LLVM/MLIR backends
+3. **Performance Focus**: Both prioritize compile-time and runtime speed
+4. **Industry Credibility**: Mojo created by Chris Lattner (LLVM, Swift, MLIR)
+5. **Direct Competition**: Mojo is positioning for production ML systems
+
+---
+
+## Benchmark Programs
+
+All Mojo programs are direct equivalents of MIND's `benches/simple_benchmarks.rs`:
+
+### 1. Scalar Arithmetic
+
+**MIND** (`benches/simple_benchmarks.rs`):
+```mind
+1 + 2 * 3 - 4 / 2
+```
+
+**Mojo** (`benchmarks/mojo/scalar_math.mojo`):
+```mojo
+fn compute() -> Int:
+    return 1 + 2 * 3 - 4 / 2
+```
+
+**MIND Result**: 17.9 µs
+**Mojo Result**: *[Run benchmarks to determine]*
+
+---
+
+### 2. Small Matrix Multiplication
+
+**Dimensions**: `[10, 20] × [20, 30] = [10, 30]`
+
+**MIND** (`benches/simple_benchmarks.rs`):
+```mind
+let a: Tensor[f32,(10,20)] = 1;
+let b: Tensor[f32,(20,30)] = 1;
+tensor.matmul(a, b)
+```
+
+**Mojo** (`benchmarks/mojo/small_matmul.mojo`):
+```mojo
+let a = Tensor[DType.float32](TensorShape(10, 20))
+let b = Tensor[DType.float32](TensorShape(20, 30))
+# Fill with ones...
+let result = a @ b
+```
+
+**MIND Result**: 29.1 µs
+**Mojo Result**: *[Run benchmarks to determine]*
+
+---
+
+### 3. Medium Matrix Multiplication
+
+**Dimensions**: `[128, 256] × [256, 512] = [128, 512]`
+
+**MIND Result**: 29.4 µs
+**Mojo Result**: *[Run benchmarks to determine]*
+
+---
+
+### 4. Large Matrix Multiplication
+
+**Dimensions**: `[512, 1024] × [1024, 512] = [512, 512]`
+
+**MIND Result**: 30.1 µs
+**Mojo Result**: *[Run benchmarks to determine]*
+
+---
+
+## Methodology
+
+### What We Measure
+
+**MIND**: `compile_source()` function
+- Parse source code
+- Type-check (including shape inference)
+- Lower to IR
+- Verify IR correctness
+
+**Mojo**: `mojo build` command
+- Parse source code
+- Type-check
+- LLVM/MLIR compilation
+- Generate executable binary
+
+### Important: Scope Difference
+
+⚠️ **These are NOT apples-to-apples comparisons!**
+
+| Phase | MIND (open-core) | Mojo |
+|-------|------------------|------|
+| **Parse** | ✅ Included | ✅ Included |
+| **Type-check** | ✅ Included | ✅ Included |
+| **Shape inference** | ✅ Included | ✅ Included |
+| **IR lowering** | ✅ Included | ✅ Included |
+| **MLIR lowering** | ❌ Not measured | ✅ Included |
+| **LLVM optimizations** | ❌ Not measured | ✅ Included |
+| **Binary generation** | ❌ Not measured | ✅ Included |
+
+### Fair Comparison Options
+
+**Option 1: Compare What We Have**
+- Accept that Mojo does more work
+- If MIND is faster, it's a valid win
+- If Mojo is faster despite doing more work, that's impressive
+
+**Option 2: Match MIND's Scope**
+- Would need to isolate Mojo's front-end only
+- Likely not possible without Modular cooperation
+- Or: Add MLIR lowering to MIND's benchmarks
+
+**Option 3: Match Mojo's Scope**
+- Run MIND benchmarks with `--features mlir-lowering`
+- Measure full compilation to MLIR text
+- More fair comparison
+
+**Recommendation**: Use **Option 3** for technical accuracy:
+```bash
+cargo bench --features mlir-lowering --bench compiler
+```
+
+---
+
+## Running the Benchmarks
+
+### Prerequisites
+
+1. **Install Mojo SDK**:
+   ```bash
+   curl https://get.modular.com | sh -
+   modular auth <your-auth-key>
+   modular install mojo
+   ```
+
+2. **Add to PATH**:
+   ```bash
+   export MODULAR_HOME="$HOME/.modular"
+   export PATH="$MODULAR_HOME/pkg/packages.modular.com_mojo/bin:$PATH"
+   ```
+
+### Run
+
+```bash
+cd benchmarks/mojo
+./run_benchmarks.sh
+```
+
+### Output
+
+The script will:
+1. Compile each Mojo program 20 times
+2. Calculate mean, median, stdev
+3. Compare with MIND baseline
+4. Print comparison table
+5. Save raw results to `mojo_results.json`
+
+---
+
+## Interpreting Results
+
+### Scenario 1: MIND is Faster
+
+**Example**:
+```
+Benchmark         MIND (µs)    Mojo (µs)    Speedup
+─────────────────────────────────────────────────────
+scalar_math       17.9         45.2         2.5x
+small_matmul      29.1         156.3        5.4x
+```
+
+**Interpretation**:
+- MIND's front-end is 2.5-5.4x faster than Mojo's full pipeline
+- **Strong claim**: "MIND compiles faster than Mojo, even though Mojo does more work"
+- **Investor pitch**: "We're faster than the industry's best"
+
+**Caveat**: Mojo includes backend compilation that MIND (open-core) doesn't measure
+
+---
+
+### Scenario 2: Mojo is Faster
+
+**Example**:
+```
+Benchmark         MIND (µs)    Mojo (µs)    Speedup
+─────────────────────────────────────────────────────
+scalar_math       17.9         8.5          0.47x
+small_matmul      29.1         12.3         0.42x
+```
+
+**Interpretation**:
+- Mojo's full pipeline is 2-2.4x faster than MIND's front-end
+- **Honest assessment**: "Mojo is faster, but does more work"
+- **Alternative pitch**: "MIND's deterministic compilation enables real-time use cases Mojo can't address"
+
+**Caveat**: This would be surprising given Mojo's larger scope
+
+---
+
+### Scenario 3: Roughly Equal
+
+**Example**:
+```
+Benchmark         MIND (µs)    Mojo (µs)    Speedup
+─────────────────────────────────────────────────────
+scalar_math       17.9         19.2         1.07x
+small_matmul      29.1         31.5         1.08x
+```
+
+**Interpretation**:
+- Comparable performance despite scope difference
+- **Neutral claim**: "MIND matches Mojo's front-end speed"
+- **Pivot to**: "Plus deterministic execution + auditable compilation"
+
+---
+
+## What This Proves (And Doesn't)
+
+### ✅ What Benchmarks Prove
+
+- **Compilation speed**: MIND vs Mojo for identical programs
+- **Scalability**: How compile time grows with program complexity
+- **Consistency**: Variance in compilation time
+- **Relative performance**: Which is faster for this workload
+
+### ❌ What Benchmarks Don't Prove
+
+- **Execution speed**: We're not running the compiled programs
+- **Real-world performance**: Synthetic benchmarks only
+- **Memory efficiency**: Not measuring memory usage
+- **Full-stack comparison**: MIND's open-core vs Mojo's full pipeline
+
+---
+
+## Action Items
+
+### Before Investor Meeting
+
+1. **Run Mojo benchmarks** on production hardware
+2. **Update this document** with actual results
+3. **Create comparison slide** for pitch deck
+4. **Prepare explanation** for why comparison is/isn't fair
+
+### For Honest Pitch
+
+**If MIND is faster**:
+> "MIND's front-end compiles 2-5x faster than Mojo's full pipeline. Even when Mojo includes LLVM optimizations and binary generation, MIND's focused architecture is faster."
+
+**If Mojo is faster**:
+> "Mojo's full compilation (including LLVM backend) is faster than MIND's front-end, which is remarkable engineering. However, MIND's deterministic execution model enables use cases in regulated environments that Mojo can't address."
+
+**If roughly equal**:
+> "MIND matches Mojo's compilation speed while providing deterministic, auditable execution—a critical requirement for medical devices and BCI systems."
+
+---
+
+## Technical Due Diligence
+
+Investors will ask:
+1. **"How does MIND compare to Mojo?"**
+   - *Show this document and mojo_results.json*
+
+2. **"Is the comparison fair?"**
+   - *Explain scope difference (front-end vs full pipeline)*
+   - *Offer to run MIND with MLIR lowering for fairer comparison*
+
+3. **"Why is MIND better if Mojo is faster?"**
+   - *Pivot to deterministic execution, auditability, safety*
+   - *Or: MIND is faster despite smaller team/budget*
+
+4. **"Can you reproduce this?"**
+   - *Yes, all code in `benchmarks/mojo/`, run `./run_benchmarks.sh`*
+
+---
+
+## Next Steps
+
+1. **Install Mojo SDK** (requires auth key)
+2. **Run benchmarks**: `cd benchmarks/mojo && ./run_benchmarks.sh`
+3. **Update this doc** with results
+4. **Create PR** with findings
+5. **Update pitch deck** with comparison data
+
+---
+
+## Files
+
+- **Benchmark programs**: `/benchmarks/mojo/*.mojo`
+- **Benchmark script**: `/benchmarks/mojo/benchmark_mojo_compilation.py`
+- **Runner script**: `/benchmarks/mojo/run_benchmarks.sh`
+- **README**: `/benchmarks/mojo/README.md`
+- **This document**: `/docs/benchmarks/mojo_comparison.md`
+
+---
+
+**Status**: Infrastructure ready, awaiting Mojo SDK access
+**Owner**: MIND benchmarking team
+**Contact**: Open GitHub issue for questions


### PR DESCRIPTION
Add complete benchmark suite to compare MIND vs Mojo compilation performance:

**Infrastructure:**
- 4 equivalent Mojo programs matching MIND benchmarks
  - scalar_math.mojo: Simple arithmetic
  - small_matmul.mojo: 10×20 × 20×30 matrix mult
  - medium_matmul.mojo: 128×256 × 256×512 matrix mult
  - large_matmul.mojo: 512×1024 × 1024×512 matrix mult

- Python benchmark harness (benchmark_mojo_compilation.py):
  - Measures compilation time with 20 samples
  - Calculates mean, median, stdev, min, max
  - Compares directly with MIND baseline results
  - Exports results to JSON

- Shell script wrapper (run_benchmarks.sh):
  - Checks Mojo installation
  - Runs benchmarks automatically
  - Provides clear output and instructions

**Documentation:**
- benchmarks/mojo/README.md: Quick start guide
- docs/benchmarks/mojo_comparison.md: Comprehensive analysis
  - Explains scope differences (front-end vs full pipeline)
  - Provides fair comparison methodology
  - Interprets possible outcomes (MIND faster/slower/equal)
  - Guidance for honest investor pitch

**Key Features:**
- Ready to run (requires Mojo SDK installation)
- Fair comparison methodology documented
- Automated result comparison with MIND
- Reproducible on any system with Mojo

**Purpose:**
Address critical investor question: "How does MIND compare to Mojo?"

**Status:**
- ✅ Infrastructure complete
- ❌ Requires Mojo SDK to generate actual results
- ⏳ Awaiting benchmark run on machine with Mojo installed

**Next Steps:**
1. Install Mojo SDK
2. Run: cd benchmarks/mojo && ./run_benchmarks.sh
3. Update docs with actual results
4. Create comparison slide for pitch deck

This enables honest, reproducible comparison with the industry's leading ML language compiler.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
