### PR TITLE
perf(compiler): FxHash two remaining hot membership maps (byte-neutral)

### DIFF
--- a/src/ir/compact/v3/emit.rs
+++ b/src/ir/compact/v3/emit.rs
@@ -332,14 +332,19 @@ pub(super) fn encode_type_ann<W: Write>(
 /// we traverse `module.instrs` sequentially).
 pub(super) struct StringTable {
     entries: Vec<String>,
-    index: HashMap<String, usize>,
+    // Dedup index: string -> its position in `entries`. `entries` (a Vec) is the
+    // ordered serialized output; this map is only ever `get`/`insert`/`contains_key`,
+    // never iterated, so the hasher choice is byte-neutral. Use the crate's FxHash
+    // to drop the default SipHash cost on the mic@3 emit hot path (also speeds
+    // `ir_trace_hash`, which re-emits mic@3).
+    index: HashMap<String, usize, crate::type_checker::FxBuild>,
 }
 
 impl StringTable {
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
-            index: HashMap::new(),
+            index: HashMap::default(),
         }
     }
 

--- a/src/type_checker/resolve.rs
+++ b/src/type_checker/resolve.rs
@@ -214,7 +214,12 @@ struct ModuleSyms {
     /// type-alias names, minus any name that also has a function definition.
     /// A call whose callee resolves only to one of these targets a data/global
     /// symbol; see `is_module_non_fn_call`.
-    non_fn_decls: BTreeSet<String>,
+    ///
+    /// Membership-only (`contains` / `retain`), never iterated in a way that
+    /// reaches emitted output or diagnostic order, so an `FxSet` (matching the
+    /// `names`/`enums` siblings) is byte-neutral and drops the per-`contains`
+    /// O(log n) BTree string-compare to O(1).
+    non_fn_decls: FxSet,
 }
 
 impl ModuleSyms {
@@ -321,11 +326,7 @@ fn collect_enum_variants(module: &Module, out: &mut FxMap<FxSet>) {
 /// recorded in `fns` so a name that also has a function definition is never
 /// treated as a non-function (defensive against a same-name redeclaration).
 /// Recurses into `module { }` blocks exactly like `collect_decl_names`.
-fn collect_non_fn_decl_names(
-    module: &Module,
-    out: &mut BTreeSet<String>,
-    fns: &mut BTreeSet<String>,
-) {
+fn collect_non_fn_decl_names(module: &Module, out: &mut FxSet, fns: &mut FxSet) {
     for item in &module.items {
         match item {
             Node::FnDef(fd, _) => {
@@ -441,8 +442,8 @@ fn collect_module_syms(module: &Module, injected: &BTreeSet<String>) -> ModuleSy
     // data/global symbol (const/let/struct/enum-type/type-alias) rather than a
     // function. Function names are collected alongside and subtracted so a name
     // that also has a `fn` definition is never treated as a non-function.
-    let mut non_fn_decls: BTreeSet<String> = BTreeSet::new();
-    let mut fn_decls: BTreeSet<String> = BTreeSet::new();
+    let mut non_fn_decls: FxSet = FxSet::default();
+    let mut fn_decls: FxSet = FxSet::default();
     collect_non_fn_decl_names(module, &mut non_fn_decls, &mut fn_decls);
     non_fn_decls.retain(|n| !fn_decls.contains(n));
     ModuleSyms {


### PR DESCRIPTION
Two independent byte-neutral compile-speed levers on hot paths still using default SipHash (levers #9/#10 from the backlog):

- **resolve.rs** `non_fn_decls`/`fn_decls`: `BTreeSet<String>` → `FxSet`. Membership-only (`contains`/`retain`), never order-iterated into output/diagnostics → byte-neutral; drops per-`contains` O(log n) BTree string-compare to O(1). Matches the `names`/`enums` siblings on the same struct.
- **emit.rs** StringTable dedup `index`: `HashMap<String,usize>` → FxHash. `entries` Vec is the ordered serialized output; `index` is only get/insert/contains_key, never iterated → hasher choice cannot move a byte. On the mic@3 emit hot path (every interned string); also speeds `ir_trace_hash`.

**Byte-neutral proven: keystone 7/7 + cross_substrate 24/24**; `cargo check --no-default-features` clean. Follows the FxBuild pattern from PR #219 (sym_env/annots). CI's Pipeline regression gate measures the compile-speed delta on the clean runner.