### PR TITLE
perf(compiler): eliminate 3 redundant clones on hot paths (byte-neutral)

### DIFF
--- a/src/eval/lower.rs
+++ b/src/eval/lower.rs
@@ -6153,8 +6153,7 @@ fn lower_expr(
             // unique and disjoint from the parent scope's ids (especially fn
             // parameters which occupy the lowest ids).
             let mut cond_ir = sub_ir_from(ir);
-            let cond_env = env.clone();
-            let cond_id = lower_expr(cond, &mut cond_ir, &cond_env, struct_env, receiver_types);
+            let cond_id = lower_expr(cond, &mut cond_ir, env, struct_env, receiver_types);
 
             // ── 2. Lower the then-branch into a scratch sub-module ────────────
             //      Starts from cond_ir's highest id.
@@ -7289,8 +7288,7 @@ fn lower_expr(
             let mut cond_ir = IRModule::new();
             // Seed the condition sub-module's env with the current bindings
             // so identifiers in the condition (e.g. `i`, `n`) resolve.
-            let cond_env = seed_env.clone();
-            let cond_id = lower_expr(cond, &mut cond_ir, &cond_env, struct_env, receiver_types);
+            let cond_id = lower_expr(cond, &mut cond_ir, &seed_env, struct_env, receiver_types);
 
             // Lower the body into a scratch sub-module.  Track every Assign
             // target — those are the variables that are live across the

--- a/src/ir/compact/v3/emit.rs
+++ b/src/ir/compact/v3/emit.rs
@@ -732,9 +732,9 @@ pub fn emit_mic3(module: &IRModule) -> Vec<u8> {
     out.write_all(&[MIC3_VERSION]).unwrap();
 
     // String table
-    let entries = st.entries().to_vec();
+    let entries = st.entries();
     uleb128_write(&mut out, entries.len() as u64).unwrap();
-    for s in &entries {
+    for s in entries {
         let b = s.as_bytes();
         uleb128_write(&mut out, b.len() as u64).unwrap();
         out.write_all(b).unwrap();


### PR DESCRIPTION
First increment of the mindc compile-speed lever campaign (25 wedge-safe levers cataloged by a 6-analyst Workflow + grok cross-family; see backlog).

**Two byte-identity-neutral levers** — the front-end emits no artifact bytes (mic@3 comes from the post-lowering IRModule), so removing these clones cannot change output:
- `src/ir/compact/v3/emit.rs`: drop the `st.entries().to_vec()` clone in emit_mic3 → iterate the borrowed `&[String]`. Removes N String heap-clones + a Vec alloc per emit_mic3; also lightens ir_trace_hash.
- `src/eval/lower.rs`: remove the two redundant immutable cond_env clones in the If/While lowering paths (each fed one immutable-borrow lower_expr call). One fewer whole-env HashMap deep-clone per if/while in the hot lowering loop.

**Byte-neutrality proven:** keystone `phase_g_keystone_bootstrap` is **7/7 byte-identical** post-change; build clean. Compile-speed is authoritatively measured by the **Pipeline regression gate (+10% one-sided)** on the dedicated CI runner — a local bench on the shared build box was load-confounded and is not used for the verdict.

The flagship lever (box `ast::Node`'s large variants, 144B→~64B — cross-family #1) is a larger dedicated slice touching 130+ match sites; deferred to its own systematic PR.