### PR TITLE
Fix matrix dimensions for MIND benchmarks

### DIFF
--- a/benchmarks/mojo/benchmark_mojo_compilation.py
+++ b/benchmarks/mojo/benchmark_mojo_compilation.py
@@ -141,8 +141,8 @@ def compare_with_mind(mojo_results: Dict[str, Dict[str, float]]):
     print("="*80)
     print()
     print("Interpretation:")
-    print("  Speedup < 1.0: MIND is faster")
-    print("  Speedup > 1.0: Mojo is faster")
+    print("  Speedup > 1.0: MIND is faster (e.g., 1000x means MIND compiles 1000x faster)")
+    print("  Speedup < 1.0: Mojo is faster")
     print("  Speedup = 1.0: Equal performance")
     print()
 

--- a/benchmarks/mojo/large_matmul.mojo
+++ b/benchmarks/mojo/large_matmul.mojo
@@ -1,5 +1,5 @@
 """
-Mojo equivalent: Large matrix multiplication (512x1024 * 1024x256)
+Mojo equivalent: Large matrix multiplication (512x1024 * 1024x512)
 MIND equivalent: benches/simple_benchmarks.rs - large_matmul
 """
 
@@ -14,7 +14,7 @@ fn matmul(a: List[Float32], b: List[Float32], mut c: List[Float32], M: Int, N: I
 
 fn main():
     var M = 512
-    var N = 256
+    var N = 512
     var K = 1024
 
     var a = List[Float32](capacity=M * K)

--- a/benchmarks/mojo/medium_matmul.mojo
+++ b/benchmarks/mojo/medium_matmul.mojo
@@ -1,5 +1,5 @@
 """
-Mojo equivalent: Medium matrix multiplication (128x256 * 256x64)
+Mojo equivalent: Medium matrix multiplication (128x256 * 256x512)
 MIND equivalent: benches/simple_benchmarks.rs - medium_matmul
 """
 
@@ -14,7 +14,7 @@ fn matmul(a: List[Float32], b: List[Float32], mut c: List[Float32], M: Int, N: I
 
 fn main():
     var M = 128
-    var N = 64
+    var N = 512
     var K = 256
 
     var a = List[Float32](capacity=M * K)

--- a/benchmarks/mojo/small_matmul.mojo
+++ b/benchmarks/mojo/small_matmul.mojo
@@ -1,5 +1,5 @@
 """
-Mojo equivalent: Small matrix multiplication (10x20 * 20x15)
+Mojo equivalent: Small matrix multiplication (10x20 * 20x30)
 MIND equivalent: benches/simple_benchmarks.rs - small_matmul
 """
 
@@ -14,7 +14,7 @@ fn matmul(a: List[Float32], b: List[Float32], mut c: List[Float32], M: Int, N: I
 
 fn main():
     var M = 10
-    var N = 15
+    var N = 30
     var K = 20
 
     var a = List[Float32](capacity=M * K)


### PR DESCRIPTION
- Fix matrix dimensions to match MIND benchmarks:
  - small_matmul: N=30 (was 15) for 10×20 × 20×30
  - medium_matmul: N=512 (was 64) for 128×256 × 256×512
  - large_matmul: N=512 (was 256) for 512×1024 × 1024×512
- Fix speedup interpretation: >1.0 means MIND is faster

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
