### PR TITLE
chore(release): v0.10.2

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -6,7 +6,7 @@
 
 **Project:** `mind`
 **Files:** 3340 | **Est. tokens:** ~7,816,849
-**Generated:** 2026-08-07 11:28 UTC
+**Generated:** 2026-08-07 12:13 UTC
 
 ## Token Budget Guide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-08-07 — runtime-free `mindc test` over real memory/struct/cross-module MIND, verifier break/continue if-merge fix, compile-speed (small-object allocator + boxed AST), and the `--backend` opt-in seam
+
 ### Performance
 - **Boxed `FnDef` AST payload — `Node` shrunk 216 → 128 bytes (byte-identical).**
   The `FnDef` variant's ~9 inline fields made it the fattest `ast::Node`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mind"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 rust-version = "1.85"
 authors = ["STARGA Inc."]


### PR DESCRIPTION
Release cut for **v0.10.2**. Version bump only (Cargo.toml 0.10.1→0.10.2, CHANGELOG `[Unreleased]`→`[0.10.2] - 2026-08-07`) — no source change; keystone + mic@3 byte-identity unaffected.

Headline content since v0.10.1: runtime-free `mindc test` over real memory/struct/cross-module MIND (#226), verifier break/continue if-branch terminator fix (#227), compile-speed (small-object allocator + boxed AST), and the `--backend` opt-in seam. Full list in CHANGELOG `[0.10.2]`.

Merging this, then pushing the `v0.10.2` tag triggers `release.yml` to build + publish the cross-platform binaries.