### PR TITLE
fix: address Copilot review feedback on conv2d benchmark

### DIFF
--- a/benchmarks/SAME_MACHINE_BENCHMARKS.md
+++ b/benchmarks/SAME_MACHINE_BENCHMARKS.md
@@ -271,13 +271,15 @@ Possible issues:
    - Code now checks for both `mind` and `mind.exe` on Windows
 
 2. **Conv2D Not Equivalent** (FIXED)
-   - Removed conv2d benchmark from both PyTorch and JAX comparisons
-   - MIND's conv2d implementation is incomplete
-   - Original benchmark was comparing apples-to-oranges (ReLU vs Conv2d+BatchNorm+ReLU)
+   - Updated conv2d benchmark to be properly equivalent across all frameworks
+   - MIND uses NHWC format: conv2d + bias + ReLU
+   - PyTorch uses NCHW format: Conv2d(64,64,3) + bias + ReLU
+   - JAX uses NHWC format: conv + bias + ReLU (matches MIND)
+   - Fixed MIND syntax: `add()` → `+` operator
 
 3. **Batch Size Inconsistency** (RESOLVED)
-   - Fixed by removing conv2d benchmark
-   - All remaining benchmarks use consistent shapes
+   - All benchmarks now use batch size of 8 for conv2d
+   - Consistent shapes across all frameworks
 
 ### **📋 Remaining Benchmarks**
 
@@ -287,6 +289,7 @@ After fixes, both PyTorch and JAX benchmarks include:
 - `medium_matmul`: 128×256 @ 256×512 matrix multiplication
 - `large_matmul`: 512×1024 @ 1024×512 matrix multiplication
 - `simple_mlp`: 2-layer neural network with ReLU
+- `conv2d`: 2D convolution (8×56×56×64) + bias + ReLU
 
 All with properly equivalent MIND programs.
 

--- a/benchmarks/jax_comparison/benchmark_jax_compile.py
+++ b/benchmarks/jax_comparison/benchmark_jax_compile.py
@@ -110,7 +110,7 @@ def measure_mind_compile_time(program_name: str, num_samples: int = 20) -> float
     mind_binary_base = Path(__file__).parent.parent.parent / "target" / "release" / "mind"
 
     # Handle Windows .exe extension
-    if platform.system().lower().startswith("win"):
+    if platform.system() == "Windows":
         mind_binary = mind_binary_base.with_suffix(".exe")
         if not mind_binary.exists():
             mind_binary = mind_binary_base

--- a/benchmarks/pytorch_comparison/benchmark_pytorch_compile.py
+++ b/benchmarks/pytorch_comparison/benchmark_pytorch_compile.py
@@ -123,7 +123,7 @@ def measure_mind_compile_time(program_name, num_samples=20):
     mind_binary_base = Path(__file__).parent.parent.parent / "target" / "release" / "mind"
 
     # Handle Windows .exe extension
-    if platform.system().lower().startswith("win"):
+    if platform.system() == "Windows":
         mind_binary = mind_binary_base.with_suffix(".exe")
         if not mind_binary.exists():
             mind_binary = mind_binary_base


### PR DESCRIPTION
Fixes all 5 issues from Copilot review of PR #175:

**1-2. Platform Detection (More Precise)**:
- Changed `platform.system().lower().startswith("win")` to exact match
- Now uses `platform.system() == "Windows"`
- Prevents hypothetical false matches (e.g., "winux")
- More explicit and precise platform detection

**3-5. Documentation Accuracy**:
- Updated to reflect that conv2d benchmark was ADDED, not removed
- Corrected description of fix: "Updated to be equivalent" vs "Removed"
- Added conv2d to the list of 6 benchmarks included in both PyTorch and JAX
- Documentation now matches actual code changes

**Files Changed**:
- benchmarks/pytorch_comparison/benchmark_pytorch_compile.py
- benchmarks/jax_comparison/benchmark_jax_compile.py
- benchmarks/SAME_MACHINE_BENCHMARKS.md

All Copilot concerns addressed with more precise and accurate code + docs.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
