### PR TITLE
feat(mindc): --backend=<mlir|native> opt-in seam (default mlir, native fail-loud)

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind`
-**Files:** 3339 | **Est. tokens:** ~7,812,164
-**Generated:** 2026-08-06 12:33 UTC
+**Files:** 3339 | **Est. tokens:** ~7,812,324
+**Generated:** 2026-08-06 13:35 UTC
 
 ## Token Budget Guide
 
@@ -396,7 +396,7 @@
 | `src/ir/` | 5 | ~47,725 |
 | `src/ir/compact/` | 3 | ~15,271 |
 | `src/ir/compact/v2/` | 8 | ~38,404 |
-| `src/ir/compact/v3/` | 6 | ~49,102 |
+| `src/ir/compact/v3/` | 6 | ~49,206 |
 | `src/lint/` | 2 | ~4,001 |
 | `src/lint/rules/` | 6 | ~9,880 |
 | `src/mlir/` | 3 | ~5,905 |
@@ -410,7 +410,7 @@
 | `src/shapes/` | 2 | ~6,052 |
 | `src/stdlib/` | 2 | ~560 |
 | `src/test/` | 1 | ~5,979 |
-| `src/type_checker/` | 1 | ~15,095 |
+| `src/type_checker/` | 1 | ~15,151 |
 | `src/types/` | 4 | ~3,336 |
 | `src/workspace/` | 1 | ~4,906 |
 | `std/` | 41 | ~198,092 |
@@ -4005,7 +4005,7 @@
 
 - `collapse_receipt.rs` (~5109 tok, huge) — Copyright 2025 STARGA Inc.
 - `ed25519.rs` (~6051 tok, huge) — Copyright 2025 STARGA Inc.
-- `emit.rs` (~11035 tok, huge) — Copyright 2025 STARGA Inc.
+- `emit.rs` (~11139 tok, huge) — Copyright 2025 STARGA Inc.
 - `mldsa.rs` (~1510 tok, huge) — Copyright 2025 STARGA Inc.
 - `mod.rs` (~13865 tok, huge) — Copyright 2025 STARGA Inc.
 - `parse.rs` (~11532 tok, huge) — Copyright 2025 STARGA Inc.
@@ -4099,7 +4099,7 @@
 - `mod.rs` (~5979 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/type_checker/`
 
