### PR TITLE
Revert F2 branch-let scope-escape fix — mic3-flip self-host divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **Branch-local `let` no longer escapes its scope (silent-miscompile fix).**
-  A `let` inside an `if`/`else` body that *shadows* an enclosing binding was
-  recorded in the branch's phi-merge set, so on branch exit the shadow's value
-  leaked into the outer variable — `let x = 10; if c { let x = 99 }; x` returned
-  99 instead of 10. The lowering now records a branch-body `let` in the merge set
-  only when its name is NOT already bound in the enclosing scope: a shadow stays
-  branch-local, a fresh name still escapes (the fn-flat semantics the self-host
-  front-end relies on). Applies to `let` and `let (…)` tuple bindings in both
-  branches. Byte-identical self-host: keystone 7/7, oracle-parity 30/30,
-  cross_substrate 24/24 (main.mind contains no such shadow, so its emitted bytes
-  are unchanged).
-
 ### Performance
 - **Boxed `FnDef` AST payload — `Node` shrunk 216 → 128 bytes (byte-identical).**
   The `FnDef` variant's ~9 inline fields made it the fattest `ast::Node`

--- a/src/eval/lower.rs
+++ b/src/eval/lower.rs
@@ -6331,16 +6331,7 @@ fn lower_expr(
                                 }
                             }
                         }
-                        // F2 (branch-local `let` scope escape): a shadowing `let`
-                        // (name already bound in the enclosing `env`) is a NEW
-                        // local, not a mutation of the outer var. Recording it as a
-                        // branch write phi-merges it into the outer binding after the
-                        // `if`, silently corrupting it (`if_shadow(1)` returned 99,
-                        // not 10). Only a FRESH name — which main.mind's fn-flat
-                        // semantics rely on escaping — is recorded.
-                        if !env.contains_key(name) {
-                            record_then_write(name, &mut then_writes);
-                        }
+                        record_then_write(name, &mut then_writes);
                         then_result = id;
                     }
                     ast::Node::Assign { name, value, .. } => {
@@ -6380,11 +6371,7 @@ fn lower_expr(
                             receiver_types,
                         );
                         for nm in names {
-                            // F2: a shadowing tuple-let element is a new local too;
-                            // only fresh names escape into the merge set.
-                            if !env.contains_key(nm) {
-                                record_then_write(nm, &mut then_writes);
-                            }
+                            record_then_write(nm, &mut then_writes);
                         }
                     }
                     other => {
@@ -6568,12 +6555,7 @@ fn lower_expr(
                                     }
                                 }
                             }
-                            // F2 (branch-local `let` scope escape) — else-branch
-                            // mirror: a shadowing `let` is a new local, not an outer
-                            // mutation, so it must not phi-merge into the outer var.
-                            if !env.contains_key(name) {
-                                record_else_write(name, &mut else_writes);
-                            }
+                            record_else_write(name, &mut else_writes);
                             else_result = id;
                         }
                         ast::Node::Assign { name, value, .. } => {
@@ -6615,11 +6597,7 @@ fn lower_expr(
                                 receiver_types,
                             );
                             for nm in names {
-                                // F2: shadowing tuple-let element is a new local;
-                                // only a fresh name escapes into the merge set.
-                                if !env.contains_key(nm) {
-                                    record_else_write(nm, &mut else_writes);
-                                }
+                                record_else_write(nm, &mut else_writes);
                             }
                         }
                         other => {


### PR DESCRIPTION
Reverts the F2 fix (#223, commit 9374fed7). The Rust-oracle change was byte-neutral for the phase_g_keystone_bootstrap + oracle-parity gates I ran locally, but it diverges the **whole-module mic@3 self-host FLIP** (mic3_flip_smoke.py, part of the KEYSTONE CI job) — which I did NOT run locally. Root cause: main.mind contains a branch-body `let` that shadows a **parameter** (my byte-neutrality scan only checked let-vs-let shadows, not let-vs-param), so the fix changed the frozen self-host emit. Reverting to restore main green; F2 will be redone param-shadow-aware, with mic3_flip in the local gate + a self-host reseed if the new behavior is confirmed safe for main.mind.