### PR TITLE
feat(eval): mindc test interpreter executes real memory-using MIND (no runtime)

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind`
-**Files:** 3339 | **Est. tokens:** ~7,812,505
-**Generated:** 2026-08-07 02:34 UTC
+**Files:** 3340 | **Est. tokens:** ~7,816,196
+**Generated:** 2026-08-07 07:13 UTC
 
 ## Token Budget Guide
 
@@ -388,8 +388,8 @@
 | `src/diagnostics/` | 1 | ~3,719 |
 | `src/distributed/` | 6 | ~7,433 |
 | `src/doc/` | 3 | ~10,987 |
-| `src/eval/` | 15 | ~80,345 |
-| `src/eval/stdlib/` | 2 | ~8,529 |
+| `src/eval/` | 16 | ~83,142 |
+| `src/eval/stdlib/` | 2 | ~8,586 |
 | `src/exec/` | 3 | ~4,592 |
 | `src/ffi/` | 3 | ~3,919 |
 | `src/fmt/` | 3 | ~21,737 |
@@ -409,7 +409,7 @@
 | `src/runtime/` | 3 | ~1,485 |
 | `src/shapes/` | 2 | ~6,052 |
 | `src/stdlib/` | 2 | ~560 |
-| `src/test/` | 1 | ~5,979 |
+| `src/test/` | 1 | ~6,816 |
 | `src/type_checker/` | 1 | ~15,151 |
 | `src/types/` | 4 | ~3,336 |
 | `src/workspace/` | 1 | ~4,906 |
@@ -3954,6 +3954,7 @@
 - `autodiff.rs` (~14268 tok, huge) — Copyright 2025 STARGA Inc.
 - `closures.rs` (~6911 tok, huge) — Copyright 2025 STARGA Inc.
 - `conv2d_grad.rs` (~2397 tok, huge) — Copyright 2025 STARGA Inc.
+- `interp_mem.rs` (~2572 tok, huge) — Copyright 2025 STARGA Inc.
 - `ir_interp.rs` (~3818 tok, huge) — Copyright 2025 STARGA Inc.
 - `mlir_build.rs` (~9421 tok, huge) — Copyright 2025 STARGA Inc.
 - `mlir_export.rs` (~12220 tok, huge) — Copyright 2025 STARGA Inc.
@@ -3965,12 +3966,12 @@
 ### `src/eval/stdlib/`
 
 - `mod.rs` (~169 tok, small) — Copyright 2025 STARGA Inc.
-- `tensor.rs` (~8360 tok, huge) — Copyright 2025 STARGA Inc.
+- `tensor.rs` (~8417 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/eval/`
 
 - `struct_resolver.rs` (~6767 tok, huge) — Copyright 2025 STARGA Inc.
 - `traits.rs` (~4150 tok, huge) — Copyright 2025 STARGA Inc.
