### PR TITLE
perf(type-checker): FxHash sym_env + annots hot maps (byte-neutral)

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind`
-**Files:** 3339 | **Est. tokens:** ~7,812,051
-**Generated:** 2026-08-06 06:43 UTC
+**Files:** 3339 | **Est. tokens:** ~7,812,048
+**Generated:** 2026-08-06 11:33 UTC
 
 ## Token Budget Guide
 
@@ -396,7 +396,7 @@
 | `src/ir/` | 5 | ~47,725 |
 | `src/ir/compact/` | 3 | ~15,271 |
 | `src/ir/compact/v2/` | 8 | ~38,404 |
-| `src/ir/compact/v3/` | 6 | ~49,105 |
+| `src/ir/compact/v3/` | 6 | ~49,102 |
 | `src/lint/` | 2 | ~4,001 |
 | `src/lint/rules/` | 6 | ~9,880 |
 | `src/mlir/` | 3 | ~5,905 |
@@ -4005,7 +4005,7 @@
 
 - `collapse_receipt.rs` (~5109 tok, huge) — Copyright 2025 STARGA Inc.
 - `ed25519.rs` (~6051 tok, huge) — Copyright 2025 STARGA Inc.
-- `emit.rs` (~11038 tok, huge) — Copyright 2025 STARGA Inc.
+- `emit.rs` (~11035 tok, huge) — Copyright 2025 STARGA Inc.
 - `mldsa.rs` (~1510 tok, huge) — Copyright 2025 STARGA Inc.
 - `mod.rs` (~13865 tok, huge) — Copyright 2025 STARGA Inc.
 - `parse.rs` (~11532 tok, huge) — Copyright 2025 STARGA Inc.

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -5156,7 +5156,7 @@ fn check_call_symbolic_dims(
     };
     // Bind symbol names to concrete sizes by walking (arg_position, tensor_param) entries.
     // sym_env: symbol_name → (bound_concrete_size, first_binding_param_name)
-    let mut sym_env: HashMap<String, (usize, String)> = HashMap::new();
+    let mut sym_env: HashMap<String, (usize, String), FxBuild> = HashMap::default();
     for (arg_pos, param_name, dims, _dtype) in tensor_params {
         // Argument at the declared position — skip if out of range.
         let Some(arg) = args.get(*arg_pos) else {
@@ -5493,7 +5493,7 @@ fn check_determinism_annotations(
 
     // Pre-scan: every user-defined function's annotation state, so the
     // determinism call-graph check can resolve callees within this module.
-    let mut annots: HashMap<&str, FnAnnot> = HashMap::new();
+    let mut annots: HashMap<&str, FnAnnot, FxBuild> = HashMap::default();
     for item in &fndefs {
         if let Node::FnDef(fd, _) = item {
             let name = &fd.name;


### PR DESCRIPTION
Next compile-speed lever increment. The type checker's `sym_env` and `annots` maps used default SipHash; both are grep-confirmed lookup/insert-only (no iteration into output), so switching to the in-file `FxBuild` hasher is byte-identity-neutral. **keystone 7/7 byte-identical**; CI's Pipeline regression gate measures the compile-speed. Part of the 25-lever campaign (flagship Node-boxing deferred to its own systematic slice).