### PR TITLE
fix: address Copilot docstring and README issues in autograd benchmark

### DIFF
--- a/benchmarks/autograd_comparison/README_REAL.md
+++ b/benchmarks/autograd_comparison/README_REAL.md
@@ -40,8 +40,10 @@ python benchmark_real_autograd.py
 ## Expected Output
 
 ```
-=== AUTODIFF COMPARISON: MIND vs PyTorch ===
+================================================================================
+AUTODIFF COMPARISON: MIND vs PyTorch
 (Both measured on the SAME machine)
+================================================================================
 
 MIND: Compile-time autodiff (gradient IR generation)
 PyTorch: Runtime autodiff (backward pass execution)

--- a/benchmarks/autograd_comparison/benchmark_real_autograd.py
+++ b/benchmarks/autograd_comparison/benchmark_real_autograd.py
@@ -47,7 +47,10 @@ def measure_pytorch_backward(forward_fn, device="cpu"):
     """
     Measure PyTorch backward pass time (runtime autodiff).
 
-    Returns (time_us, memory_bytes).
+    Returns:
+        Dict[str, float]: A dictionary with:
+            - "time_mean_us": Mean backward pass time in microseconds.
+            - "time_stdev_us": Standard deviation of backward pass time in microseconds.
     """
     times = []
 
@@ -86,7 +89,10 @@ def measure_mind_autodiff_time(program: str, num_samples: int = 20):
     1. Compile the forward pass
     2. Generate gradient IR
 
-    Returns compilation time in microseconds.
+    Returns:
+        Dict[str, float]: A dictionary with compilation time statistics in microseconds:
+            - "time_mean_us": Mean compilation time
+            - "time_stdev_us": Standard deviation of compilation time
     """
     mind_binary = Path(__file__).parent.parent.parent / "target" / "release" / "mind"
     if not mind_binary.exists():


### PR DESCRIPTION
Fixes all 3 issues from Copilot review of PR #177:

**Issue 1 - measure_pytorch_backward docstring**:
- Changed from: "Returns (time_us, memory_bytes)"
- Changed to: Proper dict return type documentation
- Now accurately describes the dict with "time_mean_us" and "time_stdev_us"

**Issue 2 - measure_mind_autodiff_time docstring**:
- Changed from: "Returns compilation time in microseconds"
- Changed to: Proper dict return type documentation
- Now accurately describes the dict structure with mean and stdev

**Issue 3 - README output format**:
- Updated example output to match actual code format
- Changed from: "=== AUTODIFF COMPARISON ... ==="
- Changed to: 80 equals signs on separate lines (matches code at lines 210-213)
- Example output now accurately reflects what users will see

All docstrings and documentation now match actual implementation.

## Summary
<what changed>

## Testing
- [ ] cargo fmt --check
- [ ] cargo check --no-default-features
- [ ] cargo test --no-default-features
- [ ] cargo clippy --no-default-features -- -D warnings
- [ ] cargo deny check