-- `value.rs` (~2003 tok, huge) — Copyright 2025 STARGA Inc.
+- `value.rs` (~2228 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/exec/`
 
 - `conv.rs` (~435 tok, medium) — Copyright 2025 STARGA Inc.
@@ -4096,7 +4097,7 @@
 - `tensor.rs` (~391 tok, medium) — Copyright 2025 STARGA Inc.
 ### `src/test/`
 
-- `mod.rs` (~5979 tok, huge) — Copyright 2025 STARGA Inc.
+- `mod.rs` (~6816 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/type_checker/`
 
 - `resolve.rs` (~15151 tok, huge) — Copyright 2025 STARGA Inc.

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind`
-**Files:** 3340 | **Est. tokens:** ~7,816,196
-**Generated:** 2026-08-07 07:13 UTC
+**Files:** 3340 | **Est. tokens:** ~7,816,617
+**Generated:** 2026-08-07 09:24 UTC
 
 ## Token Budget Guide
 
@@ -388,7 +388,7 @@
 | `src/diagnostics/` | 1 | ~3,719 |
 | `src/distributed/` | 6 | ~7,433 |
 | `src/doc/` | 3 | ~10,987 |
-| `src/eval/` | 16 | ~83,142 |
+| `src/eval/` | 16 | ~83,563 |
 | `src/eval/stdlib/` | 2 | ~8,586 |
 | `src/exec/` | 3 | ~4,592 |
 | `src/ffi/` | 3 | ~3,919 |
@@ -3954,7 +3954,7 @@
 - `autodiff.rs` (~14268 tok, huge) — Copyright 2025 STARGA Inc.
 - `closures.rs` (~6911 tok, huge) — Copyright 2025 STARGA Inc.
 - `conv2d_grad.rs` (~2397 tok, huge) — Copyright 2025 STARGA Inc.
-- `interp_mem.rs` (~2572 tok, huge) — Copyright 2025 STARGA Inc.
+- `interp_mem.rs` (~2993 tok, huge) — Copyright 2025 STARGA Inc.
 - `ir_interp.rs` (~3818 tok, huge) — Copyright 2025 STARGA Inc.
 - `mlir_build.rs` (~9421 tok, huge) — Copyright 2025 STARGA Inc.
 - `mlir_export.rs` (~12220 tok, huge) — Copyright 2025 STARGA Inc.

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -6,7 +6,7 @@
 
 **Project:** `mind`
 **Files:** 3340 | **Est. tokens:** ~7,816,617
-**Generated:** 2026-08-07 09:24 UTC
+**Generated:** 2026-08-07 09:54 UTC
 
 ## Token Budget Guide
 

--- a/src/eval/interp_mem.rs
+++ b/src/eval/interp_mem.rs
@@ -36,6 +36,7 @@
 //! substrates are little-endian).
 
 use std::cell::RefCell;
+use std::collections::BTreeSet;
 
 /// Fixed non-zero base "address" of the arena. Offsets below this are
 /// invalid, so `__mind_alloc` never returns 0 for a successful allocation
@@ -49,13 +50,21 @@ const MEM_CAP_BYTES: usize = 1 << 30; // 1 GiB
 
 thread_local! {
     static MEM: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+    /// Offsets returned by `materialize_str` — the pointers to native string
+    /// RECORDS marshalled from a `Value::Str` at the `string`-typed-param
+    /// boundary. Tracked so `==`/`!=` between two of them can fail loud instead
+    /// of silently comparing arena offsets. Membership-only (never iterated to
+    /// produce a value) and a `BTreeSet`, so it introduces no non-determinism.
+    static STR_RECORDS: RefCell<BTreeSet<i64>> = const { RefCell::new(BTreeSet::new()) };
 }
 
-/// Clear the arena (bump pointer back to base). Called once per `mindc test`
-/// case so each test sees identical fresh memory regardless of which worker
-/// thread runs it or what ran before — run-to-run and order-independent.
+/// Clear the arena (bump pointer back to base) and the string-record tag set.
+/// Called once per `mindc test` case so each test sees identical fresh memory
+/// regardless of which worker thread runs it or what ran before — run-to-run
+/// and order-independent.
 pub fn reset() {
     MEM.with(|m| m.borrow_mut().clear());
+    STR_RECORDS.with(|s| s.borrow_mut().clear());
 }
 
 /// Is `name` one of the memory intrinsics this model interprets?
@@ -137,7 +146,25 @@ pub(crate) fn materialize_str(s: &str) -> Result<i64, String> {
     store_bytes(rec, &data.to_le_bytes())?;
     store_bytes(rec + 8, &n.to_le_bytes())?;
     store_bytes(rec + 16, &n.to_le_bytes())?;
+    // Tag this record pointer so every VALUE-semantics operation between two
+    // marshalled strings (the full comparison class and field sugar — see
+    // `is_str_record`) fails loud rather than silently using arena offsets.
+    STR_RECORDS.with(|set| set.borrow_mut().insert(rec));
     Ok(rec)
+}
+
+/// Is `offset` the pointer to a native string RECORD materialized from a
+/// `Value::Str` at the `string`-typed-param boundary (`materialize_str`)?
+///
+/// The predicate behind the marshalled-string-record CLASS guard
+/// (`guard_str_record_value_op` in eval/mod.rs, consulted by both int-op
+/// dispatchers, plus the field accessor `eval_field_access`): the whole
+/// VALUE-semantics operation class on two such records — every comparison
+/// (`== != < <= > >=`) and field sugar (`.len`) — fails loud, while POINTER
+/// semantics (`rec + 8`, `__mind_load_*`, `rec == 0` null checks) stay legal.
+/// Deterministic: `BTreeSet` membership only, never iterated for ordering.
+pub(crate) fn is_str_record(offset: i64) -> bool {
+    STR_RECORDS.with(|set| set.borrow().contains(&offset))
 }
 
 /// `__mind_free` — validated no-op (the arena is a bump allocator, exactly

--- a/src/eval/interp_mem.rs
+++ b/src/eval/interp_mem.rs
@@ -1,0 +1,265 @@
+// Copyright 2025 STARGA Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Part of the MIND project (Machine Intelligence Native Design).
+
+//! Deterministic linear-memory model for the tree-walking interpreter.
+//!
+//! `mindc test` runs `[test]` fns through the interpreter, not the native
+//! artifact, so the `__mind_alloc` / `__mind_load_*` / `__mind_store_*`
+//! intrinsics (implemented in C for compiled code, see
+//! `runtime-support/mind_intrinsics.c`) need an interpreter-side model for
+//! real memory-using MIND (`std.sha256`, `std.json` byte buffers) to run
+//! without the native runtime.
+//!
+//! Design: a thread-local growable byte arena addressed by OFFSET, never by
+//! host pointer. `__mind_alloc` is a bump allocator from a fixed non-zero
+//! base, so the same program produces the same "addresses" — and therefore
+//! the same results — on every run and every host (no address-dependent
+//! behavior, per the determinism rules). Memory is zero-initialised (the
+//! deterministic choice; native `malloc` contents are undefined, so no
+//! correct program can observe a difference). Out-of-range access is a
+//! fail-closed error, never a silent garbage read.
+//!
+//! Load/store semantics mirror the C intrinsics exactly so interpreted
+//! results match compiled results: `load_i8` zero-extends to i64, stores
+//! return 0, i64 values are 8 bytes little-endian (both supported
+//! substrates are little-endian).
+
+use std::cell::RefCell;
+
+/// Fixed non-zero base "address" of the arena. Offsets below this are
+/// invalid, so `__mind_alloc` never returns 0 for a successful allocation
+/// (MIND code uses `p != 0` as the success check, matching the native ABI).
+/// 8-byte aligned so every allocation is too (see `alloc`).
+const MEM_BASE: i64 = 8;
+
+/// Hard cap on total arena size — fail-closed against a runaway allocation
+/// loop in an interpreted test, deterministic across hosts.
+const MEM_CAP_BYTES: usize = 1 << 30; // 1 GiB
+
+thread_local! {
+    static MEM: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Clear the arena (bump pointer back to base). Called once per `mindc test`
+/// case so each test sees identical fresh memory regardless of which worker
+/// thread runs it or what ran before — run-to-run and order-independent.
+pub fn reset() {
+    MEM.with(|m| m.borrow_mut().clear());
+}
+
+/// Is `name` one of the memory intrinsics this model interprets?
+///
+/// Exactly the set the std byte-buffer code (`std.sha256` / `std.json` /
+/// `std.io_canon` / `std.string`) uses; other `__mind_*` names keep their
+/// existing fail-loud "unsupported" behavior.
+pub(crate) fn is_memory_intrinsic(name: &str) -> bool {
+    matches!(
+        name,
+        "__mind_alloc"
+            | "__mind_free"
+            | "__mind_load_i8"
+            | "__mind_store_i8"
+            | "__mind_load_i64"
+            | "__mind_store_i64"
+    )
+}
+
+/// Evaluate one memory intrinsic over the thread-local arena.
+///
+/// All memory intrinsics are `(i64...) -> i64` by ABI; the caller has
+/// already reduced the arguments to scalars.
+pub(crate) fn eval_intrinsic(name: &str, args: &[i64]) -> Result<i64, String> {
+    match (name, args) {
+        ("__mind_alloc", [n]) => alloc(*n),
+        ("__mind_free", [addr]) => free(*addr),
+        ("__mind_load_i8", [addr]) => load_bytes::<1>(*addr).map(|b| b[0] as i64),
+        ("__mind_store_i8", [addr, val]) => store_bytes(*addr, &[(*val & 0xFF) as u8]),
+        ("__mind_load_i64", [addr]) => load_bytes::<8>(*addr).map(i64::from_le_bytes),
+        ("__mind_store_i64", [addr, val]) => store_bytes(*addr, &val.to_le_bytes()),
+        _ => Err(format!(
+            "{name}: wrong argument count for memory intrinsic ({} given)",
+            args.len()
+        )),
+    }
+}
+
+/// Bump-allocate `n` zeroed bytes; returns the (non-zero) offset address.
+/// `n <= 0` returns 0, matching the native `__mind_alloc`.
+fn alloc(n: i64) -> Result<i64, String> {
+    if n <= 0 {
+        return Ok(0);
+    }
+    // Round the size up to 8 so every allocation is 8-aligned, matching the
+    // alignment guarantee compiled code gets from malloc.
+    let n = (n as usize).div_ceil(8) * 8;
+    MEM.with(|m| {
+        let mut mem = m.borrow_mut();
+        let top = mem.len();
+        if top + n > MEM_CAP_BYTES {
+            return Err(format!(
+                "__mind_alloc: interpreter memory cap exceeded ({} + {} > {} bytes)",
+                top, n, MEM_CAP_BYTES
+            ));
+        }
+        let addr = MEM_BASE + top as i64;
+        mem.resize(top + n, 0);
+        Ok(addr)
+    })
+}
+
+/// Materialize a Rust-side string into the arena as a NATIVE string record —
+/// the `[addr: i64 | len: i64 | cap: i64]` triple over STRIDE-1 bytes that
+/// compiled code passes for a `string`-typed value (std/string.mind layout;
+/// consumed by e.g. std/json.mind's `jv_string_value_from_native`). Returns
+/// the record pointer. The empty string gets `addr = 0, len = 0, cap = 0`
+/// (`alloc(0)` is 0), matching `String::empty()`. Deterministic: bump
+/// allocation, little-endian stores, no address randomness beyond the fixed
+/// arena base.
+pub(crate) fn materialize_str(s: &str) -> Result<i64, String> {
+    let bytes = s.as_bytes();
+    let n = bytes.len() as i64;
+    let data = alloc(n)?;
+    if n > 0 {
+        store_bytes(data, bytes)?;
+    }
+    let rec = alloc(24)?;
+    store_bytes(rec, &data.to_le_bytes())?;
+    store_bytes(rec + 8, &n.to_le_bytes())?;
+    store_bytes(rec + 16, &n.to_le_bytes())?;
+    Ok(rec)
+}
+
+/// `__mind_free` — validated no-op (the arena is a bump allocator, exactly
+/// like the self-host compiler's own runtime arena). `free(0)` is allowed,
+/// matching C `free(NULL)`; any other address must lie inside the arena.
+fn free(addr: i64) -> Result<i64, String> {
+    if addr == 0 {
+        return Ok(0);
+    }
+    MEM.with(|m| {
+        let len = m.borrow().len();
+        if addr < MEM_BASE || addr - MEM_BASE >= len as i64 {
+            return Err(format!("__mind_free: invalid address {addr}"));
+        }
+        Ok(0)
+    })
+}
+
+/// Bounds-checked read of `N` bytes at `addr`. Fail-closed on any
+/// out-of-range access.
+fn load_bytes<const N: usize>(addr: i64) -> Result<[u8; N], String> {
+    MEM.with(|m| {
+        let mem = m.borrow();
+        let off = check_range(addr, N, mem.len())?;
+        let mut out = [0u8; N];
+        out.copy_from_slice(&mem[off..off + N]);
+        Ok(out)
+    })
+}
+
+/// Bounds-checked write of `bytes` at `addr`. Returns 0 (the native store
+/// intrinsics' return value). Fail-closed on any out-of-range access.
+fn store_bytes(addr: i64, bytes: &[u8]) -> Result<i64, String> {
+    MEM.with(|m| {
+        let mut mem = m.borrow_mut();
+        let off = check_range(addr, bytes.len(), mem.len())?;
+        mem[off..off + bytes.len()].copy_from_slice(bytes);
+        Ok(0)
+    })
+}
+
+/// Map an intrinsic address to an arena offset, rejecting any access that is
+/// not fully inside the allocated region.
+fn check_range(addr: i64, size: usize, mem_len: usize) -> Result<usize, String> {
+    if addr < MEM_BASE {
+        return Err(format!(
+            "memory access out of bounds: address {addr} below arena base {MEM_BASE}"
+        ));
+    }
+    let off = (addr - MEM_BASE) as usize;
+    if off.checked_add(size).is_none_or(|end| end > mem_len) {
+        return Err(format!(
+            "memory access out of bounds: [{addr}, {addr}+{size}) outside allocated \
+             arena (top {})",
+            MEM_BASE + mem_len as i64
+        ));
+    }
+    Ok(off)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alloc_is_nonzero_zeroed_and_deterministic() {
+        reset();
+        let p = alloc(8).unwrap();
+        assert_ne!(p, 0);
+        assert_eq!(eval_intrinsic("__mind_load_i64", &[p]).unwrap(), 0);
+        // Same program → same layout on every run: reset and repeat.
+        reset();
+        assert_eq!(alloc(8).unwrap(), p);
+    }
+
+    #[test]
+    fn alloc_nonpositive_returns_zero() {
+        reset();
+        assert_eq!(alloc(0).unwrap(), 0);
+        assert_eq!(alloc(-4).unwrap(), 0);
+    }
+
+    #[test]
+    fn i8_roundtrip_zero_extends() {
+        reset();
+        let p = alloc(1).unwrap();
+        // store_i8 truncates to the low byte; load_i8 zero-extends (matches
+        // the C intrinsics).
+        assert_eq!(eval_intrinsic("__mind_store_i8", &[p, 0x1FF]).unwrap(), 0);
+        assert_eq!(eval_intrinsic("__mind_load_i8", &[p]).unwrap(), 0xFF);
+    }
+
+    #[test]
+    fn i64_roundtrip_little_endian() {
+        reset();
+        let p = alloc(8).unwrap();
+        eval_intrinsic("__mind_store_i64", &[p, -2]).unwrap();
+        assert_eq!(eval_intrinsic("__mind_load_i64", &[p]).unwrap(), -2);
+        // Little-endian byte order: low byte first.
+        assert_eq!(eval_intrinsic("__mind_load_i8", &[p]).unwrap(), 0xFE);
+    }
+
+    #[test]
+    fn out_of_bounds_is_fail_closed() {
+        reset();
+        let p = alloc(8).unwrap();
+        // One-past-the-end i64 read straddles the arena top.
+        assert!(eval_intrinsic("__mind_load_i64", &[p + 1]).is_err());
+        assert!(eval_intrinsic("__mind_load_i8", &[p + 8]).is_err());
+        assert!(eval_intrinsic("__mind_store_i8", &[0, 7]).is_err());
+        assert!(eval_intrinsic("__mind_load_i8", &[MEM_BASE - 1]).is_err());
+    }
+
+    #[test]
+    fn free_validates_and_is_noop() {
+        reset();
+        let p = alloc(8).unwrap();
+        assert_eq!(eval_intrinsic("__mind_free", &[0]).unwrap(), 0);
+        assert_eq!(eval_intrinsic("__mind_free", &[p]).unwrap(), 0);
+        assert!(eval_intrinsic("__mind_free", &[p + 1024]).is_err());
+        // The bytes survive free (bump arena semantics).
+        eval_intrinsic("__mind_store_i8", &[p, 97]).unwrap();
+        assert_eq!(eval_intrinsic("__mind_load_i8", &[p]).unwrap(), 97);
+    }
+}

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -2468,6 +2468,21 @@ fn eval_method_call(receiver: Value, method: &str, _args: &[Value]) -> Result<Va
 }
 
 fn eval_field_access(receiver: Value, field: &str) -> Result<Value, EvalError> {
+    // Marshalled-string-record class guard (see `guard_str_record_value_op`):
+    // field sugar (`.len` et al.) on a record POINTER is a value-semantics
+    // operation the interpreter does not model — fail loud with the record
+    // contract named, never fall through to a generic error or a silent 0.
+    // The record's real fields are read via pointer semantics:
+    // `__mind_load_i64(rec + 0 / 8 / 16)`.
+    if let Value::Int(n) = &receiver {
+        if interp_mem::is_str_record(*n) {
+            return Err(EvalError::UnsupportedMsg(format!(
+                "field access `.{field}` on a marshalled native string record: \
+                 the record has pointer semantics — read its [addr|len|cap] \
+                 fields via __mind_load_i64(rec + 0/8/16)"
+            )));
+        }
+    }
     // A struct value resolves its OWN fields by name first (a struct may
     // legitimately declare a field named `len`); a missing field is a loud
     // error naming the struct.
@@ -2632,7 +2647,48 @@ fn apply_binary(op: BinOp, left: Value, right: Value, mode: ExecMode) -> Result<
     }
 }
 
+/// CHOSEN NARROWING — the marshalled-string-record operation contract, closed
+/// as a CLASS at the operator dispatch (consulted by BOTH int-op dispatchers,
+/// `apply_int_op` and `apply_int_op_u64`, so every current and future
+/// comparison arm INHERITS it instead of rediscovering the bug one operator
+/// at a time; any new int-op dispatcher must call this guard too).
+///
+/// A `Value::Int` that is a materialized native string record
+/// (`interp_mem::is_str_record`) has POINTER semantics only:
+/// - LEGAL: field addressing (`rec + 8` / `rec + 16`), `__mind_load_*` /
+///   `__mind_store_*` through it, and mixed record-vs-plain comparisons
+///   (null checks like `rec == 0` are pointer semantics) — std/json.mind's
+///   `jv_string_value_from_native` depends on exactly these.
+/// - REJECTED LOUD: the whole VALUE-comparison class (`== != < <= > >=`)
+///   between TWO records — comparing arena offsets would silently report
+///   structurally-equal strings as unequal/misordered, and a silent wrong
+///   answer is the one thing this interpreter must never produce. This is a
+///   chosen narrowing now that the arena can tell string records apart, not
+///   a lost capability: pre-marshalling, `==` on two `Value::Str` was
+///   already `Err(Unsupported)`.
+///
+/// Deterministic: a `BTreeSet` membership test, no ordering iteration.
+// deferred: a content-aware string comparison (read both [addr|len|cap]
+// records, compare byte ranges) could replace this loud error if a string
+// comparison surface ever lands in the language — upgrade HERE, in one place.
+fn guard_str_record_value_op(op: BinOp, left: i64, right: i64) -> Result<(), EvalError> {
+    let is_value_comparison = matches!(
+        op,
+        BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge
+    );
+    if is_value_comparison && interp_mem::is_str_record(left) && interp_mem::is_str_record(right) {
+        return Err(EvalError::UnsupportedMsg(format!(
+            "value comparison (`{op:?}`) of two marshalled native string records: \
+             a marshalled `string` has pointer semantics in the interpreter, and \
+             comparing arena offsets would be silently wrong for structurally \
+             equal strings — use byte-wise std string equality (`string_eq`)"
+        )));
+    }
+    Ok(())
+}
+
 fn apply_int_op(op: BinOp, left: i64, right: i64) -> Result<i64, EvalError> {
+    guard_str_record_value_op(op, left, right)?;
     Ok(match op {
         // MIND integer overflow = defined two's-complement wraparound (== the MLIR
         // artifact's `arith.addi`, no nsw/nuw); use explicit wrapping so debug and
@@ -2671,6 +2727,10 @@ fn apply_int_op(op: BinOp, left: i64, right: i64) -> Result<i64, EvalError> {
 /// never inspect the operand as an ordered value), so they defer to
 /// `apply_int_op` for exact parity.
 fn apply_int_op_u64(op: BinOp, left: i64, right: i64) -> Result<i64, EvalError> {
+    // Marshalled-string-record class guard — see `guard_str_record_value_op`.
+    // The unsigned dispatcher handles `< <= > >=` itself (never reaching
+    // `apply_int_op`), so it must consult the guard independently.
+    guard_str_record_value_op(op, left, right)?;
     let a = left as u64;
     let b = right as u64;
     Ok(match op {

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -863,30 +863,29 @@ fn match_enum_payload(
     true
 }
 
-/// Execute a `while` STATEMENT against a mutable environment, so that
-/// assignments to enclosing-scope variables survive the loop — the semantics
-/// the compiled artifact has, and what a fn body needs when it reads a
-/// loop-carried variable after the loop (std.sha256's compression rounds).
-///
-/// Scoping is kept honest: a name first bound by `let` INSIDE the loop body
-/// is loop-local — its pre-loop value (or absence) is restored at loop exit,
-/// so a shadowing body-`let` cannot leak over an outer binding, while an
-/// `assign` to an outer name propagates. Nested `while`s recurse with the
-/// same environment; each level restores its own locals. Early `return`
-/// surfaces as `EvalError::ReturnFlow`, unwound at the `Node::Call` boundary
-/// (locals are restored first, which is moot but keeps the env consistent).
-/// Execute ONE statement against a threaded `&mut env`, so that any assignment
+/// Execute ONE statement against a threaded `&mut env`, so that an assignment
 /// to an enclosing-scope variable — whether it sits directly in a loop body or
-/// nested inside an `if`/`for`/`while` within that body — survives. This is the
+/// nested inside an `if`/`for`/`while`/block within it — survives. This is the
 /// single, uniform statement executor shared by the `while`/`for` body loops,
-/// the module-level statement loop, and the function-call body loop: without it,
-/// a mutation buried in an `if` inside a `while` (e.g. std.sha256's hex-encode
-/// and padding loops) routes to the expression-level control-flow arms, which
-/// clone the env and silently discard the mutation.
+/// the module-level statement loop, and the function-call body loop: without
+/// it, a mutation buried in an `if` inside a `while` (e.g. std.sha256's
+/// hex-encode and padding loops) routes to the expression-level control-flow
+/// arms, which clone the env and silently discard the mutation.
 ///
-/// `local_saves`/`local_names` record body-`let` (and `for`-var) bindings so the
-/// enclosing loop can restore them at exit; an early `return` propagates as
-/// `EvalError::ReturnFlow` and is caught at the function-body boundary.
+/// SCOPE CONTRACT: every scope-introducing sub-block dispatched from here
+/// gets its OWN frame via `exec_block_scoped` — `while`/`for` bodies (one
+/// frame per ITERATION), each `if`/`else` BRANCH, and bare `{ … }` blocks —
+/// so a block-local `let`, INCLUDING one shadowing an enclosing binding, is
+/// restored at that block's exit (lexical scoping), while an `assign` to an
+/// outer name threads out. `local_saves`/`local_names` belong to the
+/// CALLER-OWNED frame (the block this statement sits in): the `Let` arm
+/// records into them, and that frame's owner restores them at its own exit.
+/// Any NEW scope-introducing construct added here must open its own
+/// `exec_block_scoped` frame — sharing the caller's frame silently leaks
+/// shadowing `let`s (the 2026-08-07 if-branch regression).
+///
+/// An early `return` propagates as `EvalError::ReturnFlow` and is caught at
+/// the function-body boundary.
 #[allow(clippy::too_many_arguments)]
 fn exec_threaded_stmt(
     stmt: &Node,
@@ -899,8 +898,9 @@ fn exec_threaded_stmt(
     match stmt {
         Node::Let { name, value, .. } => {
             let v = eval_value_expr_mode(value, env, tensor_env, mode.clone())?;
-            // Record the pre-loop value once, so a shadowing body-`let` cannot
-            // leak over an outer binding after the loop exits.
+            // Record the pre-block value once in the CALLER-OWNED frame, so a
+            // shadowing block-`let` is restored when that frame's owner (the
+            // enclosing `exec_block_scoped` / fn body) exits.
             if local_names.insert(name.clone()) {
                 local_saves.push((name.clone(), env.get(name).cloned()));
             }
@@ -948,10 +948,17 @@ fn exec_threaded_stmt(
             body: inner_body,
             ..
         } => eval_while_stmt_threaded(inner_cond, inner_body, env, tensor_env, mode.clone()),
-        // `if`/`else` in statement position: evaluate the condition, then thread
-        // the taken branch's statements into the SAME env so their mutations
-        // survive (the expression-level `If` arm clones the env and discards
-        // them — the std.sha256 miscompile class).
+        // `if`/`else` in statement position: evaluate the condition, then run
+        // the taken branch as its OWN block scope (`exec_block_scoped` — the
+        // same per-block frame the `while`/`for` bodies use) against the SAME
+        // threaded env. An ASSIGN to an outer name inside the branch threads
+        // out (`if c { acc = acc + i }` must survive — the std.sha256
+        // miscompile class), while a branch-local `let` — including one
+        // SHADOWING an enclosing binding — is restored at branch exit
+        // (lexical scoping). Previously both branches shared the ENCLOSING
+        // frame's `local_saves`/`local_names`, so a shadowing branch-`let`
+        // found its name already recorded, got NO restore entry of its own,
+        // and silently leaked over the outer binding.
         Node::If {
             cond,
             then_branch,
@@ -959,32 +966,22 @@ fn exec_threaded_stmt(
             ..
         } => {
             let c = eval_value_expr_mode(cond, env, tensor_env, mode.clone())?;
-            let mut result = Value::Int(0);
             if !matches!(c, Value::Int(0)) {
-                for s in then_branch {
-                    result = exec_threaded_stmt(
-                        s,
-                        env,
-                        tensor_env,
-                        mode.clone(),
-                        local_saves,
-                        local_names,
-                    )?;
-                }
+                exec_block_scoped(then_branch, env, tensor_env, mode.clone())
             } else if let Some(else_stmts) = else_branch {
-                for s in else_stmts {
-                    result = exec_threaded_stmt(
-                        s,
-                        env,
-                        tensor_env,
-                        mode.clone(),
-                        local_saves,
-                        local_names,
-                    )?;
-                }
+                exec_block_scoped(else_stmts, env, tensor_env, mode.clone())
+            } else {
+                Ok(Value::Int(0))
             }
-            Ok(result)
         }
+        // Bare block `{ … }` in statement position: its own block scope over
+        // the SAME threaded env — outer assigns thread out, block-local
+        // `let`s (shadowing included) are restored at block exit. Without
+        // this arm a statement-position block fell through to the
+        // expression-level `Block` arm, which clones the env: block `let`s
+        // were lost to later block statements and outer assigns were
+        // silently discarded.
+        Node::Block { stmts, .. } => exec_block_scoped(stmts, env, tensor_env, mode.clone()),
         // `for v in start..end`: bounded integer range, body threaded like a
         // `while` body. The `for` gets its OWN scope, never the enclosing
         // loop's: each iteration of the body is a block scope
@@ -1686,12 +1683,17 @@ pub(crate) fn eval_value_expr_mode(
         // honored solely by the MLIR codegen path.
         #[cfg(feature = "std-surface")]
         Node::Break { .. } | Node::Continue { .. } => Ok(Value::Int(0)),
+        // Block-expression semantics (mirrors the expression-level `If` arm
+        // below): the block is ONE scope — a `let` inside it is visible to
+        // later statements and the tail expression, and dies at block exit.
+        // The expression position receives an IMMUTABLE env, so the block
+        // runs over a clone (outer-var assigns inside a block EXPRESSION are
+        // not propagated — same contract as every expression-position eval
+        // here; in STATEMENT position a block routes through
+        // `exec_threaded_stmt`'s `Block` arm, which threads them).
         Node::Block { stmts, .. } => {
-            let mut result = Value::Int(0);
-            for stmt in stmts {
-                result = eval_value_expr_mode(stmt, env, tensor_env, mode.clone())?;
-            }
-            Ok(result)
+            let mut block_env = env.clone();
+            exec_block_scoped(stmts, &mut block_env, tensor_env, mode.clone())
         }
         Node::If {
             cond,

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -43,6 +43,7 @@ pub mod abi_gate;
 pub mod autodiff;
 pub mod closures;
 pub mod conv2d_grad;
+pub mod interp_mem;
 pub mod ir_interp;
 pub mod lower;
 /// Module-wide narrow-int surface prescan — the compile-speed early-skip gate
@@ -445,6 +446,10 @@ pub fn eval_module_value_with_env_mode(
     // Register all top-level functions so calls can dispatch to them (generic or
     // not). Restored after the module finishes so nested module evals don't leak.
     let _fn_prev = fn_table_install(m);
+    // Register module-level `const`s AFTER the fn table (an initializer may
+    // call a const-evaluable fn); called fn bodies resolve them through the
+    // Ident arm's CONST_TABLE fallback.
+    let _const_prev = const_table_install(m, mode.clone())?;
     // issue #99: start with a clean u64-var set (restored below) so a nested
     // module eval neither sees nor leaks the caller's u64 declarations.
     let _u64_prev = u64_vars_take();
@@ -582,7 +587,16 @@ pub fn eval_module_value_with_env_mode(
                 body,
                 ..
             } => {
-                // Module-level for-loop with mutable environment propagation
+                // Module-level `for`: route the body through the SAME uniform
+                // threaded executor the fn-level `For` arm uses — each
+                // iteration a block scope, the loop var restored at loop exit
+                // — so a mutation nested inside an `if` in the body survives
+                // (the old hand-rolled Assign/Let/IndexAssign-only match
+                // routed nested `if` to expression eval, which cloned the env
+                // and silently discarded the mutation). The final integer
+                // bindings are then reflected back into `env`, mirroring the
+                // module-level `While` arm, so a later assert or consumer
+                // reads the post-loop values.
                 let s = match eval_value_expr_mode(start, &venv, &tensor_env, mode.clone())? {
                     Value::Int(n) => n,
                     _ => {
@@ -595,70 +609,37 @@ pub fn eval_module_value_with_env_mode(
                     Value::Int(n) => n,
                     _ => return Err(EvalError::UnsupportedMsg("for-loop end must be int".into())),
                 };
+                let saved_var = venv.get(var).cloned();
                 for i in s..e {
                     venv.insert(var.clone(), Value::Int(i));
-                    for stmt in body {
-                        match stmt {
-                            Node::Assign { name, value, .. } => {
-                                let rhs =
-                                    eval_value_expr_mode(value, &venv, &tensor_env, mode.clone())?;
-                                if let Value::Int(n) = &rhs {
-                                    env.insert(name.clone(), *n);
-                                }
-                                venv.insert(name.clone(), rhs.clone());
-                                last = rhs;
-                            }
-                            Node::Let { name, value, .. } => {
-                                let rhs =
-                                    eval_value_expr_mode(value, &venv, &tensor_env, mode.clone())?;
-                                if let Value::Int(n) = &rhs {
-                                    env.insert(name.clone(), *n);
-                                }
-                                venv.insert(name.clone(), rhs.clone());
-                                last = rhs;
-                            }
-                            // `arr[i] = v` inside the loop body: rebuild + rebind
-                            // the array tuple (mirrors the module-level handler).
-                            Node::IndexAssign {
-                                receiver,
-                                index,
-                                value,
-                                ..
-                            } => {
-                                let val =
-                                    eval_value_expr_mode(value, &venv, &tensor_env, mode.clone())?;
-                                if let Node::Lit(Literal::Ident(arr), _) = receiver.as_ref() {
-                                    if let Some(Value::Tuple(mut items)) = venv.get(arr).cloned() {
-                                        let idx = match eval_value_expr_mode(
-                                            index,
-                                            &venv,
-                                            &tensor_env,
-                                            mode.clone(),
-                                        )? {
-                                            Value::Int(i) => i,
-                                            other => {
-                                                return Err(EvalError::UnsupportedMsg(format!(
-                                                    "array index must be an integer, got {other:?}"
-                                                )));
-                                            }
-                                        };
-                                        if idx < 0 || idx as usize >= items.len() {
-                                            return Err(EvalError::UnsupportedMsg(format!(
-                                                "array index {idx} out of bounds (len {})",
-                                                items.len()
-                                            )));
-                                        }
-                                        items[idx as usize] = val.clone();
-                                        venv.insert(arr.clone(), Value::Tuple(items));
-                                    }
-                                }
-                                last = val;
-                            }
-                            _ => {
-                                last =
-                                    eval_value_expr_mode(stmt, &venv, &tensor_env, mode.clone())?;
-                            }
-                        }
+                    last = exec_block_scoped(body, &mut venv, &tensor_env, mode.clone())?;
+                }
+                match saved_var {
+                    Some(v) => {
+                        venv.insert(var.clone(), v);
+                    }
+                    None => {
+                        venv.remove(var);
+                    }
+                }
+                for (k, v) in venv.iter() {
+                    if let Value::Int(n) = v {
+                        env.insert(k.clone(), *n);
+                    }
+                }
+            }
+            // Top-level `while`: thread the loop so body mutations of outer
+            // variables survive (`while i < n { sum = sum + i; i = i + 1 }`),
+            // then reflect the final integer bindings back into `env` so a later
+            // assert or consumer reads the post-loop values. Without this a
+            // top-level `while` routes to the expression-level arm, which clones
+            // the env and silently discards every loop-carried mutation.
+            #[cfg(feature = "std-surface")]
+            Node::While { cond, body, .. } => {
+                last = eval_while_stmt_threaded(cond, body, &mut venv, &tensor_env, mode.clone())?;
+                for (k, v) in venv.iter() {
+                    if let Value::Int(n) = v {
+                        env.insert(k.clone(), *n);
                     }
                 }
             }
@@ -794,6 +775,23 @@ fn is_enum_variant_ctor(callee: &str) -> bool {
     callee.contains("::") || callee == "Some"
 }
 
+/// Resolve a call callee against the installed user-fn table: the full name
+/// first, then — for a qualified `Module::fn` path — its final `::` segment
+/// (imported std fns are registered under their BARE name by
+/// `fn_table_install`, so `sha256::sha256(...)` must find `sha256`). The fn
+/// table is the arbiter between a qualified CALL and an enum-variant
+/// CONSTRUCTOR, which parse identically: `Result::Ok(x)` only resolves here
+/// if a fn named `Result::Ok` or `Ok` is genuinely registered; otherwise the
+/// caller falls through to the enum-ctor path. Deterministic — a pure table
+/// lookup keyed on the callee string.
+fn resolve_user_fn(callee: &str) -> Option<UserFn> {
+    fn_table_lookup(callee).or_else(|| {
+        callee
+            .rsplit_once("::")
+            .and_then(|(_, last)| fn_table_lookup(last))
+    })
+}
+
 /// Phase 10.7: does this bare identifier denote a payload-less (unit) variant?
 /// `Type::Variant` paths and the bare `None` constructor qualify.
 fn is_enum_unit_ctor(name: &str) -> bool {
@@ -865,6 +863,256 @@ fn match_enum_payload(
     true
 }
 
+/// Execute a `while` STATEMENT against a mutable environment, so that
+/// assignments to enclosing-scope variables survive the loop — the semantics
+/// the compiled artifact has, and what a fn body needs when it reads a
+/// loop-carried variable after the loop (std.sha256's compression rounds).
+///
+/// Scoping is kept honest: a name first bound by `let` INSIDE the loop body
+/// is loop-local — its pre-loop value (or absence) is restored at loop exit,
+/// so a shadowing body-`let` cannot leak over an outer binding, while an
+/// `assign` to an outer name propagates. Nested `while`s recurse with the
+/// same environment; each level restores its own locals. Early `return`
+/// surfaces as `EvalError::ReturnFlow`, unwound at the `Node::Call` boundary
+/// (locals are restored first, which is moot but keeps the env consistent).
+/// Execute ONE statement against a threaded `&mut env`, so that any assignment
+/// to an enclosing-scope variable — whether it sits directly in a loop body or
+/// nested inside an `if`/`for`/`while` within that body — survives. This is the
+/// single, uniform statement executor shared by the `while`/`for` body loops,
+/// the module-level statement loop, and the function-call body loop: without it,
+/// a mutation buried in an `if` inside a `while` (e.g. std.sha256's hex-encode
+/// and padding loops) routes to the expression-level control-flow arms, which
+/// clone the env and silently discard the mutation.
+///
+/// `local_saves`/`local_names` record body-`let` (and `for`-var) bindings so the
+/// enclosing loop can restore them at exit; an early `return` propagates as
+/// `EvalError::ReturnFlow` and is caught at the function-body boundary.
+#[allow(clippy::too_many_arguments)]
+fn exec_threaded_stmt(
+    stmt: &Node,
+    env: &mut HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+    mode: ExecMode,
+    local_saves: &mut Vec<(String, Option<Value>)>,
+    local_names: &mut std::collections::HashSet<String>,
+) -> Result<Value, EvalError> {
+    match stmt {
+        Node::Let { name, value, .. } => {
+            let v = eval_value_expr_mode(value, env, tensor_env, mode.clone())?;
+            // Record the pre-loop value once, so a shadowing body-`let` cannot
+            // leak over an outer binding after the loop exits.
+            if local_names.insert(name.clone()) {
+                local_saves.push((name.clone(), env.get(name).cloned()));
+            }
+            env.insert(name.clone(), v.clone());
+            Ok(v)
+        }
+        Node::Assign { name, value, .. } => {
+            let v = eval_value_expr_mode(value, env, tensor_env, mode.clone())?;
+            env.insert(name.clone(), v.clone());
+            Ok(v)
+        }
+        // `arr[i] = v`: rebuild + rebind the array tuple in the threaded env.
+        Node::IndexAssign {
+            receiver,
+            index,
+            value,
+            ..
+        } => {
+            let val = eval_value_expr_mode(value, env, tensor_env, mode.clone())?;
+            if let Node::Lit(Literal::Ident(arr), _) = receiver.as_ref() {
+                if let Some(Value::Tuple(mut items)) = env.get(arr).cloned() {
+                    let idx = match eval_value_expr_mode(index, env, tensor_env, mode.clone())? {
+                        Value::Int(i) => i,
+                        other => {
+                            return Err(EvalError::UnsupportedMsg(format!(
+                                "array index must be an integer, got {other:?}"
+                            )));
+                        }
+                    };
+                    if idx < 0 || idx as usize >= items.len() {
+                        return Err(EvalError::UnsupportedMsg(format!(
+                            "array index {idx} out of bounds (len {})",
+                            items.len()
+                        )));
+                    }
+                    items[idx as usize] = val.clone();
+                    env.insert(arr.clone(), Value::Tuple(items));
+                }
+            }
+            Ok(val)
+        }
+        #[cfg(feature = "std-surface")]
+        Node::While {
+            cond: inner_cond,
+            body: inner_body,
+            ..
+        } => eval_while_stmt_threaded(inner_cond, inner_body, env, tensor_env, mode.clone()),
+        // `if`/`else` in statement position: evaluate the condition, then thread
+        // the taken branch's statements into the SAME env so their mutations
+        // survive (the expression-level `If` arm clones the env and discards
+        // them — the std.sha256 miscompile class).
+        Node::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            let c = eval_value_expr_mode(cond, env, tensor_env, mode.clone())?;
+            let mut result = Value::Int(0);
+            if !matches!(c, Value::Int(0)) {
+                for s in then_branch {
+                    result = exec_threaded_stmt(
+                        s,
+                        env,
+                        tensor_env,
+                        mode.clone(),
+                        local_saves,
+                        local_names,
+                    )?;
+                }
+            } else if let Some(else_stmts) = else_branch {
+                for s in else_stmts {
+                    result = exec_threaded_stmt(
+                        s,
+                        env,
+                        tensor_env,
+                        mode.clone(),
+                        local_saves,
+                        local_names,
+                    )?;
+                }
+            }
+            Ok(result)
+        }
+        // `for v in start..end`: bounded integer range, body threaded like a
+        // `while` body. The `for` gets its OWN scope, never the enclosing
+        // loop's: each iteration of the body is a block scope
+        // (`exec_block_scoped` — body-`let`s die at iteration end, so a
+        // body-`let` shadowing an outer name, or even the loop var itself,
+        // never leaks or pollutes an enclosing `while`'s restore list), and
+        // the loop VAR's shadowed binding (if any) is saved here and restored
+        // the moment the loop exits, so a later statement in the enclosing
+        // body reads the OUTER binding (compiled scoping).
+        Node::For {
+            var,
+            start,
+            end,
+            body,
+            ..
+        } => {
+            let s = match eval_value_expr_mode(start, env, tensor_env, mode.clone())? {
+                Value::Int(n) => n,
+                _ => {
+                    return Err(EvalError::UnsupportedMsg(
+                        "for-loop start must be int".into(),
+                    ));
+                }
+            };
+            let e = match eval_value_expr_mode(end, env, tensor_env, mode.clone())? {
+                Value::Int(n) => n,
+                _ => return Err(EvalError::UnsupportedMsg("for-loop end must be int".into())),
+            };
+            let saved_var = env.get(var).cloned();
+            let run = (|| -> Result<Value, EvalError> {
+                let mut result = Value::Int(0);
+                for i in s..e {
+                    env.insert(var.clone(), Value::Int(i));
+                    result = exec_block_scoped(body, env, tensor_env, mode.clone())?;
+                }
+                Ok(result)
+            })();
+            // Restore on success AND on error/`ReturnFlow`, keeping the env
+            // consistent however the loop unwinds (moot for `ReturnFlow`
+            // — the fn boundary discards the call env — but honest).
+            match saved_var {
+                Some(v) => {
+                    env.insert(var.clone(), v);
+                }
+                None => {
+                    env.remove(var);
+                }
+            }
+            run
+        }
+        // Everything else (calls, bare expressions, `return`, …) is a pure
+        // expression evaluation; `return` surfaces as `ReturnFlow` and unwinds.
+        other => eval_value_expr_mode(other, env, tensor_env, mode.clone()),
+    }
+}
+
+/// Execute a loop body's statement list as ONE BLOCK SCOPE against the
+/// threaded env — the per-ITERATION scope of a `while`/`for` body. Names
+/// first bound by `let` inside the list (directly, or within a nested `if`
+/// branch) are block-local: their pre-block value (or absence) is restored
+/// when the block exits — success or error — so a shadowing body-`let` dies
+/// at iteration end and can never leak over an outer binding, while an
+/// `assign` to an outer name propagates. Restoring PER ITERATION (not once
+/// at loop exit) matches native block scoping exactly: a body `let` is
+/// fresh each iteration, so `x = x + 1; let x = 99` increments the OUTER
+/// `x` every iteration (an at-loop-exit restore would freeze it at its
+/// first-shadow snapshot instead).
+fn exec_block_scoped(
+    stmts: &[Node],
+    env: &mut HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+    mode: ExecMode,
+) -> Result<Value, EvalError> {
+    let mut saves: Vec<(String, Option<Value>)> = Vec::new();
+    let mut names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let outcome = (|| -> Result<Value, EvalError> {
+        let mut result = Value::Int(0);
+        for stmt in stmts {
+            result =
+                exec_threaded_stmt(stmt, env, tensor_env, mode.clone(), &mut saves, &mut names)?;
+        }
+        Ok(result)
+    })();
+    for (name, saved) in saves.into_iter().rev() {
+        match saved {
+            Some(v) => {
+                env.insert(name, v);
+            }
+            None => {
+                env.remove(&name);
+            }
+        }
+    }
+    outcome
+}
+
+#[cfg(feature = "std-surface")]
+fn eval_while_stmt_threaded(
+    cond: &Node,
+    body: &[Node],
+    env: &mut HashMap<String, Value>,
+    tensor_env: &HashMap<String, TensorEnvEntry>,
+    mode: ExecMode,
+) -> Result<Value, EvalError> {
+    const MAX_EVAL_ITERS: u64 = 1_000_000;
+    let mut result = Value::Int(0);
+    let mut iters: u64 = 0;
+    loop {
+        let cond_val = eval_value_expr_mode(cond, env, tensor_env, mode.clone())?;
+        if matches!(cond_val, Value::Int(0)) {
+            break;
+        }
+        iters += 1;
+        if iters > MAX_EVAL_ITERS {
+            return Err(EvalError::UnsupportedMsg(
+                "`while` exceeded the compile-time evaluation iteration cap \
+                 (possible non-terminating loop)"
+                    .into(),
+            ));
+        }
+        // Each iteration is its own block scope (`exec_block_scoped`):
+        // body-`let`s are restored at iteration end, `assign`s to outer
+        // names survive into the next condition check and past the loop.
+        result = exec_block_scoped(body, env, tensor_env, mode.clone())?;
+    }
+    Ok(result)
+}
+
 pub(crate) fn eval_value_expr_mode(
     node: &Node,
     env: &HashMap<String, Value>,
@@ -878,6 +1126,13 @@ pub(crate) fn eval_value_expr_mode(
         Node::Lit(Literal::Ident(name), _) => {
             if let Some(v) = env.get(name) {
                 return Ok(v.clone());
+            }
+            // Module-level `const NAME = …` fallback: the local env
+            // (params / `let`s) shadows first; the per-module-eval const
+            // table resolves next, so a CALLED fn body sees module consts
+            // (std/json.mind's `MAX_DEPTH`) without any env plumbing.
+            if let Some(v) = const_table_lookup(name) {
+                return Ok(v);
             }
             // Phase 10.7: a bare unit enum/`Option` variant (`Mode::On`, `None`)
             // that is not a bound variable evaluates to a payload-less
@@ -905,7 +1160,15 @@ pub(crate) fn eval_value_expr_mode(
             // builds a `Value::Enum` carrying the evaluated positional payload.
             // This is detected before the tensor-stdlib dispatch because those
             // callees never use `::` and are never named `Some`/`None`.
-            if is_enum_variant_ctor(callee) {
+            //
+            // A qualified CROSS-MODULE call (`sha256::sha256(...)`) parses the
+            // same `A::B` shape, so the installed fn table is consulted FIRST
+            // (`resolve_user_fn`: full path, then final segment — imported std
+            // fns register under their bare name). Only a callee that resolves
+            // to NO registered fn constructs an enum, so `Result::Ok` /
+            // `Mode::On` still build variants.
+            let user_fn = resolve_user_fn(callee);
+            if user_fn.is_none() && is_enum_variant_ctor(callee) {
                 let mut payload = Vec::with_capacity(args.len());
                 for arg in args {
                     payload.push(eval_value_expr_mode(arg, env, tensor_env, mode.clone())?);
@@ -921,7 +1184,7 @@ pub(crate) fn eval_value_expr_mode(
             // typed interpreter binds the concrete arg Values; type params are
             // only recorded on the FnDef. Checked before the tensor stdlib so a
             // user fn shadowing a stdlib name resolves to the user fn.
-            if let Some(func) = fn_table_lookup(callee) {
+            if let Some(func) = user_fn {
                 if func.params.len() != args.len() {
                     return Err(EvalError::UnsupportedMsg(format!(
                         "function `{callee}` expects {} argument(s), got {}",
@@ -930,8 +1193,29 @@ pub(crate) fn eval_value_expr_mode(
                     )));
                 }
                 let mut call_env = env.clone();
-                for (p, a) in func.params.iter().zip(args.iter()) {
-                    let v = eval_value_expr_mode(a, env, tensor_env, mode.clone())?;
+                for ((p, is_string), a) in func
+                    .params
+                    .iter()
+                    .zip(func.string_params.iter())
+                    .zip(args.iter())
+                {
+                    let mut v = eval_value_expr_mode(a, env, tensor_env, mode.clone())?;
+                    // Native-string boundary: a `Value::Str` bound to a param
+                    // DECLARED `string` is materialized in the interp_mem
+                    // arena as the compiled `[addr|len|cap]` record, so
+                    // byte-level std code (std/json.mind's
+                    // `jv_string_value_from_native`) can address it. A
+                    // record handle already in flight (`Value::Int`) passes
+                    // through untouched; non-`string` params keep `Str`
+                    // values Rust-side (e.g. the `.len` arm). Fail-loud on
+                    // arena errors.
+                    if *is_string {
+                        if let Value::Str(s) = &v {
+                            let rec = interp_mem::materialize_str(s)
+                                .map_err(EvalError::UnsupportedMsg)?;
+                            v = Value::Int(rec);
+                        }
+                    }
                     call_env.insert(p.clone(), v);
                 }
                 // Salov C3 (#179): the function-body boundary is where an early
@@ -946,25 +1230,55 @@ pub(crate) fn eval_value_expr_mode(
                 // the same binding-propagation the module / `For` / `While` body
                 // loops already perform. Without it a body with a top-level
                 // counter could not be const-evaluated at all.
+                // Execute the body through the uniform threaded executor so
+                // let/assign AND any mutation nested inside a top-level
+                // `if`/`for`/`while` survive to a later statement — the same
+                // binding-propagation the module / loop bodies perform (e.g.
+                // std.sha256's compression `while` and its hex-encode
+                // `if`-in-`while`, whose working state is read after the loop).
+                // An early `return` surfaces as `ReturnFlow` and yields here.
                 let mut result = Value::Int(0);
+                let mut fn_local_saves: Vec<(String, Option<Value>)> = Vec::new();
+                let mut fn_local_names: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
                 for stmt in &func.body {
-                    match stmt {
-                        Node::Let { name, value, .. } | Node::Assign { name, value, .. } => {
-                            let v =
-                                eval_value_expr_mode(value, &call_env, tensor_env, mode.clone())?;
-                            call_env.insert(name.clone(), v.clone());
-                            result = v;
-                        }
-                        _ => {
-                            match eval_value_expr_mode(stmt, &call_env, tensor_env, mode.clone()) {
-                                Ok(v) => result = v,
-                                Err(EvalError::ReturnFlow(v)) => return Ok(*v),
-                                Err(e) => return Err(e),
-                            }
-                        }
+                    match exec_threaded_stmt(
+                        stmt,
+                        &mut call_env,
+                        tensor_env,
+                        mode.clone(),
+                        &mut fn_local_saves,
+                        &mut fn_local_names,
+                    ) {
+                        Ok(v) => result = v,
+                        Err(EvalError::ReturnFlow(v)) => return Ok(*v),
+                        Err(e) => return Err(e),
                     }
                 }
                 return Ok(result);
+            }
+            // Deterministic linear-memory intrinsics (`__mind_alloc` /
+            // `__mind_load_*` / `__mind_store_*` / `__mind_free`): interpreted
+            // over the thread-local arena (`interp_mem`) so `mindc test` can
+            // run real memory-using MIND (std.sha256 / std.json byte buffers)
+            // without the native runtime. All are `(i64...) -> i64` by ABI.
+            // (`fn_table_install` skips `__mind_*` names, so a user fn can
+            // never shadow these — E2023 defence-in-depth.)
+            if interp_mem::is_memory_intrinsic(callee) {
+                let mut int_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    match eval_value_expr_mode(arg, env, tensor_env, mode.clone())? {
+                        Value::Int(n) => int_args.push(n),
+                        other => {
+                            return Err(EvalError::UnsupportedMsg(format!(
+                                "{callee}: expected an i64 argument, got {other:?}"
+                            )));
+                        }
+                    }
+                }
+                return interp_mem::eval_intrinsic(callee, &int_args)
+                    .map(Value::Int)
+                    .map_err(EvalError::UnsupportedMsg);
             }
             stdlib::tensor::dispatch(callee, args, env, tensor_env, mode.clone())
         }
@@ -1386,28 +1700,26 @@ pub(crate) fn eval_value_expr_mode(
             ..
         } => {
             let cond_val = eval_value_expr_mode(cond, env, tensor_env, mode.clone())?;
-            match cond_val {
-                Value::Int(0) => {
-                    // False branch
-                    if let Some(else_stmts) = else_branch {
-                        let mut result = Value::Int(0);
-                        for stmt in else_stmts {
-                            result = eval_value_expr_mode(stmt, env, tensor_env, mode.clone())?;
-                        }
-                        Ok(result)
-                    } else {
-                        Ok(Value::Int(0))
-                    }
-                }
-                _ => {
-                    // True branch
-                    let mut result = Value::Int(0);
-                    for stmt in then_branch {
-                        result = eval_value_expr_mode(stmt, env, tensor_env, mode.clone())?;
-                    }
-                    Ok(result)
-                }
-            }
+            let stmts: &[Node] = match cond_val {
+                Value::Int(0) => match else_branch {
+                    Some(else_stmts) => else_stmts.as_slice(),
+                    None => return Ok(Value::Int(0)),
+                },
+                _ => then_branch.as_slice(),
+            };
+            // Block-expression semantics: the taken branch is a BLOCK — a
+            // `let` inside it must be visible to later statements and to the
+            // tail expression (std/json.mind's `let d = __mind_alloc(n);
+            // jv_copy_bytes(..); d`). The expression position receives an
+            // IMMUTABLE env, so the block runs over a clone: local bindings
+            // resolve, the block's value is its last statement's, and the
+            // clone is discarded. (In STATEMENT position `if` routes through
+            // `exec_threaded_stmt`, which threads outer-var assigns; an
+            // outer-var assign buried in an if-EXPRESSION is not propagated —
+            // the same contract as every other expression-position eval
+            // here.)
+            let mut branch_env = env.clone();
+            exec_block_scoped(stmts, &mut branch_env, tensor_env, mode.clone())
         }
         // Import statements are module-level declarations, no runtime value
         Node::Import { .. } => Ok(Value::Int(0)),
