### PR TITLE
fix(lower): branch-local `let` scope escape — shadowing let leaked into outer var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Branch-local `let` no longer escapes its scope (silent-miscompile fix).**
+  A `let` inside an `if`/`else` body that *shadows* an enclosing binding was
+  recorded in the branch's phi-merge set, so on branch exit the shadow's value
+  leaked into the outer variable — `let x = 10; if c { let x = 99 }; x` returned
+  99 instead of 10. The lowering now records a branch-body `let` in the merge set
+  only when its name is NOT already bound in the enclosing scope: a shadow stays
+  branch-local, a fresh name still escapes (the fn-flat semantics the self-host
+  front-end relies on). Applies to `let` and `let (…)` tuple bindings in both
+  branches. Byte-identical self-host: keystone 7/7, oracle-parity 30/30,
+  cross_substrate 24/24 (main.mind contains no such shadow, so its emitted bytes
+  are unchanged).
+
 ### Performance
 - **Boxed `FnDef` AST payload — `Node` shrunk 216 → 128 bytes (byte-identical).**
   The `FnDef` variant's ~9 inline fields made it the fattest `ast::Node`

--- a/src/eval/lower.rs
+++ b/src/eval/lower.rs
@@ -6331,7 +6331,16 @@ fn lower_expr(
                                 }
                             }
                         }
-                        record_then_write(name, &mut then_writes);
+                        // F2 (branch-local `let` scope escape): a shadowing `let`
+                        // (name already bound in the enclosing `env`) is a NEW
+                        // local, not a mutation of the outer var. Recording it as a
+                        // branch write phi-merges it into the outer binding after the
+                        // `if`, silently corrupting it (`if_shadow(1)` returned 99,
+                        // not 10). Only a FRESH name — which main.mind's fn-flat
+                        // semantics rely on escaping — is recorded.
+                        if !env.contains_key(name) {
+                            record_then_write(name, &mut then_writes);
+                        }
                         then_result = id;
                     }
                     ast::Node::Assign { name, value, .. } => {
@@ -6371,7 +6380,11 @@ fn lower_expr(
                             receiver_types,
                         );
                         for nm in names {
-                            record_then_write(nm, &mut then_writes);
+                            // F2: a shadowing tuple-let element is a new local too;
+                            // only fresh names escape into the merge set.
+                            if !env.contains_key(nm) {
+                                record_then_write(nm, &mut then_writes);
+                            }
                         }
                     }
                     other => {
@@ -6555,7 +6568,12 @@ fn lower_expr(
                                     }
                                 }
                             }
-                            record_else_write(name, &mut else_writes);
+                            // F2 (branch-local `let` scope escape) — else-branch
+                            // mirror: a shadowing `let` is a new local, not an outer
+                            // mutation, so it must not phi-merge into the outer var.
+                            if !env.contains_key(name) {
+                                record_else_write(name, &mut else_writes);
+                            }
                             else_result = id;
                         }
                         ast::Node::Assign { name, value, .. } => {
@@ -6597,7 +6615,11 @@ fn lower_expr(
                                 receiver_types,
                             );
                             for nm in names {
-                                record_else_write(nm, &mut else_writes);
+                                // F2: shadowing tuple-let element is a new local;
+                                // only a fresh name escapes into the merge set.
+                                if !env.contains_key(nm) {
+                                    record_else_write(nm, &mut else_writes);
+                                }
                             }
                         }
                         other => {


### PR DESCRIPTION
**Live HIGH silent-miscompile** (net-verified in the shipped compiler AND the self-host oracle). A `let` inside an if/else body that *shadows* an enclosing binding was recorded in the branch's phi-merge set, so on exit the shadow's value leaked into the outer var:

```
fn if_shadow(c: i64) -> i64 { let x = 10; if c > 0 { let x = 99 }; return x }
// if_shadow(1) returned 99, should be 10   (if_shadow(0) already 10)
```

**Fix:** gate the branch-body Let/LetTuple `record_{then,else}_write` calls on `!env.contains_key(name)`. A shadowing let is a new local (don't merge into outer); a fresh branch-body let still escapes (the fn-flat semantics main.mind relies on). Genuine outer mutations (Assign / value-if / nested-region rebindings) untouched. Both branches, simple + tuple lets.

**Byte-neutral for self-host** — a brace-scope scan confirms main.mind has 0 enclosing-scope shadows, so its emitted bytes are unchanged: **keystone 7/7 · oracle-parity 30/30 · cross_substrate 24/24**, and net-verify now `if_shadow(1)==10`.

RI-queue #1 (Fable's reconciled plan): F2 sits in the oracle and S4/S8 build on the branch-body env model, so it lands first. main.mind self-host emitter lockstep + a gap-corpus shadow fixture (ratchets FLOOR) follow as slice 2.