-- `resolve.rs` (~15095 tok, huge) — Copyright 2025 STARGA Inc.
+- `resolve.rs` (~15151 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/types/`
 
 - `infer.rs` (~448 tok, medium) — Copyright 2025 STARGA Inc.

--- a/src/bin/mindc.rs
+++ b/src/bin/mindc.rs
@@ -39,7 +39,8 @@ use libmind::diagnostics::{ColorChoice, DiagnosticEmitter, DiagnosticFormat};
 use libmind::ops::core_v1;
 use libmind::pipeline::{CompileOptions, compile_source_with_name};
 use libmind::project::{
-    BenchOptions, BuildOptions, BuildTarget, EmitKind, OptimizeLevel, bench_project, run_project,
+    Backend, BenchOptions, BuildOptions, BuildTarget, EmitKind, OptimizeLevel, bench_project,
+    run_project,
 };
 use libmind::{ConformanceOptions, ConformanceProfile, conformance};
 
@@ -81,6 +82,15 @@ enum Command {
         /// Overrides `[build].target` in Mind.toml.
         #[arg(long, value_name = "TARGET")]
         target: Option<String>,
+        /// Code-generation backend: mlir (default) | native.
+        ///
+        /// `mlir` drives the production MLIR-text → mlir-opt/clang pipeline.
+        /// `native` selects the pure-MIND x86-64 native-ELF seam (RI-D "drop
+        /// LLVM" track); it is not yet wired into the Rust driver and fails
+        /// loud when selected, so the default build is unaffected.
+        #[arg(long, value_name = "BACKEND", default_value = "mlir",
+              value_parser = ["mlir", "native"])]
+        backend: String,
         /// Output artifact type: binary | cdylib | object.
         /// Overrides `[build].emit` in Mind.toml.
         #[arg(long, value_name = "EMIT")]
@@ -477,6 +487,7 @@ fn main() {
             paths,
             release,
             target,
+            backend,
             emit,
             optimize,
             out,
@@ -489,6 +500,7 @@ fn main() {
                 paths,
                 *release,
                 target,
+                backend,
                 emit,
                 optimize,
                 out,
@@ -796,6 +808,7 @@ fn run_mindc_build(
     paths: &[String],
     release: bool,
     target: &Option<String>,
+    backend: &str,
     emit: &Option<String>,
     optimize: &Option<String>,
     out: &Option<String>,
@@ -803,6 +816,27 @@ fn run_mindc_build(
     package: Option<&str>,
     no_cache: bool,
 ) {
+    // Code-generation backend dispatch (RI-D seam). The default `mlir` path is
+    // left fully inert: it falls through to the existing pipeline unchanged.
+    // `native` selects the pure-MIND x86-64 native-ELF emitters, which are not
+    // yet reachable from the Rust driver — fail loud rather than silently
+    // producing MLIR output under a `native` request.
+    match Backend::parse(backend) {
+        Ok(Backend::Mlir) => {}
+        Ok(Backend::Native) => {
+            eprintln!(
+                "error[backend]: native backend not yet wired into the Rust driver \
+                 (RI-D seam; the pure-MIND x86-64 native-ELF path lives in the \
+                 self-host compiler). Use the default --backend=mlir."
+            );
+            process::exit(2);
+        }
+        Err(msg) => {
+            eprintln!("error[build]: {}", msg);
+            process::exit(2);
+        }
+    }
+
     // Workspace detection: if we are at a workspace root and no explicit
     // source paths are given, delegate to the workspace build path.
     if paths.is_empty() {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -370,6 +370,49 @@ impl EmitKind {
     }
 }
 
+/// Code-generation backend (RI-D seam, RFC-track "drop LLVM").
+///
+/// `Mlir` (default) drives the production MLIR-text → `mlir-opt` /
+/// `mlir-translate` / `clang` pipeline and is the ONLY wired path today; its
+/// artifacts are the byte-identity–gated canonical output.
+///
+/// `Native` is the opt-in seam for the pure-MIND x86-64 native-ELF emitters
+/// (the self-host `nb_*` lane). It is NOT yet reachable from the Rust driver —
+/// selecting it fails loud rather than silently falling back to MLIR, so the
+/// default build stays fully inert while future RI-D slices land behind this
+/// flag.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Backend {
+    /// MLIR-text → mlir-opt/mlir-translate/clang (default, wired).
+    #[default]
+    Mlir,
+    /// Pure-MIND x86-64 native-ELF path (seam only; not yet wired).
+    Native,
+}
+
+impl Backend {
+    /// Canonical string name for display and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Backend::Mlir => "mlir",
+            Backend::Native => "native",
+        }
+    }
+
+    /// Parse from a CLI string. Returns an error string on unknown input.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.to_ascii_lowercase().as_str() {
+            "mlir" => Ok(Backend::Mlir),
+            "native" => Ok(Backend::Native),
+            other => Err(format!(
+                "unknown backend '{}' (expected mlir|native)",
+                other
+            )),
+        }
+    }
+}
+
 /// RFC 0008 §3 — optimization / profile level.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
RI campaign structural keystone (S2 from Fable's reconciled queue) — the seam every future "drop LLVM" RI-D slice lands behind.

- `Backend` enum + `--backend <mlir|native>` build arg, default `mlir`.
- Native path not yet wired from the Rust driver → `--backend=native` fails loud (exit 2), not silent.
- **Provably inert by default:** MLIR path byte-identical with flag absent and `--backend=mlir` (6/6 canary sha256 pre==post); **keystone 7/7 byte-identical**; check/clippy/fmt/doc clean.

Parallel-safe (touches only src/bin/mindc.rs + src/project/mod.rs). x86-64 native path only (ARM rides MLIR) — no RI 'LLVM-free' claim implied by this seam.