@@ -1671,21 +1983,23 @@ pub(crate) fn eval_value_expr_mode(
                 _ => Ok(Value::Int(0)),
             }
         }
-        // Phase 10.6: struct literal preview-eval. Evaluate each field's
-        // value sub-expression and pack them into a Tuple in declared
-        // field order. Full structural eval (returning a typed aggregate
-        // tied to the struct name) lands when AOT codegen needs it.
-        Node::StructLit { fields, .. } => {
+        // Phase 10.6: struct literal eval. Evaluate each field's value
+        // sub-expression IN SOURCE ORDER and pack them, with their names,
+        // into a typed `Value::Struct` — so `v.h` on the result resolves by
+        // field NAME (std/json.mind's `Value { h: … }` handle-wrapper), and
+        // the struct's identity survives through call/return boundaries.
+        Node::StructLit { name, fields, .. } => {
             let mut items = Vec::with_capacity(fields.len());
             for f in fields {
-                items.push(eval_value_expr_mode(
-                    &f.value,
-                    env,
-                    tensor_env,
-                    mode.clone(),
-                )?);
+                items.push((
+                    f.name.clone(),
+                    eval_value_expr_mode(&f.value, env, tensor_env, mode.clone())?,
+                ));
             }
-            Ok(Value::Tuple(items))
+            Ok(Value::Struct {
+                name: name.clone(),
+                fields: items,
+            })
         }
         // Phase 10.6: index access `receiver[index]`. For an array/tuple value
         // (what `[a, b, c]` literals evaluate to) the interpreter returns the
@@ -2154,6 +2468,19 @@ fn eval_method_call(receiver: Value, method: &str, _args: &[Value]) -> Result<Va
 }
 
 fn eval_field_access(receiver: Value, field: &str) -> Result<Value, EvalError> {
+    // A struct value resolves its OWN fields by name first (a struct may
+    // legitimately declare a field named `len`); a missing field is a loud
+    // error naming the struct.
+    if let Value::Struct { name, fields } = &receiver {
+        for (fname, fval) in fields {
+            if fname == field {
+                return Ok(fval.clone());
+            }
+        }
+        return Err(EvalError::UnsupportedMsg(format!(
+            "struct `{name}` has no field .{field}"
+        )));
+    }
     match field {
         "len" => match &receiver {
             Value::Tuple(items) => Ok(Value::Int(items.len() as i64)),
@@ -3302,6 +3629,13 @@ use std::cell::RefCell;
 #[derive(Clone)]
 struct UserFn {
     params: Vec<String>,
+    /// Per-param: is the DECLARED type the native `string`? A `Value::Str`
+    /// argument bound to such a param is marshalled into the interp_mem arena
+    /// as a native `[addr|len|cap]` string record (the layout compiled code
+    /// passes — std/string.mind), so byte-level std code
+    /// (`jv_string_value_from_native` et al.) reads real memory, not a
+    /// Rust-side `Str` it cannot address.
+    string_params: Vec<bool>,
     body: Vec<Node>,
 }
 
@@ -3329,6 +3663,10 @@ fn fn_table_install(m: &Module) -> HashMap<String, UserFn> {
                 name.clone(),
                 UserFn {
                     params: params.iter().map(|p| p.name.clone()).collect(),
+                    string_params: params
+                        .iter()
+                        .map(|p| matches!(&p.ty, TypeAnn::Named(n) if n == "string"))
+                        .collect(),
                     body: body.clone(),
                 },
             );
@@ -3350,6 +3688,50 @@ fn fn_table_restore(prev: HashMap<String, UserFn>) {
 /// Look up a user-defined function by callee name.
 fn fn_table_lookup(name: &str) -> Option<UserFn> {
     FN_TABLE.with(|t| t.borrow().get(name).cloned())
+}
+
+// Module-level `const NAME: T = expr` bindings, mirrored from `FN_TABLE`:
+// installed once per module eval, consulted by `eval_value_expr_mode`'s Ident
+// arm as a fallback AFTER the local env (so a fn param or body `let` of the
+// same name still shadows the const) and BEFORE the enum-unit-ctor fallback.
+// This is what puts module consts (e.g. std/json.mind's `MAX_DEPTH`) in scope
+// inside CALLED fn bodies, whose fresh call envs never see module bindings.
+thread_local! {
+    static CONST_TABLE: RefCell<HashMap<String, Value>> = RefCell::new(HashMap::new());
+}
+
+/// Evaluate and register every top-level `const` in SOURCE ORDER — each
+/// initializer is const-evaluated against the consts registered before it
+/// (plus the already-installed fn table, so a const may call a
+/// const-evaluable fn). Deterministic: same items, same order, same values.
+/// A non-const-evaluable initializer is a LOUD error — never a silent 0.
+/// Returns the previous table for symmetry with `fn_table_install` (the
+/// install site discards it, same known deferral as `_fn_prev`).
+fn const_table_install(m: &Module, mode: ExecMode) -> Result<HashMap<String, Value>, EvalError> {
+    let prev = CONST_TABLE.with(|t| std::mem::take(&mut *t.borrow_mut()));
+    let empty_env: HashMap<String, Value> = HashMap::new();
+    let empty_tensors: HashMap<String, TensorEnvEntry> = HashMap::new();
+    for item in &m.items {
+        if let Node::Const { name, value, .. } = item {
+            // Earlier consts resolve through the Ident arm's CONST_TABLE
+            // fallback (the table is populated incrementally, in order).
+            let v = eval_value_expr_mode(value, &empty_env, &empty_tensors, mode.clone()).map_err(
+                |e| {
+                    EvalError::UnsupportedMsg(format!(
+                        "const `{name}` initializer is not const-evaluable \
+                         in the interpreter: {e}"
+                    ))
+                },
+            )?;
+            CONST_TABLE.with(|t| t.borrow_mut().insert(name.clone(), v));
+        }
+    }
+    Ok(prev)
+}
+
+/// Look up a module-level `const` by name (Ident-arm fallback).
+fn const_table_lookup(name: &str) -> Option<Value> {
+    CONST_TABLE.with(|t| t.borrow().get(name).cloned())
 }
 
 // issue #99: names of top-level bindings declared `u64`. The const-fold

--- a/src/eval/stdlib/tensor.rs
+++ b/src/eval/stdlib/tensor.rs
@@ -390,6 +390,9 @@ fn shape_dim_from_value(value: &Value) -> Result<ShapeDim, EvalError> {
             Ok(ShapeDim::Known(*n as usize))
         }
         Value::Str(sym) => Ok(ShapeDim::Sym(leak_symbol(sym))),
+        // A plain-struct value is never a tensor shape dimension (fail-loud, not
+        // a silent 0): tensor shapes come from ints / symbolic dims / 1-D tensors.
+        Value::Struct { .. } => Err(EvalError::Unsupported),
         Value::Tensor(t) => {
             if t.shape.len() == 1 {
                 match t.shape[0] {

--- a/src/eval/value.rs
+++ b/src/eval/value.rs
@@ -121,6 +121,14 @@ pub enum Value {
         variant: String,
         payload: Vec<Value>,
     },
+    /// Plain-struct value (interpreter): the struct's name plus its fields as
+    /// `(field_name, value)` pairs in literal order. Field access resolves by
+    /// NAME (`eval_field_access`), so declared-vs-literal field order never
+    /// matters. Deterministic: construction evaluates fields in source order.
+    Struct {
+        name: String,
+        fields: Vec<(String, Value)>,
+    },
 }
 
 impl Value {
@@ -209,6 +217,21 @@ pub fn format_value_human(v: &Value) -> String {
                 out.push(')');
                 out
             }
+        }
+        Value::Struct { name, fields } => {
+            let mut out = String::new();
+            out.push_str(name);
+            out.push_str(" { ");
+            for (i, (fname, fval)) in fields.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push_str(fname);
+                out.push_str(": ");
+                out.push_str(&format_value_human(fval));
+            }
+            out.push_str(" }");
+            out
         }
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -469,6 +469,14 @@ fn eval_test_fn(entry: &TestEntry) -> Result<(), String> {
     use crate::eval;
     use crate::eval::ExecMode;
 
+    // Fresh, deterministic linear memory for THIS test: every test sees an
+    // identical zeroed arena regardless of worker-thread assignment or run
+    // order (the arena is thread-local and worker threads are reused). The
+    // arena must survive across BOTH eval passes below — asserts in the
+    // second pass read memory the first pass wrote — so this is the only
+    // reset point.
+    eval::interp_mem::reset();
+
     // Re-parse to get a fresh, unaliased AST.
     let module = parser::parse(&entry.source_text).map_err(|errs| {
         errs.iter()
@@ -494,14 +502,17 @@ fn eval_test_fn(entry: &TestEntry) -> Result<(), String> {
         })
         .ok_or_else(|| format!("test function '{}' not found in module", fn_name))?;
 
-    // Build the synthetic module: module-level non-fn items first, then the
-    // test body. This puts consts/structs/types in scope for the test body.
-    let mut synthetic_items: Vec<Node> = module
-        .items
-        .iter()
-        .filter(|item| !matches!(item, Node::FnDef(..)))
-        .cloned()
-        .collect();
+    // Build the synthetic module: imported-std fn defs first (so file-local
+    // fns shadow them in the fn table — later install wins), then ALL
+    // module-level items, then the test body. `FnDef` items are inert at
+    // module eval level (`Ok(Int(0))`) but are registered by
+    // `fn_table_install`, which is what lets a test body call helper fns in
+    // its own file and `pub fn`s of bundled std modules (e.g. run the
+    // std.sha256 KAT) through the interpreter, with no native runtime.
+    let mut synthetic_items: Vec<Node> = Vec::new();
+    #[cfg(any(feature = "cross-module-imports", feature = "std-surface"))]
+    synthetic_items.extend(resolve_std_import_fns(&module)?);
+    synthetic_items.extend(module.items.iter().cloned());
     synthetic_items.extend(body_items.clone());
 
     let synthetic_module = Module {
@@ -518,6 +529,66 @@ fn eval_test_fn(entry: &TestEntry) -> Result<(), String> {
     // Second pass: walk the body looking for `assert` nodes and evaluate them
     // against the environment that the first pass populated.
     eval_asserts_in_stmts(&body_items, &env)
+}
+
+/// Resolve `import std.X` / `use std::X` declarations of a test module (and,
+/// transitively, of the modules they import) against the stdlib sources baked
+/// into the binary (RFC 0005 Phase C, `project::stdlib`), returning the
+/// imported modules' `FnDef` items so the interpreter's fn table can dispatch
+/// cross-module calls — e.g. a `[test]` running the std.sha256 KAT — plus
+/// their module-level `Const` items, so a fn body that reads a module const
+/// (std.json's `MAX_DEPTH`) resolves it through the interpreter's const
+/// table.
+///
+/// Deterministic: imports are processed in source-encounter order (FIFO
+/// worklist, `BTreeSet` visited guard against cycles). An import that is not
+/// a bundled `std.*` module contributes nothing (existing behavior for it is
+/// unchanged); a bundled module that fails to parse is a fail-loud error.
+#[cfg(any(feature = "cross-module-imports", feature = "std-surface"))]
+fn resolve_std_import_fns(module: &crate::ast::Module) -> Result<Vec<Node>, String> {
+    use crate::project::stdlib::STDLIB_MIND_SOURCES;
+
+    fn import_key(item: &Node) -> Option<String> {
+        if let Node::Import { path, .. } = item {
+            if path.len() == 2 && path[0] == "std" {
+                return Some(path.join("."));
+            }
+        }
+        None
+    }
+
+    let mut out: Vec<Node> = Vec::new();
+    let mut visited: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut queue: VecDeque<String> = module.items.iter().filter_map(import_key).collect();
+    while let Some(key) = queue.pop_front() {
+        if !visited.insert(key.clone()) {
+            continue;
+        }
+        let Some((_, src)) = STDLIB_MIND_SOURCES.iter().find(|(k, _)| *k == key) else {
+            continue;
+        };
+        let imported = parser::parse(src).map_err(|errs| {
+            format!(
+                "failed to parse bundled std module '{key}': {}",
+                errs.iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            )
+        })?;
+        for item in &imported.items {
+            match item {
+                Node::FnDef(..) | Node::Const { .. } => out.push(item.clone()),
+                Node::Import { .. } => {
+                    if let Some(k) = import_key(item) {
+                        queue.push_back(k);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(out)
 }
 
 /// Walk a list of statements and evaluate any `assert(cond[, "msg"])` nodes.


### PR DESCRIPTION
## Summary

Extends the `mindc test` tree-interpreter (RFC 0008 Phase B) so it executes real
memory-using, struct-using, cross-module MIND end to end **with no native
runtime** — a fresh clone can run pure-MIND programs (e.g. the `std.sha256` /
`std.json` known-answer suites) through the interpreter alone.

New interpreter capability:
- `interp_mem`: a deterministic linear-memory arena + `__mind_alloc` / load/store
  intrinsics; `materialize_str` marshals a string literal to a native
  `[addr|len|cap]` record at the `string`-typed-param boundary.
- `exec_threaded_stmt`: one threaded statement executor so a mutation nested in an
  `if`/`for` inside a loop body survives; every scope-introducing sub-block opens
  its own scope frame (shadowing branch-`let`s stay branch-local while assigns to
  outer variables thread out).
- Qualified `Module::fn` resolution from nested fn bodies; module-level `const`
  resolution inside called fn bodies; `Value::Struct` literals + field access.

**Emit-neutral by construction** — the change is confined to the `mindc test`
interpreter path and touches no emit / lowering / IR / wire file. keystone 7/7 and
the whole-module mic@3 FLIP are byte-identical; the mic@3 wire bytes, the evidence
chain, and cross-substrate byte-identity that the wedge depends on are unchanged.

## Verification

- Interpreter probes + the full downstream canonical-hashing known-answer suite
  (SHA-256, canonical-JSON, typed-record builder, e2e digest) execute via
  `mindc test`, pure-MIND, no runtime.
- keystone `7 passed; 0 failed`, byte-identical; whole-module mic@3 FLIP
  byte-identical (676211 B).
- `cargo fmt --check`, `cargo clippy --no-default-features -- -D warnings`, and
  rustdoc `-D warnings` all clean; release build 0 warnings.

This change was gated by a multi-reviewer architecture + ecosystem review with
adversarial verification of emit-neutrality and determinism. That gate caught and
blocked two silent-wrong regressions in the new interpreter surface, both fixed
here at the correct layer:
- a marshalled-string value comparison that compared arena offsets — closed as a
  whole class, fail-loud (guard consulted at both int-op dispatchers + field
  access), with pointer arithmetic kept legal;
- a branch-`let` scope leak — closed by giving every scope-introducing sub-block
  its own scope frame.

## Known items (disclosed, not hidden)

1. **Pre-existing full-suite failure, NOT introduced here:** `continue_in_match_arm_runs`
   — an `--emit-shared` `E3001` in match-arm `continue` lowering. Full
   `cargo test --release` = **658 passed, 1 failed**; the failure reproduces at
   the branch base `f095a852` with this branch's changes stashed, and this diff
   touches no emit/lowering path. Needs a separate `lower.rs` fix.

2. **Interpreter-vs-emit parity gap (follow-up):** MIND has interpreter-vs-emit
   differential coverage today (`g2_differential_mlir`, `parity_cpu_vs_mlir_exec`)
   but only for tensor/reduction ops. The new interpreter surface (linear memory,
   structs, string marshalling, cross-module) has **no** interpreter-vs-emit parity
   gate yet, so `mindc test` green is not, today, mechanically tied to "the compiled
   artifact does the same" for these constructs. This change is emit-neutral (no new
   emit drift) and the interpreter fails loud on what it cannot model; the follow-up
   is to extend the differential gate to assert interpreter-run == native-run over a
   memory/struct/string corpus.

## Test plan

- [x] keystone 7/7 byte-identical
- [x] whole-module mic@3 FLIP byte-identical
- [x] canonical-hashing 10/10 known-answer tests via `mindc test` (pure-MIND, no runtime)
- [x] fmt / clippy (`--no-default-features -D warnings`) / rustdoc clean
- [ ] CI green
