### PR TITLE
perf(ast): box Closure — Node 144→≤128 bytes (byte-neutral)

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind`
-**Files:** 3339 | **Est. tokens:** ~7,812,048
-**Generated:** 2026-08-06 11:33 UTC
+**Files:** 3339 | **Est. tokens:** ~7,812,164
+**Generated:** 2026-08-06 12:33 UTC
 
 ## Token Budget Guide
 
@@ -378,7 +378,7 @@
 | `sdk/ts/mic-map/test/fixtures/` | 2 | ~96 |
 | `skills/write-mind/` | 1 | ~6,002 |
 | `src/` | 7 | ~18,597 |
-| `src/ast/` | 1 | ~10,100 |
+| `src/ast/` | 1 | ~10,205 |
 | `src/autodiff/` | 3 | ~6,624 |
 | `src/bin/` | 1 | ~9,878 |
 | `src/build/` | 2 | ~16,852 |
@@ -388,11 +388,11 @@
 | `src/diagnostics/` | 1 | ~3,719 |
 | `src/distributed/` | 6 | ~7,433 |
 | `src/doc/` | 3 | ~10,987 |
-| `src/eval/` | 15 | ~80,351 |
+| `src/eval/` | 15 | ~80,345 |
 | `src/eval/stdlib/` | 2 | ~8,529 |
 | `src/exec/` | 3 | ~4,592 |
 | `src/ffi/` | 3 | ~3,919 |
-| `src/fmt/` | 3 | ~21,719 |
+| `src/fmt/` | 3 | ~21,737 |
 | `src/ir/` | 5 | ~47,725 |
 | `src/ir/compact/` | 3 | ~15,271 |
 | `src/ir/compact/v2/` | 8 | ~38,404 |
@@ -410,7 +410,7 @@
 | `src/shapes/` | 2 | ~6,052 |
 | `src/stdlib/` | 2 | ~560 |
 | `src/test/` | 1 | ~5,979 |
-| `src/type_checker/` | 1 | ~15,096 |
+| `src/type_checker/` | 1 | ~15,095 |
 | `src/types/` | 4 | ~3,336 |
 | `src/workspace/` | 1 | ~4,906 |
 | `std/` | 41 | ~198,092 |
@@ -3902,7 +3902,7 @@
 - `SKILL.md` (~6002 tok, huge) — Write MIND Code
 ### `src/ast/`
 
-- `mod.rs` (~10100 tok, huge) — Copyright 2025 STARGA Inc.
+- `mod.rs` (~10205 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/autodiff/`
 
 - `engine.rs` (~3890 tok, huge) — Copyright 2025 STARGA Inc.
@@ -3952,7 +3952,7 @@
 
 - `abi_gate.rs` (~12049 tok, huge) — Runnable-artifact ABI gate (release-readiness P1.1).
 - `autodiff.rs` (~14268 tok, huge) — Copyright 2025 STARGA Inc.
-- `closures.rs` (~6915 tok, huge) — Copyright 2025 STARGA Inc.
+- `closures.rs` (~6911 tok, huge) — Copyright 2025 STARGA Inc.
 - `conv2d_grad.rs` (~2397 tok, huge) — Copyright 2025 STARGA Inc.
 - `ir_interp.rs` (~3818 tok, huge) — Copyright 2025 STARGA Inc.
 - `mlir_build.rs` (~9421 tok, huge) — Copyright 2025 STARGA Inc.
@@ -3961,7 +3961,7 @@
 - `mlir_jit.rs` (~501 tok, large) — Copyright 2025 STARGA Inc.
 - `mlir_opt.rs` (~995 tok, large) — Copyright 2025 STARGA Inc.
 - `mlir_run.rs` (~1535 tok, huge) — Copyright 2025 STARGA Inc.
-- `narrow_scan.rs` (~3011 tok, huge) — Module-wide narrow-int SURFACE prescan (compile-speed early-skip).
+- `narrow_scan.rs` (~3009 tok, huge) — Module-wide narrow-int SURFACE prescan (compile-speed early-skip).
 ### `src/eval/stdlib/`
 
 - `mod.rs` (~169 tok, small) — Copyright 2025 STARGA Inc.
@@ -3985,7 +3985,7 @@
 
 - `cli.rs` (~3873 tok, huge) — Copyright 2025 STARGA Inc.
 - `mod.rs` (~594 tok, large) — Copyright 2025 STARGA Inc.
