### PR TITLE
fix(verify): recognize break/continue as if-branch terminators in SSA merge check

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind`
-**Files:** 3340 | **Est. tokens:** ~7,816,617
-**Generated:** 2026-08-07 09:54 UTC
+**Files:** 3340 | **Est. tokens:** ~7,816,849
+**Generated:** 2026-08-07 11:28 UTC
 
 ## Token Budget Guide
 
@@ -393,7 +393,7 @@
 | `src/exec/` | 3 | ~4,592 |
 | `src/ffi/` | 3 | ~3,919 |
 | `src/fmt/` | 3 | ~21,737 |
-| `src/ir/` | 5 | ~47,725 |
+| `src/ir/` | 5 | ~47,957 |
 | `src/ir/compact/` | 3 | ~15,271 |
 | `src/ir/compact/v2/` | 8 | ~38,404 |
 | `src/ir/compact/v3/` | 6 | ~49,206 |
@@ -4016,7 +4016,7 @@
 - `fp_mode.rs` (~13657 tok, huge) — FP-contract mode — the strict-vs-relaxed floating-point determinism state of
 - `mod.rs` (~12311 tok, huge) — Copyright 2025 STARGA Inc.
 - `print.rs` (~3540 tok, huge) — Copyright 2025 STARGA Inc.
-- `verify.rs` (~12458 tok, huge) — Copyright 2025 STARGA Inc.
+- `verify.rs` (~12690 tok, huge) — Copyright 2025 STARGA Inc.
 ### `src/`
 
 - `lib.rs` (~1012 tok, large) — Copyright 2025 STARGA Inc.

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -142,17 +142,32 @@ pub fn check_ssa_well_formed(module: &IRModule) -> Result<(), SsaViolation> {
 /// Does a branch sub-stream fall through to `^if_after` (i.e. does it reach the
 /// merge), or does it terminate early with a `return`?
 ///
-/// This MUST mirror the lowering rule in `src/eval/lower.rs` (§ "A branch that
-/// ends in `return` does not fall through to `^if_after`"): a branch whose last
-/// instruction is `Return` has its `cf.br` omitted and does NOT pass a merge
-/// value. Its slot in the `(merge_id, then_val, else_val)` tuple is a PLACEHOLDER
-/// — the *other* branch's value, or a `usize::MAX` sentinel when neither branch
-/// assigns the name — and therefore must NOT be validated against this branch's
-/// scope (it is not a real edge into the merge). Only a falling-through branch
-/// contributes a genuine merge operand that must be defined in its own scope.
+/// This MUST mirror the lowering rule in `src/eval/lower.rs` (`branch_terminates`,
+/// § "A branch that ends in a block terminator does not fall through to
+/// `^if_after`") and the MLIR emitter (`instr_is_block_terminator` in
+/// `src/mlir/lowering.rs`): a branch whose last instruction is a terminator has
+/// its `cf.br` omitted and does NOT pass a merge value. Its slot in the
+/// `(merge_id, then_val, else_val)` tuple is a PLACEHOLDER — the *other* branch's
+/// value, or a `usize::MAX` sentinel when neither branch assigns the name — and
+/// therefore must NOT be validated against this branch's scope (it is not a real
+/// edge into the merge). Only a falling-through branch contributes a genuine merge
+/// operand that must be defined in its own scope.
+///
+/// `Return` always terminates. Under `std-surface`, a `match`-arm/branch body that
+/// exits or re-tests the enclosing loop ends in `Break`/`Continue`, which likewise
+/// emits a `cf.br` to `^while_after`/`^while_header` and NOT to `^if_after` — so it
+/// too does not fall through. Recognizing only `Return` here (while the lowering
+/// and MLIR emitter recognized `Break`/`Continue`) made the verifier reject a
+/// well-formed `if { outer = … } else { continue }` inside a loop: it validated the
+/// terminating branch's dead placeholder edge (the *other* branch's value, defined
+/// in the *other* scope) and flagged it as an undefined operand (E3001). All three
+/// surfaces must classify terminators identically.
 #[cfg(feature = "std-surface")]
 fn branch_falls_through(instrs: &[Instr]) -> bool {
-    !matches!(instrs.last(), Some(Instr::Return { .. }))
+    !matches!(
+        instrs.last(),
+        Some(Instr::Return { .. }) | Some(Instr::Break { .. }) | Some(Instr::Continue { .. })
+    )
 }
 
 /// Validate the F2 merge operands of an `If` against PER-BRANCH scopes — the


### PR DESCRIPTION
## Summary

Fixes the pre-existing full-suite red `continue_in_match_arm_runs` at its root.

The IR verifier's `branch_falls_through` (src/ir/verify.rs) classified **only**
`Return` as a branch terminator, so an `if`-branch ending in `break`/`continue`
was wrongly deemed to fall through to `^if_after`. `validate_if_merges` then
validated that branch's **dead placeholder** merge edge — which the lowering sets
to the *other* branch's value, defined in the *other* scope — and rejected it as
an undefined operand:

```
while c { if p { acc = acc + i } else { continue } }
-> error[ir-verify][E3001]: use of undefined value %N at instruction 2
```

The lowering (`branch_terminates`, `src/eval/lower.rs`) and the MLIR emitter
(`instr_is_block_terminator`, `src/mlir/lowering.rs`) **already** recognize
`Break`/`Continue` as terminators under `std-surface` — a terminating branch
emits its `cf.br` to `^while_after`/`^while_header`, never to `^if_after`, so its
merge slot is a dead placeholder that must not be validated. The verifier was the
only one of the three surfaces still matching `Return` alone; this brings it into
line via the single shared helper, so both `verify_module` and
`check_ssa_well_formed` are fixed at once.

**Soundness:** the skipped edge is never emitted (no `cf.br`), exactly as for
`Return`; the falling-through branch's edge value and the merge id itself are
still validated per-branch — a forged artifact cannot hide a bad operand behind a
terminating branch.

## Why this is emit-neutral

Pure-checker change (the verifier emits nothing). Verified byte-identical:

- keystone `7 passed; 0 failed` — byte-identical (1205816 B, SHA `4fdd0159…`)
- whole-module mic@3 FLIP — byte-identical (676211 B)

## Verification

- `tests/continue_in_match_arm_run` now compiles **and runs correctly**:
  `accumulate() == 12`, `stop_at_four() == 6` (both the `continue` and the `break`
  path, via the ctypes runtime check — not just a passing verifier).
- `cargo fmt --check`, `cargo clippy --no-default-features -- -D warnings`,
  `cargo clippy … --features "mlir-build std-surface cross-module-imports" -- -D warnings`,
  and rustdoc `-D warnings` all clean.

## Test plan

- [x] keystone 7/7 byte-identical
- [x] whole-module mic@3 FLIP byte-identical
- [x] continue/break-in-match-arm KAT compiles + runs (12 / 6)
- [x] fmt / clippy (bare + featured) / rustdoc clean
- [ ] CI green
