### PR TITLE
Format Rust code with cargo fmt

### DIFF
--- a/benches/autodiff.rs
+++ b/benches/autodiff.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use mind::{compile_source, differentiate_function, CompileOptions};
 
 /// Simple linear function
@@ -123,21 +123,15 @@ fn attention_qk(
 fn bench_autodiff_simple(c: &mut Criterion) {
     let mut group = c.benchmark_group("autodiff_simple");
 
-    for (name, source) in [
-        ("linear", LINEAR),
-        ("mse_loss", MSE_LOSS),
-    ] {
-        let products = compile_source(source, &CompileOptions::default())
-            .expect("compilation failed");
+    for (name, source) in [("linear", LINEAR), ("mse_loss", MSE_LOSS)] {
+        let products =
+            compile_source(source, &CompileOptions::default()).expect("compilation failed");
 
         group.bench_with_input(
             BenchmarkId::new("gradient_gen", name),
             &products.ir,
             |b, ir| {
-                b.iter(|| {
-                    differentiate_function(black_box(ir), "main")
-                        .expect("autodiff failed")
-                });
+                b.iter(|| differentiate_function(black_box(ir), "main").expect("autodiff failed"));
             },
         );
     }
@@ -148,21 +142,15 @@ fn bench_autodiff_simple(c: &mut Criterion) {
 fn bench_autodiff_mlp(c: &mut Criterion) {
     let mut group = c.benchmark_group("autodiff_mlp");
 
-    for (name, source) in [
-        ("two_layer", TWO_LAYER_MLP),
-        ("five_layer", DEEP_NETWORK),
-    ] {
-        let products = compile_source(source, &CompileOptions::default())
-            .expect("compilation failed");
+    for (name, source) in [("two_layer", TWO_LAYER_MLP), ("five_layer", DEEP_NETWORK)] {
+        let products =
+            compile_source(source, &CompileOptions::default()).expect("compilation failed");
 
         group.bench_with_input(
             BenchmarkId::new("gradient_gen", name),
             &products.ir,
             |b, ir| {
-                b.iter(|| {
-                    differentiate_function(black_box(ir), "main")
-                        .expect("autodiff failed")
-                });
+                b.iter(|| differentiate_function(black_box(ir), "main").expect("autodiff failed"));
             },
         );
     }
@@ -173,17 +161,14 @@ fn bench_autodiff_mlp(c: &mut Criterion) {
 fn bench_autodiff_conv(c: &mut Criterion) {
     let mut group = c.benchmark_group("autodiff_conv");
 
-    let products = compile_source(CONV_NETWORK, &CompileOptions::default())
-        .expect("compilation failed");
+    let products =
+        compile_source(CONV_NETWORK, &CompileOptions::default()).expect("compilation failed");
 
     group.bench_with_input(
         BenchmarkId::new("gradient_gen", "conv_net"),
         &products.ir,
         |b, ir| {
-            b.iter(|| {
-                differentiate_function(black_box(ir), "main")
-                    .expect("autodiff failed")
-            });
+            b.iter(|| differentiate_function(black_box(ir), "main").expect("autodiff failed"));
         },
     );
 
@@ -198,17 +183,14 @@ fn bench_autodiff_complex_loss(c: &mut Criterion) {
         ("complex_multi_term", COMPLEX_LOSS),
         ("attention", ATTENTION_GRAD),
     ] {
-        let products = compile_source(source, &CompileOptions::default())
-            .expect("compilation failed");
+        let products =
+            compile_source(source, &CompileOptions::default()).expect("compilation failed");
 
         group.bench_with_input(
             BenchmarkId::new("gradient_gen", name),
             &products.ir,
             |b, ir| {
-                b.iter(|| {
-                    differentiate_function(black_box(ir), "main")
-                        .expect("autodiff failed")
-                });
+                b.iter(|| differentiate_function(black_box(ir), "main").expect("autodiff failed"));
             },
         );
     }
@@ -231,8 +213,7 @@ fn bench_autodiff_end_to_end(c: &mut Criterion) {
                 b.iter(|| {
                     let products = compile_source(black_box(src), &CompileOptions::default())
                         .expect("compilation failed");
-                    differentiate_function(&products.ir, "main")
-                        .expect("autodiff failed")
+                    differentiate_function(&products.ir, "main").expect("autodiff failed")
                 });
             },
         );

--- a/benches/compiler.rs
+++ b/benches/compiler.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use mind::{compile_source, CompileOptions};
 
 #[cfg(feature = "mlir-lowering")]
@@ -94,17 +94,14 @@ fn bench_mlir_lowering(c: &mut Criterion) {
         ("large_network", LARGE_NETWORK),
     ] {
         // Pre-compile to IR
-        let products = compile_source(source, &CompileOptions::default())
-            .expect("compilation failed");
+        let products =
+            compile_source(source, &CompileOptions::default()).expect("compilation failed");
 
         group.bench_with_input(
             BenchmarkId::new("ir_to_mlir", name),
             &products.ir,
             |b, ir| {
-                b.iter(|| {
-                    lower_to_mlir(black_box(ir), None)
-                        .expect("MLIR lowering failed")
-                });
+                b.iter(|| lower_to_mlir(black_box(ir), None).expect("MLIR lowering failed"));
             },
         );
     }
@@ -128,8 +125,7 @@ fn bench_end_to_end_compilation(c: &mut Criterion) {
                 b.iter(|| {
                     let products = compile_source(black_box(src), &CompileOptions::default())
                         .expect("compilation failed");
-                    lower_to_mlir(&products.ir, None)
-                        .expect("MLIR lowering failed")
+                    lower_to_mlir(&products.ir, None).expect("MLIR lowering failed")
                 });
             },
         );
@@ -148,17 +144,14 @@ fn bench_autodiff_generation(c: &mut Criterion) {
         ("loss_function", AUTODIFF_TARGET),
     ] {
         // Pre-compile to IR
-        let products = compile_source(source, &CompileOptions::default())
-            .expect("compilation failed");
+        let products =
+            compile_source(source, &CompileOptions::default()).expect("compilation failed");
 
         group.bench_with_input(
             BenchmarkId::new("generate_gradients", name),
             &products.ir,
             |b, ir| {
-                b.iter(|| {
-                    differentiate_function(black_box(ir), "main")
-                        .expect("autodiff failed")
-                });
+                b.iter(|| differentiate_function(black_box(ir), "main").expect("autodiff failed"));
             },
         );
     }
@@ -191,9 +184,6 @@ criterion_group!(
 );
 
 #[cfg(all(not(feature = "mlir-lowering"), not(feature = "autodiff")))]
-criterion_group!(
-    benches,
-    bench_compilation_pipeline
-);
+criterion_group!(benches, bench_compilation_pipeline);
 
 criterion_main!(benches);

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use mind::{compile_source, CompileOptions};
 
 /// Element-wise operations
@@ -106,20 +106,13 @@ fn residual_block(
 fn bench_elementwise_operations(c: &mut Criterion) {
     let mut group = c.benchmark_group("operations_elementwise");
 
-    for (name, source) in [
-        ("chain", ELEMENTWISE_CHAIN),
-        ("deep_nest", DEEP_NEST),
-    ] {
-        group.bench_with_input(
-            BenchmarkId::new("compile", name),
-            source,
-            |b, src| {
-                b.iter(|| {
-                    compile_source(black_box(src), &CompileOptions::default())
-                        .expect("compilation failed")
-                });
-            },
-        );
+    for (name, source) in [("chain", ELEMENTWISE_CHAIN), ("deep_nest", DEEP_NEST)] {
+        group.bench_with_input(BenchmarkId::new("compile", name), source, |b, src| {
+            b.iter(|| {
+                compile_source(black_box(src), &CompileOptions::default())
+                    .expect("compilation failed")
+            });
+        });
     }
 
     group.finish();
@@ -128,20 +121,13 @@ fn bench_elementwise_operations(c: &mut Criterion) {
 fn bench_indexing_operations(c: &mut Criterion) {
     let mut group = c.benchmark_group("operations_indexing");
 
-    for (name, source) in [
-        ("slice", INDEXING_OPS),
-        ("reduction_axes", REDUCTION_AXES),
-    ] {
-        group.bench_with_input(
-            BenchmarkId::new("compile", name),
-            source,
-            |b, src| {
-                b.iter(|| {
-                    compile_source(black_box(src), &CompileOptions::default())
-                        .expect("compilation failed")
-                });
-            },
-        );
+    for (name, source) in [("slice", INDEXING_OPS), ("reduction_axes", REDUCTION_AXES)] {
+        group.bench_with_input(BenchmarkId::new("compile", name), source, |b, src| {
+            b.iter(|| {
+                compile_source(black_box(src), &CompileOptions::default())
+                    .expect("compilation failed")
+            });
+        });
     }
 
     group.finish();
@@ -155,16 +141,12 @@ fn bench_neural_patterns(c: &mut Criterion) {
         ("attention", ATTENTION_PATTERN),
         ("residual_block", RESIDUAL_BLOCK),
     ] {
-        group.bench_with_input(
-            BenchmarkId::new("compile", name),
-            source,
-            |b, src| {
-                b.iter(|| {
-                    compile_source(black_box(src), &CompileOptions::default())
-                        .expect("compilation failed")
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("compile", name), source, |b, src| {
+            b.iter(|| {
+                compile_source(black_box(src), &CompileOptions::default())
+                    .expect("compilation failed")
+            });
+        });
     }
 
     group.finish();

--- a/benches/shapes.rs
+++ b/benches/shapes.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use mind::{compile_source, CompileOptions};
 
 /// Simple broadcasting scenarios
@@ -111,16 +111,12 @@ fn bench_shape_inference_broadcast(c: &mut Criterion) {
         ("complex", BROADCAST_COMPLEX),
         ("high_rank", HIGH_RANK),
     ] {
-        group.bench_with_input(
-            BenchmarkId::new("broadcast", name),
-            source,
-            |b, src| {
-                b.iter(|| {
-                    compile_source(black_box(src), &CompileOptions::default())
-                        .expect("compilation failed")
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("broadcast", name), source, |b, src| {
+            b.iter(|| {
+                compile_source(black_box(src), &CompileOptions::default())
+                    .expect("compilation failed")
+            });
+        });
     }
 
     group.finish();
@@ -129,20 +125,13 @@ fn bench_shape_inference_broadcast(c: &mut Criterion) {
 fn bench_shape_inference_reductions(c: &mut Criterion) {
     let mut group = c.benchmark_group("shape_inference_reductions");
 
-    for (name, source) in [
-        ("chain", REDUCTIONS),
-        ("transforms", SHAPE_TRANSFORMS),
-    ] {
-        group.bench_with_input(
-            BenchmarkId::new("reduction", name),
-            source,
-            |b, src| {
-                b.iter(|| {
-                    compile_source(black_box(src), &CompileOptions::default())
-                        .expect("compilation failed")
-                });
-            },
-        );
+    for (name, source) in [("chain", REDUCTIONS), ("transforms", SHAPE_TRANSFORMS)] {
+        group.bench_with_input(BenchmarkId::new("reduction", name), source, |b, src| {
+            b.iter(|| {
+                compile_source(black_box(src), &CompileOptions::default())
+                    .expect("compilation failed")
+            });
+        });
     }
 
     group.finish();
@@ -157,16 +146,12 @@ fn bench_shape_inference_matmul(c: &mut Criterion) {
         ("1024x2048", MATMUL_LARGE),
         ("batched_32x128x256", MATMUL_BATCHED),
     ] {
-        group.bench_with_input(
-            BenchmarkId::new("matmul", name),
-            source,
-            |b, src| {
-                b.iter(|| {
-                    compile_source(black_box(src), &CompileOptions::default())
-                        .expect("compilation failed")
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("matmul", name), source, |b, src| {
+            b.iter(|| {
+                compile_source(black_box(src), &CompileOptions::default())
+                    .expect("compilation failed")
+            });
+        });
     }
 
     group.finish();
@@ -175,20 +160,13 @@ fn bench_shape_inference_matmul(c: &mut Criterion) {
 fn bench_shape_inference_conv(c: &mut Criterion) {
     let mut group = c.benchmark_group("shape_inference_conv");
 
-    for (name, source) in [
-        ("3x3_stride1", CONV_3x3),
-        ("5x5_stride2", CONV_5x5),
-    ] {
-        group.bench_with_input(
-            BenchmarkId::new("conv2d", name),
-            source,
-            |b, src| {
-                b.iter(|| {
-                    compile_source(black_box(src), &CompileOptions::default())
-                        .expect("compilation failed")
-                });
-            },
-        );
+    for (name, source) in [("3x3_stride1", CONV_3x3), ("5x5_stride2", CONV_5x5)] {
+        group.bench_with_input(BenchmarkId::new("conv2d", name), source, |b, src| {
+            b.iter(|| {
+                compile_source(black_box(src), &CompileOptions::default())
+                    .expect("compilation failed")
+            });
+        });
     }
 
     group.finish();

--- a/benches/simple_benchmarks.rs
+++ b/benches/simple_benchmarks.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use mind::{compile_source, CompileOptions};
 
 /// Benchmark source programs that are known to work
@@ -62,12 +62,16 @@ fn bench_compile_small(c: &mut Criterion) {
     let mut group = c.benchmark_group("compile_small");
 
     for &(name, source) in &PROGRAMS[0..3] {
-        group.bench_with_input(BenchmarkId::new("parse_check_lower", name), &source, |b, src| {
-            b.iter(|| {
-                compile_source(black_box(src), &CompileOptions::default())
-                    .expect("compilation failed")
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("parse_check_lower", name),
+            &source,
+            |b, src| {
+                b.iter(|| {
+                    compile_source(black_box(src), &CompileOptions::default())
+                        .expect("compilation failed")
+                });
+            },
+        );
     }
 
     group.finish();
@@ -77,12 +81,16 @@ fn bench_compile_medium(c: &mut Criterion) {
     let mut group = c.benchmark_group("compile_medium");
 
     for &(name, source) in &PROGRAMS[3..] {
-        group.bench_with_input(BenchmarkId::new("parse_check_lower", name), &source, |b, src| {
-            b.iter(|| {
-                compile_source(black_box(src), &CompileOptions::default())
-                    .expect("compilation failed")
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("parse_check_lower", name),
+            &source,
+            |b, src| {
+                b.iter(|| {
+                    compile_source(black_box(src), &CompileOptions::default())
+                        .expect("compilation failed")
+                });
+            },
+        );
     }
 
     group.finish();

--- a/src/autodiff/rules.rs
+++ b/src/autodiff/rules.rs
@@ -58,12 +58,12 @@ pub(super) fn apply_rule(
             Ok(())
         }
         Instr::Conv2d { .. } => Err(AutodiffError::UnsupportedOp { op: "conv2d" }),
-        Instr::Conv2dGradInput { .. } => {
-            Err(AutodiffError::UnsupportedOp { op: "conv2d_grad_input" })
-        }
-        Instr::Conv2dGradFilter { .. } => {
-            Err(AutodiffError::UnsupportedOp { op: "conv2d_grad_filter" })
-        }
+        Instr::Conv2dGradInput { .. } => Err(AutodiffError::UnsupportedOp {
+            op: "conv2d_grad_input",
+        }),
+        Instr::Conv2dGradFilter { .. } => Err(AutodiffError::UnsupportedOp {
+            op: "conv2d_grad_filter",
+        }),
         Instr::Dot { a, b, .. } => {
             let da = ops.add_binop(BinOp::Mul, upstream, *b);
             let db = ops.add_binop(BinOp::Mul, upstream, *a);


### PR DESCRIPTION
Run cargo fmt --all to fix formatting issues in benchmarks and autodiff rules.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