-- `printer.rs` (~17252 tok, huge) — Copyright 2025 STARGA Inc.
+- `printer.rs` (~17270 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/ir/compact/`
 
 - `emit.rs` (~4693 tok, huge) — Copyright 2025 STARGA Inc.
@@ -4099,7 +4099,7 @@
 - `mod.rs` (~5979 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/type_checker/`
 
-- `resolve.rs` (~15096 tok, huge) — Copyright 2025 STARGA Inc.
+- `resolve.rs` (~15095 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/types/`
 
 - `infer.rs` (~448 tok, medium) — Copyright 2025 STARGA Inc.

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -283,6 +283,20 @@ pub struct Param {
 /// This is purely an internal memory-layout change: lowering/codegen read the
 /// same field values, so no emitted byte changes.
 #[derive(Debug, Clone, PartialEq)]
+pub struct ClosureData {
+    pub captures: Vec<String>,
+    pub params: Vec<Param>,
+    pub ret_type: Option<TypeAnn>,
+    pub body: Vec<Node>,
+}
+
+// Regression guard: boxing the fattest variants keeps `ast::Node` small on the
+// hot parse path (every parse_pratt/parse_atom return memmoves the max-variant
+// width). Closure's ~144B payload is now behind a `Box`; a future inline fat
+// variant that regrows Node past this bound fails the build here.
+const _: () = assert!(std::mem::size_of::<Node>() <= 128);
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct FnDefData {
     /// Whether the `pub` visibility modifier was present in source.
     pub is_pub: bool,
@@ -838,13 +852,7 @@ pub enum Node {
     /// Non-gated (unlike `While`/`Region`) so no `#[cfg]` mismatch can arise
     /// between feature configs; the desugar output (structs/fns) is what a
     /// std-surface build actually lowers.
-    Closure {
-        captures: Vec<String>,
-        params: Vec<Param>,
-        ret_type: Option<TypeAnn>,
-        body: Vec<Node>,
-        span: Span,
-    },
+    Closure(Box<ClosureData>, Span),
     /// Trait declaration (#268 Phase 1): `trait T { fn m(self, ...) -> R }`.
     ///
     /// A trait is a NAMED set of method signatures — a static contract only.
@@ -1088,7 +1096,7 @@ impl Node {
             Node::Break { span } | Node::Continue { span } => *span,
             #[cfg(feature = "std-surface")]
             Node::Region { span, .. } => *span,
-            Node::Closure { span, .. } => *span,
+            Node::Closure(_, span) => *span,
             Node::TraitDef { span, .. } | Node::ImplBlock { span, .. } => *span,
         }
     }

--- a/src/eval/closures.rs
+++ b/src/eval/closures.rs
@@ -95,7 +95,7 @@ fn desugar_fn_body(
     for stmt in body.iter_mut() {
         // `let f = |caps; params| ...` — the sole Phase-1 binding shape.
         if let Node::Let { name, value, .. } = stmt {
-            if let Node::Closure { .. } = value.as_ref() {
+            if let Node::Closure(..) = value.as_ref() {
                 match build_closure_items(value, synthesized, source, file) {
                     Ok((fn_name, struct_lit)) => {
                         closure_fns.insert(name.clone(), fn_name);
@@ -127,13 +127,13 @@ fn build_closure_items(
     file: Option<&str>,
 ) -> Result<(String, Node), Diagnostic> {
     let (captures, params, ret_type, cbody, span) = match closure {
-        Node::Closure {
-            captures,
-            params,
-            ret_type,
-            body,
-            span,
-        } => (captures, params, ret_type, body, *span),
+        Node::Closure(data, span) => (
+            &data.captures,
+            &data.params,
+            &data.ret_type,
+            &data.body,
+            *span,
+        ),
         _ => unreachable!("build_closure_items called on non-closure"),
     };
     // Phase-1 support boundary — EXACTLY one capture and one param. Multi-capture
@@ -478,7 +478,7 @@ fn node_children_mut(node: &mut Node) -> Vec<&mut Node> {
         // ── Leaves / different-scope boundaries (nothing to rewrite) ─────
         Node::Lit(..)
         | Node::FnDef(..)
-        | Node::Closure { .. }
+        | Node::Closure(..)
         | Node::TraitDef { .. }
         | Node::ImplBlock { .. }
         | Node::Import { .. }
@@ -506,7 +506,7 @@ fn node_has_closure(node: &Node) -> bool {
 /// the extra bodies that set omits (FnDef/While/closure bodies), so a survivor
 /// in any position is detected.
 fn find_closure_span(node: &Node) -> Option<Span> {
-    if let Node::Closure { span, .. } = node {
+    if let Node::Closure(_, span) = node {
         return Some(*span);
     }
     // FnDef / closure bodies are not in `node_children` (immutable variant):
@@ -519,8 +519,8 @@ fn find_closure_span(node: &Node) -> Option<Span> {
                 }
             }
         }
-        Node::Closure { body, .. } => {
-            for n in body {
+        Node::Closure(data, _) => {
+            for n in &data.body {
                 if let Some(sp) = find_closure_span(n) {
                     return Some(sp);
                 }
@@ -684,7 +684,7 @@ pub(crate) fn node_children_ref(node: &Node) -> Vec<&Node> {
         Node::Region { body, .. } => out.extend(body.iter()),
         Node::Lit(..)
         | Node::FnDef(..)
-        | Node::Closure { .. }
+        | Node::Closure(..)
         | Node::TraitDef { .. }
         | Node::ImplBlock { .. }
         | Node::Import { .. }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1965,7 +1965,7 @@ pub(crate) fn eval_value_expr_mode(
         // codegen path: a region evaluates to its last expression.
         // #267: a raw closure is desugared before lowering; the tree-eval
         // interpreter never executes one (fail-closed).
-        Node::Closure { .. } => Err(EvalError::UnsupportedMsg(
+        Node::Closure(..) => Err(EvalError::UnsupportedMsg(
             "closures are desugared before evaluation; a raw closure cannot be interpreted".into(),
         )),
         // #268: trait/impl declarations are desugared (impls to free fns, traits

--- a/src/eval/narrow_scan.rs
+++ b/src/eval/narrow_scan.rs
@@ -225,12 +225,11 @@ fn node_mentions_narrow(node: &Node) -> bool {
             .iter()
             .any(|ef| params_mention_narrow(&ef.params) || opt_ty_mentions_narrow(&ef.ret_type)),
         Node::Region { body, .. } => any(body),
-        Node::Closure {
-            params,
-            ret_type,
-            body,
-            ..
-        } => params_mention_narrow(params) || opt_ty_mentions_narrow(ret_type) || any(body),
+        Node::Closure(data, _) => {
+            params_mention_narrow(&data.params)
+                || opt_ty_mentions_narrow(&data.ret_type)
+                || any(&data.body)
+        }
         Node::TraitDef { methods, .. } => methods
             .iter()
             .any(|m| params_mention_narrow(&m.params) || opt_ty_mentions_narrow(&m.ret_type)),

--- a/src/fmt/printer.rs
+++ b/src/fmt/printer.rs
@@ -1708,13 +1708,13 @@ fn emit_expr(p: &mut Printer, node: &Node) {
         }
         // #267: closure `|caps; params| -> R { body }`. `mindc fmt` runs on the
         // pre-desugar AST, so a source closure round-trips through this emitter.
-        Node::Closure {
-            captures,
-            params,
-            ret_type,
-            body,
-            span,
-        } => {
+        Node::Closure(data, span) => {
+            let crate::ast::ClosureData {
+                captures,
+                params,
+                ret_type,
+                body,
+            } = data.as_ref();
             p.push("|");
             for (i, c) in captures.iter().enumerate() {
                 if i > 0 {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3063,13 +3063,15 @@ impl<'a> P<'a> {
         self.skip_ws_and_newlines();
         self.expect(b'}')?;
         let span = Span::new(start, self.pos);
-        Ok(Node::Closure {
-            captures,
-            params,
-            ret_type,
-            body,
+        Ok(Node::Closure(
+            Box::new(crate::ast::ClosureData {
+                captures,
+                params,
+                ret_type,
+                body,
+            }),
             span,
-        })
+        ))
     }
 
     fn parse_param(&mut self) -> Result<Param, ParseError> {

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -2074,7 +2074,7 @@ fn infer_expr(node: &Node, env: &TypeEnv) -> Result<(ValueType, AstSpan), TypeEr
         // struct literal) BEFORE type inference runs, so a raw `Closure` should
         // never reach here. Fail closed with a TypeError rather than a benign
         // scalar placeholder that could mask a missed desugar.
-        Node::Closure { span, .. } => Err(TypeErrSpan {
+        Node::Closure(_, span) => Err(TypeErrSpan {
             msg: "internal: closure reached type inference before desugaring".to_string(),
             span: *span,
         }),

--- a/src/type_checker/resolve.rs
+++ b/src/type_checker/resolve.rs
@@ -1264,7 +1264,7 @@ impl<'a> Resolver<'a> {
             // references inside a fn body (or are handled at module level).
             Node::FnDef(..)
             // #267: closures are desugared before the resolver runs.
-            | Node::Closure { .. }
+            | Node::Closure(..)
             // #268: trait/impl are desugared (impls to free fns, traits dropped)
             // before the resolver runs.
             | Node::TraitDef { .. }


### PR DESCRIPTION
Flagship compile-speed lever (cross-family #1). `Node::Closure` was the fattest variant (~144B) after the FnDef boxing; every parse return + `Vec<Node>` growth memmoves the max-variant width on the hot front-end path. Boxing its payload into `ClosureData` (`Node::Closure(Box<ClosureData>, Span)`, mirroring FnDef) drops `size_of::<Node>` to **≤128B**, pinned by a compile-time regression guard.

Internal memory-layout only — no emitter serializes AST layout. **Byte-neutral proven: keystone 7/7 byte-identical + cross_substrate 24/24**; the `size_of::<Node> <= 128` assertion compiles. Bounded one-variant slice (14 sites); Const/TypeAlias are follow-ups. CI's Pipeline regression gate measures the compile-speed on the clean runner.